### PR TITLE
[codex] ship overlay and block verticals

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -18,6 +18,7 @@ The strategic model combines a primitive layer with a source-first registry laye
 - `part`: named DOM/component piece in a primitive, exposed through `data-part`.
 - `scope`: primitive namespace exposed through `data-scope`, for example `dialog` or `select`.
 - `registry item`: Mason-distributed component, block, hook, utility, theme, page, template, config, rule, or asset.
+- `install transaction`: Mason's planned install unit, including target files, content hashes, existing target state, dependency changes, installed metadata, and conflicts before any writes occur.
 - `block`: production-shaped Mason UI composed from components, such as `dashboard-01`, `auth-01`, or `settings-01`.
 - `template`: starter project installed by Mason, such as `vite-solid-basic` or `solidstart-basic`.
 - `TanStack app layer`: Mason's preferred app-behavior layer for serious forms, data tables, shared app state, and keyboard shortcuts.

--- a/README.md
+++ b/README.md
@@ -27,9 +27,12 @@ Current Mason preview surface:
 ```bash
 mason init
 mason add button --registry <local-registry-path>
+mason add account-settings --registry <local-registry-path>
 ```
 
-The default local registry currently includes base components (`button`, `badge`, `card`, `field`, `input`, `label`, `separator`, `textarea`, `cn`), Keystone-backed overlays (`dialog`, `popover`, `sheet`, `tooltip`), and TanStack Form field examples (`text-field`, `select-field`).
+The default local registry currently includes base components (`button`, `badge`, `card`, `field`, `input`, `label`, `separator`, `textarea`, `cn`), Keystone-backed overlays (`dialog`, `popover`, `sheet`, `tooltip`), TanStack Form field examples (`text-field`, `select-field`), and the first block tracer (`account-settings`).
+
+Mason install planning records target files, content hashes, existing target state, dependency changes, installed-item metadata, and conflicts before applying writes.
 
 ## Design Principles
 
@@ -54,6 +57,7 @@ packages/
 
 registry/
   default/             first-party Mason registry source
+    blocks/            first block tracer source
 
 docs/
   adr/                 durable decisions
@@ -117,7 +121,7 @@ bun run verify:release
 - `@keystone-ui` is the current workspace scope, not a cleared public package scope.
 - Keystone overlay and utility internals are private for `0.1.0`.
 - Mason currently supports a local registry path for the first tracer.
-- Mason blocks, templates, themes, and a public registry are not ready.
+- Mason has an early block tracer, but templates, themes, and a public registry are not ready.
 - The docs/product surface lives in `apps/docs` and is still early.
 
 ## License

--- a/apps/docs/src/routeTree.gen.ts
+++ b/apps/docs/src/routeTree.gen.ts
@@ -8,150 +8,151 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from "./routes/__root";
-import { Route as IndexRouteImport } from "./routes/index";
-import { Route as DocsOverlayPopoverTooltipSheetRouteImport } from "./routes/docs.overlay.popover-tooltip-sheet";
-import { Route as DocsMasonTextFieldRouteImport } from "./routes/docs.mason.text-field";
-import { Route as DocsMasonSelectFieldRouteImport } from "./routes/docs.mason.select-field";
-import { Route as DocsMasonDialogRouteImport } from "./routes/docs.mason.dialog";
-import { Route as DocsKeystoneDialogRouteImport } from "./routes/docs.keystone.dialog";
+import { Route as rootRouteImport } from './routes/__root'
+import { Route as IndexRouteImport } from './routes/index'
+import { Route as DocsOverlayPopoverTooltipSheetRouteImport } from './routes/docs.overlay.popover-tooltip-sheet'
+import { Route as DocsMasonTextFieldRouteImport } from './routes/docs.mason.text-field'
+import { Route as DocsMasonSelectFieldRouteImport } from './routes/docs.mason.select-field'
+import { Route as DocsMasonDialogRouteImport } from './routes/docs.mason.dialog'
+import { Route as DocsKeystoneDialogRouteImport } from './routes/docs.keystone.dialog'
 
 const IndexRoute = IndexRouteImport.update({
-  id: "/",
-  path: "/",
+  id: '/',
+  path: '/',
   getParentRoute: () => rootRouteImport,
-} as any);
-const DocsOverlayPopoverTooltipSheetRoute = DocsOverlayPopoverTooltipSheetRouteImport.update({
-  id: "/docs/overlay/popover-tooltip-sheet",
-  path: "/docs/overlay/popover-tooltip-sheet",
-  getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
+const DocsOverlayPopoverTooltipSheetRoute =
+  DocsOverlayPopoverTooltipSheetRouteImport.update({
+    id: '/docs/overlay/popover-tooltip-sheet',
+    path: '/docs/overlay/popover-tooltip-sheet',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const DocsMasonTextFieldRoute = DocsMasonTextFieldRouteImport.update({
-  id: "/docs/mason/text-field",
-  path: "/docs/mason/text-field",
+  id: '/docs/mason/text-field',
+  path: '/docs/mason/text-field',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const DocsMasonSelectFieldRoute = DocsMasonSelectFieldRouteImport.update({
-  id: "/docs/mason/select-field",
-  path: "/docs/mason/select-field",
+  id: '/docs/mason/select-field',
+  path: '/docs/mason/select-field',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const DocsMasonDialogRoute = DocsMasonDialogRouteImport.update({
-  id: "/docs/mason/dialog",
-  path: "/docs/mason/dialog",
+  id: '/docs/mason/dialog',
+  path: '/docs/mason/dialog',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const DocsKeystoneDialogRoute = DocsKeystoneDialogRouteImport.update({
-  id: "/docs/keystone/dialog",
-  path: "/docs/keystone/dialog",
+  id: '/docs/keystone/dialog',
+  path: '/docs/keystone/dialog',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 
 export interface FileRoutesByFullPath {
-  "/": typeof IndexRoute;
-  "/docs/keystone/dialog": typeof DocsKeystoneDialogRoute;
-  "/docs/mason/dialog": typeof DocsMasonDialogRoute;
-  "/docs/mason/select-field": typeof DocsMasonSelectFieldRoute;
-  "/docs/mason/text-field": typeof DocsMasonTextFieldRoute;
-  "/docs/overlay/popover-tooltip-sheet": typeof DocsOverlayPopoverTooltipSheetRoute;
+  '/': typeof IndexRoute
+  '/docs/keystone/dialog': typeof DocsKeystoneDialogRoute
+  '/docs/mason/dialog': typeof DocsMasonDialogRoute
+  '/docs/mason/select-field': typeof DocsMasonSelectFieldRoute
+  '/docs/mason/text-field': typeof DocsMasonTextFieldRoute
+  '/docs/overlay/popover-tooltip-sheet': typeof DocsOverlayPopoverTooltipSheetRoute
 }
 export interface FileRoutesByTo {
-  "/": typeof IndexRoute;
-  "/docs/keystone/dialog": typeof DocsKeystoneDialogRoute;
-  "/docs/mason/dialog": typeof DocsMasonDialogRoute;
-  "/docs/mason/select-field": typeof DocsMasonSelectFieldRoute;
-  "/docs/mason/text-field": typeof DocsMasonTextFieldRoute;
-  "/docs/overlay/popover-tooltip-sheet": typeof DocsOverlayPopoverTooltipSheetRoute;
+  '/': typeof IndexRoute
+  '/docs/keystone/dialog': typeof DocsKeystoneDialogRoute
+  '/docs/mason/dialog': typeof DocsMasonDialogRoute
+  '/docs/mason/select-field': typeof DocsMasonSelectFieldRoute
+  '/docs/mason/text-field': typeof DocsMasonTextFieldRoute
+  '/docs/overlay/popover-tooltip-sheet': typeof DocsOverlayPopoverTooltipSheetRoute
 }
 export interface FileRoutesById {
-  __root__: typeof rootRouteImport;
-  "/": typeof IndexRoute;
-  "/docs/keystone/dialog": typeof DocsKeystoneDialogRoute;
-  "/docs/mason/dialog": typeof DocsMasonDialogRoute;
-  "/docs/mason/select-field": typeof DocsMasonSelectFieldRoute;
-  "/docs/mason/text-field": typeof DocsMasonTextFieldRoute;
-  "/docs/overlay/popover-tooltip-sheet": typeof DocsOverlayPopoverTooltipSheetRoute;
+  __root__: typeof rootRouteImport
+  '/': typeof IndexRoute
+  '/docs/keystone/dialog': typeof DocsKeystoneDialogRoute
+  '/docs/mason/dialog': typeof DocsMasonDialogRoute
+  '/docs/mason/select-field': typeof DocsMasonSelectFieldRoute
+  '/docs/mason/text-field': typeof DocsMasonTextFieldRoute
+  '/docs/overlay/popover-tooltip-sheet': typeof DocsOverlayPopoverTooltipSheetRoute
 }
 export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath;
+  fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
-    | "/"
-    | "/docs/keystone/dialog"
-    | "/docs/mason/dialog"
-    | "/docs/mason/select-field"
-    | "/docs/mason/text-field"
-    | "/docs/overlay/popover-tooltip-sheet";
-  fileRoutesByTo: FileRoutesByTo;
+    | '/'
+    | '/docs/keystone/dialog'
+    | '/docs/mason/dialog'
+    | '/docs/mason/select-field'
+    | '/docs/mason/text-field'
+    | '/docs/overlay/popover-tooltip-sheet'
+  fileRoutesByTo: FileRoutesByTo
   to:
-    | "/"
-    | "/docs/keystone/dialog"
-    | "/docs/mason/dialog"
-    | "/docs/mason/select-field"
-    | "/docs/mason/text-field"
-    | "/docs/overlay/popover-tooltip-sheet";
+    | '/'
+    | '/docs/keystone/dialog'
+    | '/docs/mason/dialog'
+    | '/docs/mason/select-field'
+    | '/docs/mason/text-field'
+    | '/docs/overlay/popover-tooltip-sheet'
   id:
-    | "__root__"
-    | "/"
-    | "/docs/keystone/dialog"
-    | "/docs/mason/dialog"
-    | "/docs/mason/select-field"
-    | "/docs/mason/text-field"
-    | "/docs/overlay/popover-tooltip-sheet";
-  fileRoutesById: FileRoutesById;
+    | '__root__'
+    | '/'
+    | '/docs/keystone/dialog'
+    | '/docs/mason/dialog'
+    | '/docs/mason/select-field'
+    | '/docs/mason/text-field'
+    | '/docs/overlay/popover-tooltip-sheet'
+  fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
-  IndexRoute: typeof IndexRoute;
-  DocsKeystoneDialogRoute: typeof DocsKeystoneDialogRoute;
-  DocsMasonDialogRoute: typeof DocsMasonDialogRoute;
-  DocsMasonSelectFieldRoute: typeof DocsMasonSelectFieldRoute;
-  DocsMasonTextFieldRoute: typeof DocsMasonTextFieldRoute;
-  DocsOverlayPopoverTooltipSheetRoute: typeof DocsOverlayPopoverTooltipSheetRoute;
+  IndexRoute: typeof IndexRoute
+  DocsKeystoneDialogRoute: typeof DocsKeystoneDialogRoute
+  DocsMasonDialogRoute: typeof DocsMasonDialogRoute
+  DocsMasonSelectFieldRoute: typeof DocsMasonSelectFieldRoute
+  DocsMasonTextFieldRoute: typeof DocsMasonTextFieldRoute
+  DocsOverlayPopoverTooltipSheetRoute: typeof DocsOverlayPopoverTooltipSheetRoute
 }
 
-declare module "@tanstack/solid-router" {
+declare module '@tanstack/solid-router' {
   interface FileRoutesByPath {
-    "/": {
-      id: "/";
-      path: "/";
-      fullPath: "/";
-      preLoaderRoute: typeof IndexRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/docs/overlay/popover-tooltip-sheet": {
-      id: "/docs/overlay/popover-tooltip-sheet";
-      path: "/docs/overlay/popover-tooltip-sheet";
-      fullPath: "/docs/overlay/popover-tooltip-sheet";
-      preLoaderRoute: typeof DocsOverlayPopoverTooltipSheetRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/docs/mason/text-field": {
-      id: "/docs/mason/text-field";
-      path: "/docs/mason/text-field";
-      fullPath: "/docs/mason/text-field";
-      preLoaderRoute: typeof DocsMasonTextFieldRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/docs/mason/select-field": {
-      id: "/docs/mason/select-field";
-      path: "/docs/mason/select-field";
-      fullPath: "/docs/mason/select-field";
-      preLoaderRoute: typeof DocsMasonSelectFieldRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/docs/mason/dialog": {
-      id: "/docs/mason/dialog";
-      path: "/docs/mason/dialog";
-      fullPath: "/docs/mason/dialog";
-      preLoaderRoute: typeof DocsMasonDialogRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/docs/keystone/dialog": {
-      id: "/docs/keystone/dialog";
-      path: "/docs/keystone/dialog";
-      fullPath: "/docs/keystone/dialog";
-      preLoaderRoute: typeof DocsKeystoneDialogRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/docs/overlay/popover-tooltip-sheet': {
+      id: '/docs/overlay/popover-tooltip-sheet'
+      path: '/docs/overlay/popover-tooltip-sheet'
+      fullPath: '/docs/overlay/popover-tooltip-sheet'
+      preLoaderRoute: typeof DocsOverlayPopoverTooltipSheetRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/docs/mason/text-field': {
+      id: '/docs/mason/text-field'
+      path: '/docs/mason/text-field'
+      fullPath: '/docs/mason/text-field'
+      preLoaderRoute: typeof DocsMasonTextFieldRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/docs/mason/select-field': {
+      id: '/docs/mason/select-field'
+      path: '/docs/mason/select-field'
+      fullPath: '/docs/mason/select-field'
+      preLoaderRoute: typeof DocsMasonSelectFieldRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/docs/mason/dialog': {
+      id: '/docs/mason/dialog'
+      path: '/docs/mason/dialog'
+      fullPath: '/docs/mason/dialog'
+      preLoaderRoute: typeof DocsMasonDialogRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/docs/keystone/dialog': {
+      id: '/docs/keystone/dialog'
+      path: '/docs/keystone/dialog'
+      fullPath: '/docs/keystone/dialog'
+      preLoaderRoute: typeof DocsKeystoneDialogRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
@@ -162,16 +163,16 @@ const rootRouteChildren: RootRouteChildren = {
   DocsMasonSelectFieldRoute: DocsMasonSelectFieldRoute,
   DocsMasonTextFieldRoute: DocsMasonTextFieldRoute,
   DocsOverlayPopoverTooltipSheetRoute: DocsOverlayPopoverTooltipSheetRoute,
-};
+}
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
-  ._addFileTypes<FileRouteTypes>();
+  ._addFileTypes<FileRouteTypes>()
 
-import type { getRouter } from "./router.tsx";
-import type { createStart } from "@tanstack/solid-start";
-declare module "@tanstack/solid-start" {
+import type { getRouter } from './router.tsx'
+import type { createStart } from '@tanstack/solid-start'
+declare module '@tanstack/solid-start' {
   interface Register {
-    ssr: true;
-    router: Awaited<ReturnType<typeof getRouter>>;
+    ssr: true
+    router: Awaited<ReturnType<typeof getRouter>>
   }
 }

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -25,6 +25,17 @@ No issue tracker convention is recorded in this repository yet. Until one is cho
 - Keep scratch notes under `.context/` when they are workspace-local.
 - Do not invent labels, issue states, or external tracker workflow.
 
+## Task Selection Hygiene
+
+Attachments under `.context/attachments/` may be duplicated, stale, or already implemented.
+Before treating an attachment as the next task:
+
+- Compare it with existing repo docs and prior attachments when it looks like a PRD or issue brief.
+- Check the local package/source surface for the requested files, tests, and behavior.
+- Check the current GitHub issue state with `gh issue list` or `gh issue view` when an issue number is referenced.
+- Prefer the oldest unblocked open issue whose acceptance criteria are visibly absent from the repo.
+- Do not propose completed tracer work as next work only because its brief is present in `.context/attachments/`.
+
 ## Skill Usage
 
 - Use `context-map` when entering an unfamiliar product or code area.

--- a/packages/keystone/src/dialog/index.tsx
+++ b/packages/keystone/src/dialog/index.tsx
@@ -1,19 +1,8 @@
-import { Show, createContext, createSignal, splitProps, useContext, type JSX } from "solid-js";
+import { Show, createContext, splitProps, useContext, type JSX } from "solid-js";
 import { Portal } from "solid-js/web";
-import {
-  OverlayLayerProvider,
-  createOverlayLayer,
-  type DismissableLayerOutsideEvent,
-  type OverlayLayerApi,
-} from "../overlay/index";
-import { assignRef } from "../overlay/dom";
-import {
-  composeEventHandlers,
-  createControllableBooleanSignal,
-  createStableId,
-  renderPolymorphic,
-  type PolymorphicProps,
-} from "../utils/index";
+import { OverlayLayerProvider, type DismissableLayerOutsideEvent } from "../overlay/index";
+import { createOverlayController } from "../overlay/controller";
+import { renderPolymorphic, type PolymorphicProps } from "../utils/index";
 
 export type DialogChangeDetail = {
   event?: Event;
@@ -95,78 +84,23 @@ export type CreateDialogOptions = {
 const DialogContext = createContext<DialogApi>();
 
 export function createDialog(options: CreateDialogOptions = {}): DialogApi {
-  const titleId = createStableId("dialog-title");
-  const descriptionId = createStableId("dialog-description");
-  const contentId = createStableId("dialog-content");
-  let lastDetail: DialogChangeDetail = { reason: "programmatic" };
-  const [open, setOpenState] = createControllableBooleanSignal({
-    value: options.open,
-    defaultValue: options.defaultOpen ?? false,
-    onChange: (next) => {
-      options.onOpenChange?.(next, lastDetail);
-    },
+  const overlay = createOverlayController<DialogChangeDetail["reason"]>({
+    scope: "dialog",
+    open: options.open,
+    defaultOpen: options.defaultOpen,
+    modal: () => options.modal?.() ?? true,
+    onOpenChange: (open, detail) => options.onOpenChange?.(open, detail),
   });
-
-  const setOpen = (next: boolean, detail: DialogChangeDetail) => {
-    lastDetail = detail;
-    setOpenState(next);
-  };
-  const state = () => (open() ? "open" : "closed");
-  const partProps = (part: string) => ({
-    "data-scope": "dialog",
-    "data-part": part,
-    get "data-state"() {
-      return state();
-    },
-  });
-  let contentElementSetter: ((element: HTMLDivElement) => void) | undefined;
-  let contentLayer: OverlayLayerApi | undefined;
-  let contentProps: DialogContentContractProps | undefined;
-  const ensureContentLayer = () => {
-    if (contentLayer) {
-      return contentLayer;
-    }
-
-    const [content, setContent] = createSignal<HTMLDivElement>();
-    contentElementSetter = setContent;
-    contentLayer = createOverlayLayer({
-      id: contentId(),
-      element: content,
-      modal: () => options.modal?.() ?? true,
-      disableOutsidePointerEvents: () => options.modal?.() ?? true,
-      trapFocus: () => options.modal?.() ?? true,
-      restoreFocus: () => true,
-      onEscapeKeyDown: (event) => contentProps?.onEscapeKeyDown?.(event),
-      onPointerDownOutside: (event) => contentProps?.onPointerDownOutside?.(event),
-      onFocusOutside: (event) => contentProps?.onFocusOutside?.(event),
-      onInteractOutside: (event) => contentProps?.onInteractOutside?.(event),
-      onDismiss: (event) => {
-        setOpen(false, { event, reason: event.type === "keydown" ? "escape" : "outside" });
-      },
-      onMountAutoFocus: (event) => contentProps?.onMountAutoFocus?.(event),
-      onUnmountAutoFocus: (event) => contentProps?.onUnmountAutoFocus?.(event),
-    });
-
-    return contentLayer;
-  };
 
   return {
-    contentId: contentId(),
-    descriptionId: descriptionId(),
+    contentId: overlay.contentId,
+    descriptionId: overlay.descriptionId,
     getBackdropProps: (props) => ({
       ...props,
-      ...partProps("backdrop"),
+      ...overlay.getPartProps("backdrop"),
     }),
-    getCloseProps: (props) => ({
-      ...props,
-      type: "button",
-      ...partProps("close"),
-      onClick: composeEventHandlers(props.onClick, (event) => {
-        setOpen(false, { event, reason: "close" });
-      }),
-    }),
+    getCloseProps: (props) => overlay.getCloseProps(props, "close") as Record<string, unknown>,
     getContentProps: (props) => {
-      contentProps = props;
       const [local, others] = splitProps(props, [
         "ref",
         "onEscapeKeyDown",
@@ -176,62 +110,62 @@ export function createDialog(options: CreateDialogOptions = {}): DialogApi {
         "onMountAutoFocus",
         "onUnmountAutoFocus",
       ]);
-      const layer = ensureContentLayer();
+      const layerProps = overlay.getContentLayerProps<HTMLDivElement>(
+        {
+          ref: local.ref,
+          onEscapeKeyDown: local.onEscapeKeyDown,
+          onFocusOutside: local.onFocusOutside,
+          onInteractOutside: local.onInteractOutside,
+          onMountAutoFocus: local.onMountAutoFocus,
+          onPointerDownOutside: local.onPointerDownOutside,
+          onUnmountAutoFocus: local.onUnmountAutoFocus,
+        },
+        {
+          modal: overlay.modal,
+          disableOutsidePointerEvents: overlay.modal,
+          trapFocus: overlay.modal,
+          restoreFocus: () => true,
+          dismissReason: (event) => (event.type === "keydown" ? "escape" : "outside"),
+        },
+      );
 
       return {
         ...others,
-        id: contentId(),
+        ...layerProps,
+        id: overlay.contentId,
         tabIndex: -1,
         role: "dialog",
-        "aria-modal": (options.modal?.() ?? true) ? "true" : undefined,
-        "aria-labelledby": titleId(),
-        "aria-describedby": descriptionId(),
-        "data-layer-id": layer.id,
-        get "data-layer-index"() {
-          return layer.index();
-        },
-        get "data-top-layer"() {
-          return layer.isTopLayer() ? "" : undefined;
-        },
-        ...partProps("content"),
-        ref: (node: HTMLDivElement) => {
-          contentElementSetter?.(node);
-          assignRef(local.ref, node);
-        },
+        "aria-modal": overlay.modal() ? "true" : undefined,
+        "aria-labelledby": overlay.titleId,
+        "aria-describedby": overlay.descriptionId,
+        ...overlay.getPartProps("content"),
       };
     },
     getDescriptionProps: (props) => ({
       ...props,
-      id: descriptionId(),
+      id: overlay.descriptionId,
       "data-scope": "dialog",
       "data-part": "description",
     }),
     getPositionerProps: (props) => ({
       ...props,
-      ...partProps("positioner"),
+      ...overlay.getPartProps("positioner"),
     }),
     getTitleProps: (props) => ({
       ...props,
-      id: titleId(),
+      id: overlay.titleId,
       "data-scope": "dialog",
       "data-part": "title",
     }),
-    getTriggerProps: (props) => ({
-      ...props,
-      type: "button",
-      "aria-controls": contentId(),
-      get "aria-expanded"() {
-        return open();
-      },
-      ...partProps("trigger"),
-      onClick: composeEventHandlers(props.onClick, (event) => {
-        setOpen(true, { event, reason: "trigger" });
-      }),
-    }),
-    modal: () => options.modal?.() ?? true,
-    open,
-    setOpen,
-    titleId: titleId(),
+    getTriggerProps: (props) =>
+      overlay.getTriggerProps(props, {
+        action: "open",
+        reason: "trigger",
+      }) as Record<string, unknown>,
+    modal: overlay.modal,
+    open: overlay.open,
+    setOpen: overlay.setOpen,
+    titleId: overlay.titleId,
   };
 }
 
@@ -295,15 +229,17 @@ function Backdrop(props: DialogContentProps) {
 function Positioner(props: DialogContentProps) {
   const dialog = useDialog("Positioner");
   const [local, others] = splitProps(props, ["children"]);
+  const positionerProps = dialog.getPositionerProps(others);
 
-  return <div {...dialog.getPositionerProps(others)}>{local.children}</div>;
+  return <div {...positionerProps}>{local.children}</div>;
 }
 
 function Content(props: DialogContentProps) {
   const dialog = useDialog("Content");
   const [local, others] = splitProps(props, ["children"]);
+  const contentProps = dialog.getContentProps(others);
 
-  return <div {...dialog.getContentProps(others)}>{local.children}</div>;
+  return <div {...contentProps}>{local.children}</div>;
 }
 
 function Title(props: DialogTitleProps) {

--- a/packages/keystone/src/listbox/index.ts
+++ b/packages/keystone/src/listbox/index.ts
@@ -1,0 +1,198 @@
+import { createMemo, splitProps, type Accessor, type JSX } from "solid-js";
+import {
+  composeEventHandlers,
+  createListInteractionKernel,
+  dataBoolean,
+  type CollectionItem,
+  type CollectionRegistration,
+  type ListInteractionKernelApi,
+  type ListInteractionKernelOptions,
+  type ListInteractionNavigationIntent,
+  type TypeaheadApi,
+} from "../utils/index";
+
+export type ListboxOpenIntent = "open-and-highlight" | "close";
+
+export type ListboxKeyboardDetailOptions<Detail> = {
+  selectDetail: (event: KeyboardEvent) => Detail;
+};
+
+export type ListboxPartProps<T extends HTMLElement = HTMLElement> = {
+  class?: string;
+  id?: string;
+  ref?: T | ((element: T) => void);
+  style?: JSX.CSSProperties | string;
+};
+
+export type ListboxRootContractProps = ListboxPartProps<HTMLDivElement> &
+  Omit<JSX.HTMLAttributes<HTMLDivElement>, "children" | "ref">;
+
+export type ListboxOptionContractProps = ListboxPartProps<HTMLDivElement> &
+  Omit<JSX.HTMLAttributes<HTMLDivElement>, "children" | "ref" | "value"> & {
+    disabled?: boolean;
+    label: string;
+    value: string;
+  };
+
+export type ListboxInteractionOptions<
+  T extends CollectionItem,
+  Detail,
+> = ListInteractionKernelOptions<T, Detail> & {
+  id: Accessor<string>;
+  labelledBy: Accessor<string | undefined>;
+  optionId: (value: string) => string;
+  optionSelectDetail: (event: MouseEvent) => Detail;
+  optionPart?: string;
+  rootPart?: string;
+  scope: string;
+};
+
+export type ListboxSelectionContract<T extends CollectionItem, Detail> = {
+  isSelected: (value: string) => boolean;
+  selectHighlighted: (detail: Detail) => T | undefined;
+  selectedItem: Accessor<T | undefined>;
+  selectValue: (value: string, detail: Detail) => T | undefined;
+  setValue: (value: string | undefined, detail: Detail) => T | undefined;
+  value: Accessor<string | undefined>;
+};
+
+export type ListboxActiveDescendantContract<T extends CollectionItem> = {
+  highlightedItem: Accessor<T | undefined>;
+  highlightedValue: Accessor<string | undefined>;
+  id: Accessor<string | undefined>;
+  isHighlighted: (value: string) => boolean;
+  setHighlightedValue: (value: string | undefined) => void;
+};
+
+export type ListboxKeyboardContract<T extends CollectionItem, Detail> = {
+  getTriggerOpenIntent: (event: KeyboardEvent) => ListboxOpenIntent | undefined;
+  handleKeyDown: (event: KeyboardEvent, options: ListboxKeyboardDetailOptions<Detail>) => boolean;
+  highlight: (intent: ListInteractionNavigationIntent) => T | undefined;
+};
+
+export type ListboxInteractionApi<T extends CollectionItem, Detail> = {
+  activeDescendant: ListboxActiveDescendantContract<T>;
+  getListboxProps: (
+    props: ListboxRootContractProps,
+    options: ListboxKeyboardDetailOptions<Detail>,
+  ) => Record<string, unknown>;
+  getOptionProps: (props: ListboxOptionContractProps) => Record<string, unknown>;
+  interaction: ListInteractionKernelApi<T, Detail>;
+  items: Accessor<readonly T[]>;
+  keyboard: ListboxKeyboardContract<T, Detail>;
+  optionId: (value: string) => string;
+  registerOption: (item: CollectionRegistration<T>) => () => void;
+  selection: ListboxSelectionContract<T, Detail>;
+  typeahead: TypeaheadApi;
+};
+
+export function createListboxInteraction<T extends CollectionItem, Detail>(
+  options: ListboxInteractionOptions<T, Detail>,
+): ListboxInteractionApi<T, Detail> {
+  const list = createListInteractionKernel<T, Detail>(options);
+  const rootPart = options.rootPart ?? "listbox";
+  const optionPart = options.optionPart ?? "option";
+  const activeDescendantId = createMemo(() => {
+    const highlighted = list.highlightedValue();
+    return highlighted ? options.optionId(highlighted) : undefined;
+  });
+  const partProps = (part: string) => ({
+    "data-scope": options.scope,
+    "data-part": part,
+  });
+
+  const getTriggerOpenIntent = (event: KeyboardEvent): ListboxOpenIntent | undefined => {
+    if (event.key === "ArrowDown" || event.key === "Enter" || event.key === " ") {
+      return "open-and-highlight";
+    }
+
+    if (event.key === "Escape") {
+      return "close";
+    }
+
+    return undefined;
+  };
+
+  return {
+    activeDescendant: {
+      highlightedItem: list.highlightedItem,
+      highlightedValue: list.highlightedValue,
+      id: activeDescendantId,
+      isHighlighted: list.isHighlighted,
+      setHighlightedValue: list.setHighlightedValue,
+    },
+    getListboxProps: (props, keyboardOptions) => ({
+      ...props,
+      id: options.id(),
+      role: "listbox",
+      "aria-labelledby": options.labelledBy(),
+      get "aria-activedescendant"() {
+        return activeDescendantId();
+      },
+      tabindex: -1,
+      ...partProps(rootPart),
+      onKeyDown: composeEventHandlers<KeyboardEvent>(props.onKeyDown, (event) => {
+        list.handleKeyDown(event, keyboardOptions);
+      }),
+    }),
+    getOptionProps: (props) => {
+      const [local, others] = splitProps(props, [
+        "disabled",
+        "label",
+        "onClick",
+        "onPointerMove",
+        "value",
+      ]);
+
+      list.registerItem({
+        disabled: local.disabled,
+        label: local.label,
+        value: local.value,
+      } as CollectionRegistration<T>);
+
+      return {
+        ...others,
+        id: options.optionId(local.value),
+        role: "option",
+        "aria-disabled": local.disabled ? "true" : undefined,
+        get "aria-selected"() {
+          return list.isSelected(local.value);
+        },
+        ...partProps(optionPart),
+        "data-disabled": dataBoolean(local.disabled),
+        get "data-highlighted"() {
+          return dataBoolean(list.isHighlighted(local.value));
+        },
+        get "data-selected"() {
+          return dataBoolean(list.isSelected(local.value));
+        },
+        onPointerMove: composeEventHandlers<PointerEvent>(local.onPointerMove, () => {
+          if (!local.disabled) {
+            list.setHighlightedValue(local.value);
+          }
+        }),
+        onClick: composeEventHandlers<MouseEvent>(local.onClick, (event) => {
+          list.selectValue(local.value, options.optionSelectDetail(event));
+        }),
+      };
+    },
+    interaction: list,
+    items: list.items,
+    keyboard: {
+      getTriggerOpenIntent,
+      handleKeyDown: list.handleKeyDown,
+      highlight: list.highlight,
+    },
+    optionId: options.optionId,
+    registerOption: list.registerItem,
+    selection: {
+      isSelected: list.isSelected,
+      selectHighlighted: list.selectHighlighted,
+      selectedItem: list.selectedItem,
+      selectValue: list.selectValue,
+      setValue: list.setValue,
+      value: list.value,
+    },
+    typeahead: list.typeahead,
+  };
+}

--- a/packages/keystone/src/listbox/listbox.test.tsx
+++ b/packages/keystone/src/listbox/listbox.test.tsx
@@ -1,0 +1,111 @@
+import { createRoot } from "solid-js";
+import { describe, expect, test } from "vitest";
+import { createListboxInteraction } from "./index";
+
+describe("Listbox interaction module", () => {
+  test("returns listbox, option, active-descendant, keyboard, and selection contracts", () => {
+    createRoot((dispose) => {
+      const changes: Array<{ reason: string; value: string | undefined }> = [];
+      const selected: string[] = [];
+      const listbox = createListboxInteraction<
+        { disabled?: boolean; label: string; value: string },
+        { event?: Event; reason: string }
+      >({
+        defaultValue: "alpha",
+        id: () => "project-listbox",
+        labelledBy: () => "project-trigger",
+        optionId: (value) => `project-option-${value}`,
+        optionSelectDetail: (event) => ({ event, reason: "item" }),
+        programmaticDetail: { reason: "programmatic" },
+        scope: "test-listbox",
+        onSelectionChange: (value, detail) => changes.push({ value, reason: detail.reason }),
+        onValueSelect: (item) => selected.push(item.value),
+      });
+
+      const alpha = listbox.getOptionProps({ label: "Alpha", value: "alpha" });
+      listbox.getOptionProps({ disabled: true, label: "Beta", value: "beta" });
+      const bravo = listbox.getOptionProps({ label: "Bravo", value: "bravo" });
+      const props = listbox.getListboxProps(
+        {},
+        {
+          selectDetail: (event) => ({ event, reason: "keyboard" }),
+        },
+      );
+
+      expect(props.id).toBe("project-listbox");
+      expect(props.role).toBe("listbox");
+      expect(props["aria-labelledby"]).toBe("project-trigger");
+      expect(alpha.id).toBe("project-option-alpha");
+      expect(alpha.role).toBe("option");
+      expect(alpha["data-scope"]).toBe("test-listbox");
+      expect(alpha["aria-selected"]).toBe(true);
+
+      (props.onKeyDown as (event: KeyboardEvent) => void)(
+        new KeyboardEvent("keydown", { cancelable: true, key: "ArrowDown" }),
+      );
+      expect(listbox.activeDescendant.highlightedValue()).toBe("alpha");
+      expect(props["aria-activedescendant"]).toBe("project-option-alpha");
+
+      (props.onKeyDown as (event: KeyboardEvent) => void)(
+        new KeyboardEvent("keydown", { cancelable: true, key: "ArrowDown" }),
+      );
+      expect(listbox.activeDescendant.highlightedValue()).toBe("bravo");
+
+      (props.onKeyDown as (event: KeyboardEvent) => void)(
+        new KeyboardEvent("keydown", { cancelable: true, key: "Enter" }),
+      );
+      expect(changes).toEqual([{ value: "bravo", reason: "keyboard" }]);
+      expect(selected).toEqual(["bravo"]);
+
+      (alpha.onClick as (event: MouseEvent) => void)(new MouseEvent("click", { cancelable: true }));
+      expect(changes.at(-1)).toEqual({ value: "alpha", reason: "item" });
+
+      (bravo.onPointerMove as (event: PointerEvent) => void)(
+        new PointerEvent("pointermove", { cancelable: true }),
+      );
+      expect(listbox.activeDescendant.highlightedValue()).toBe("bravo");
+      expect(
+        listbox.keyboard.getTriggerOpenIntent(new KeyboardEvent("keydown", { key: " " })),
+      ).toBe("open-and-highlight");
+      expect(
+        listbox.keyboard.getTriggerOpenIntent(new KeyboardEvent("keydown", { key: "Escape" })),
+      ).toBe("close");
+      expect(listbox.typeahead.isTyping()).toBe(false);
+
+      dispose();
+    });
+  });
+
+  test("typeahead highlights enabled options through the shared keydown contract", () => {
+    createRoot((dispose) => {
+      const listbox = createListboxInteraction<
+        { disabled?: boolean; label: string; value: string },
+        { reason: string }
+      >({
+        id: () => "project-listbox",
+        labelledBy: () => "project-trigger",
+        optionId: (value) => `project-option-${value}`,
+        optionSelectDetail: () => ({ reason: "item" }),
+        programmaticDetail: { reason: "programmatic" },
+        scope: "test-listbox",
+      });
+
+      listbox.getOptionProps({ label: "Alpha", value: "alpha" });
+      listbox.getOptionProps({ disabled: true, label: "Beta", value: "beta" });
+      listbox.getOptionProps({ label: "Bravo", value: "bravo" });
+      const props = listbox.getListboxProps(
+        {},
+        {
+          selectDetail: () => ({ reason: "keyboard" }),
+        },
+      );
+
+      (props.onKeyDown as (event: KeyboardEvent) => void)(
+        new KeyboardEvent("keydown", { cancelable: true, key: "b" }),
+      );
+
+      expect(listbox.activeDescendant.highlightedValue()).toBe("bravo");
+      dispose();
+    });
+  });
+});

--- a/packages/keystone/src/overlay/controller.ts
+++ b/packages/keystone/src/overlay/controller.ts
@@ -1,0 +1,323 @@
+import { createSignal, type Accessor, type JSX } from "solid-js";
+import { assignRef, contains } from "./dom";
+import { createFloatingAdapter, type FloatingAdapter, type FloatingPlacement } from "./floating";
+import {
+  createOverlayLayer,
+  type CreateOverlayLayerOptions,
+  type OverlayLayerApi,
+  type OverlayLayerOutsideEvent,
+} from "./layer-kernel";
+import {
+  composeEventHandlers,
+  createControllableBooleanSignal,
+  createStableId,
+} from "../utils/index";
+
+export type OverlayControllerChangeDetail<Reason extends string> = {
+  event?: Event;
+  reason: Reason;
+};
+
+export type OverlayControllerContentEvents = {
+  onEscapeKeyDown?: (event: KeyboardEvent) => void;
+  onFocusOutside?: (event: OverlayLayerOutsideEvent) => void;
+  onInteractOutside?: (event: OverlayLayerOutsideEvent) => void;
+  onMountAutoFocus?: (event: Event) => void;
+  onPointerDownOutside?: (event: OverlayLayerOutsideEvent) => void;
+  onUnmountAutoFocus?: (event: Event) => void;
+};
+
+export type OverlayControllerOptions<Reason extends string> = {
+  defaultOpen?: boolean;
+  floating?: {
+    placement?: Accessor<FloatingPlacement | undefined>;
+  };
+  ids?: {
+    content?: string;
+    description?: string;
+    title?: string;
+    trigger?: string;
+  };
+  modal?: Accessor<boolean | undefined>;
+  onOpenChange?: (open: boolean, detail: OverlayControllerChangeDetail<Reason>) => void;
+  open?: Accessor<boolean | undefined>;
+  scope: string;
+};
+
+export type OverlayControllerLayerOptions<Reason extends string> = {
+  containsTrigger?: boolean;
+  disableOutsidePointerEvents?: Accessor<boolean>;
+  modal?: Accessor<boolean>;
+  onDismiss?: (event: Event) => void;
+  restoreFocus?: Accessor<boolean>;
+  trapFocus?: Accessor<boolean>;
+  dismissReason?: (event: Event) => Reason;
+};
+
+export type OverlayController<Reason extends string> = {
+  close: (event: Event | undefined, reason: Reason) => void;
+  contentId: string;
+  descriptionId: string;
+  floating?: FloatingAdapter;
+  getCloseProps: <T extends HTMLElement>(
+    props: JSX.HTMLAttributes<T>,
+    reason: Reason,
+  ) => JSX.HTMLAttributes<T>;
+  getContentLayerProps: <T extends HTMLElement>(
+    props: JSX.HTMLAttributes<T> & OverlayControllerContentEvents,
+    options?: OverlayControllerLayerOptions<Reason>,
+  ) => JSX.HTMLAttributes<T> & {
+    "data-layer-id": string;
+    ref: (element: T) => void;
+  };
+  getFloatingContentProps: <T extends HTMLElement>(
+    props: JSX.HTMLAttributes<T>,
+  ) => JSX.HTMLAttributes<T> & {
+    ref: (element: T) => void;
+  };
+  getFloatingPositionerProps: <T extends HTMLElement>(
+    props: JSX.HTMLAttributes<T>,
+  ) => JSX.HTMLAttributes<T> & {
+    ref: (element: T) => void;
+  };
+  getHoverFocusTriggerProps: <T extends HTMLElement>(
+    props: JSX.HTMLAttributes<T>,
+    options: {
+      focusReason: Reason;
+      pointerReason: Reason;
+    },
+  ) => JSX.HTMLAttributes<T>;
+  getPartProps: (part: string) => Record<string, unknown>;
+  getTriggerProps: <T extends HTMLElement>(
+    props: JSX.HTMLAttributes<T>,
+    options: {
+      action: "open" | "toggle";
+      ariaDescribedBy?: boolean;
+      ariaHasPopup?: JSX.HTMLAttributes<T>["aria-haspopup"];
+      reason: Reason;
+    },
+  ) => JSX.HTMLAttributes<T>;
+  modal: Accessor<boolean>;
+  open: Accessor<boolean>;
+  setOpen: (open: boolean, detail: OverlayControllerChangeDetail<Reason>) => void;
+  shouldMount: (forceMount?: boolean) => boolean;
+  state: Accessor<"closed" | "open">;
+  titleId: string;
+  triggerId: string;
+};
+
+export function createOverlayController<Reason extends string>(
+  options: OverlayControllerOptions<Reason>,
+): OverlayController<Reason> {
+  const triggerId = createStableId(options.ids?.trigger ?? `${options.scope}-trigger`);
+  const contentId = createStableId(options.ids?.content ?? `${options.scope}-content`);
+  const titleId = createStableId(options.ids?.title ?? `${options.scope}-title`);
+  const descriptionId = createStableId(options.ids?.description ?? `${options.scope}-description`);
+  const [triggerElement, setTriggerElement] = createSignal<HTMLElement>();
+  const [contentElement, setContentElement] = createSignal<HTMLElement>();
+  const [positionerElement, setPositionerElement] = createSignal<HTMLElement>();
+  let lastDetail: OverlayControllerChangeDetail<Reason> = {
+    reason: "programmatic" as Reason,
+  };
+  let contentLayer: OverlayLayerApi | undefined;
+  let currentContentEvents: OverlayControllerContentEvents | undefined;
+  const [open, setOpenState] = createControllableBooleanSignal({
+    value: options.open,
+    defaultValue: options.defaultOpen ?? false,
+    onChange: (next) => options.onOpenChange?.(next, lastDetail),
+  });
+  const floating = options.floating
+    ? createFloatingAdapter({
+        anchor: triggerElement,
+        floating: () => positionerElement() ?? contentElement(),
+        enabled: open,
+        placement: options.floating.placement,
+      })
+    : undefined;
+  const modal = () => options.modal?.() ?? false;
+  const state = () => (open() ? "open" : "closed") as "closed" | "open";
+  const setOpen = (next: boolean, detail: OverlayControllerChangeDetail<Reason>) => {
+    lastDetail = detail;
+    setOpenState(next);
+  };
+  const getPartProps = (part: string) => ({
+    "data-scope": options.scope,
+    "data-part": part,
+    get "data-state"() {
+      return state();
+    },
+  });
+  const getFloatingProps = <T extends HTMLElement>(props: JSX.HTMLAttributes<T>) => {
+    return floating?.getFloatingProps({ style: props.style }) ?? { style: props.style };
+  };
+
+  return {
+    close: (event, reason) => setOpen(false, { event, reason }),
+    contentId: contentId(),
+    descriptionId: descriptionId(),
+    floating,
+    getCloseProps: (props, reason) => ({
+      ...props,
+      type: "button",
+      ...getPartProps("close"),
+      onClick: composeEventHandlers<MouseEvent>(props.onClick, (event) => {
+        setOpen(false, { event, reason });
+      }),
+    }),
+    getContentLayerProps: <T extends HTMLElement>(
+      props: JSX.HTMLAttributes<T> & OverlayControllerContentEvents,
+      layerOptions: OverlayControllerLayerOptions<Reason> = {},
+    ) => {
+      currentContentEvents = props;
+      const {
+        onEscapeKeyDown: _onEscapeKeyDown,
+        onFocusOutside: _onFocusOutside,
+        onInteractOutside: _onInteractOutside,
+        onMountAutoFocus: _onMountAutoFocus,
+        onPointerDownOutside: _onPointerDownOutside,
+        onUnmountAutoFocus: _onUnmountAutoFocus,
+        ...domProps
+      } = props;
+      contentLayer ??= createOverlayLayer({
+        id: contentId(),
+        element: contentElement,
+        modal: layerOptions.modal ?? modal,
+        containsTarget: layerOptions.containsTrigger
+          ? (target) => contains(triggerElement(), target)
+          : undefined,
+        disableOutsidePointerEvents: layerOptions.disableOutsidePointerEvents,
+        trapFocus: layerOptions.trapFocus,
+        restoreFocus: layerOptions.restoreFocus,
+        onEscapeKeyDown: (event) => currentContentEvents?.onEscapeKeyDown?.(event),
+        onPointerDownOutside: (event) => currentContentEvents?.onPointerDownOutside?.(event),
+        onFocusOutside: (event) => currentContentEvents?.onFocusOutside?.(event),
+        onInteractOutside: (event) => currentContentEvents?.onInteractOutside?.(event),
+        onMountAutoFocus: (event) => currentContentEvents?.onMountAutoFocus?.(event),
+        onUnmountAutoFocus: (event) => currentContentEvents?.onUnmountAutoFocus?.(event),
+        onDismiss: (event) => {
+          if (layerOptions.onDismiss) {
+            layerOptions.onDismiss(event);
+            return;
+          }
+
+          setOpen(false, {
+            event,
+            reason: layerOptions.dismissReason?.(event) ?? ("programmatic" as Reason),
+          });
+        },
+      } satisfies CreateOverlayLayerOptions);
+      const layer = contentLayer;
+
+      return {
+        ...domProps,
+        "data-layer-id": layer.id,
+        get "data-layer-index"() {
+          return layer.index();
+        },
+        get "data-top-layer"() {
+          return layer.isTopLayer() ? "" : undefined;
+        },
+        ref: (element: T) => {
+          setContentElement(() => element);
+          assignRef(domProps.ref, element);
+        },
+      };
+    },
+    getFloatingContentProps: <T extends HTMLElement>(props: JSX.HTMLAttributes<T>) => {
+      const floatingProps = getFloatingProps(props);
+
+      return {
+        ...props,
+        "data-side": floating?.side(),
+        "data-align": floating?.align(),
+        style: floatingProps.style,
+        ref: (element: T) => {
+          setContentElement(() => element);
+          assignRef(props.ref, element);
+          queueMicrotask(() => floating?.update());
+        },
+      };
+    },
+    getFloatingPositionerProps: <T extends HTMLElement>(props: JSX.HTMLAttributes<T>) => {
+      const floatingProps = getFloatingProps(props);
+
+      return {
+        ...props,
+        "data-side": floating?.side(),
+        "data-align": floating?.align(),
+        style: floatingProps.style,
+        ref: (element: T) => {
+          setPositionerElement(() => element);
+          assignRef(props.ref, element);
+          queueMicrotask(() => floating?.update());
+        },
+      };
+    },
+    getHoverFocusTriggerProps: <T extends HTMLElement>(
+      props: JSX.HTMLAttributes<T>,
+      triggerOptions: {
+        focusReason: Reason;
+        pointerReason: Reason;
+      },
+    ) => ({
+      ...props,
+      type: "button",
+      "aria-describedby": contentId(),
+      ...getPartProps("trigger"),
+      ref: (element: T) => {
+        setTriggerElement(() => element);
+        assignRef(props.ref, element);
+      },
+      onBlur: composeEventHandlers<FocusEvent>(props.onBlur, (event) => {
+        setOpen(false, { event, reason: triggerOptions.focusReason });
+      }),
+      onFocus: composeEventHandlers<FocusEvent>(props.onFocus, (event) => {
+        setOpen(true, { event, reason: triggerOptions.focusReason });
+      }),
+      onPointerEnter: composeEventHandlers<PointerEvent>(props.onPointerEnter, (event) => {
+        setOpen(true, { event, reason: triggerOptions.pointerReason });
+      }),
+      onPointerLeave: composeEventHandlers<PointerEvent>(props.onPointerLeave, (event) => {
+        setOpen(false, { event, reason: triggerOptions.pointerReason });
+      }),
+    }),
+    getPartProps,
+    getTriggerProps: <T extends HTMLElement>(
+      props: JSX.HTMLAttributes<T>,
+      triggerOptions: {
+        action: "open" | "toggle";
+        ariaDescribedBy?: boolean;
+        ariaHasPopup?: JSX.HTMLAttributes<T>["aria-haspopup"];
+        reason: Reason;
+      },
+    ) => ({
+      ...props,
+      id: triggerId(),
+      type: "button",
+      "aria-controls": triggerOptions.ariaDescribedBy ? undefined : contentId(),
+      "aria-describedby": triggerOptions.ariaDescribedBy ? contentId() : undefined,
+      get "aria-expanded"() {
+        return triggerOptions.ariaDescribedBy ? undefined : open();
+      },
+      "aria-haspopup": triggerOptions.ariaHasPopup,
+      ...getPartProps("trigger"),
+      ref: (element: T) => {
+        setTriggerElement(() => element);
+        assignRef(props.ref, element);
+      },
+      onClick: composeEventHandlers<MouseEvent>(props.onClick, (event) => {
+        setOpen(triggerOptions.action === "toggle" ? !open() : true, {
+          event,
+          reason: triggerOptions.reason,
+        });
+      }),
+    }),
+    modal,
+    open,
+    setOpen,
+    shouldMount: (forceMount) => forceMount === true || open(),
+    state,
+    titleId: titleId(),
+    triggerId: triggerId(),
+  };
+}

--- a/packages/keystone/src/overlay/floating.test.tsx
+++ b/packages/keystone/src/overlay/floating.test.tsx
@@ -3,12 +3,24 @@ import { describe, expect, test } from "vitest";
 import { createFloatingAdapter } from "./floating";
 
 describe("Keystone floating adapter", () => {
+  const setViewport = (width: number, height: number) => {
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: width,
+    });
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      value: height,
+    });
+  };
+
   test("positions floating content from an anchor and exposes geometry variables", () => {
     createRoot((dispose) => {
       const anchor = document.createElement("button");
       const floatingElement = document.createElement("div");
       const [enabled] = createSignal(true);
 
+      setViewport(1024, 768);
       anchor.getBoundingClientRect = () =>
         ({
           bottom: 70,
@@ -43,8 +55,215 @@ describe("Keystone floating adapter", () => {
       expect(floatingElement.style.left).toBe("20px");
       expect(floatingElement.style.top).toBe("78px");
       expect(floatingElement.style.getPropertyValue("--keystone-anchor-width")).toBe("120px");
+      expect(floatingElement.style.getPropertyValue("--keystone-available-height")).toBe("686px");
+      expect(floatingElement.style.getPropertyValue("--keystone-arrow-x")).toBe("60px");
+      expect(floatingElement.style.getPropertyValue("--keystone-arrow-y")).toBe("0px");
+      expect(floatingElement.style.getPropertyValue("--keystone-transform-origin")).toBe(
+        "start top",
+      );
       expect(floating.getFloatingProps()["data-side"]).toBe("bottom");
       dispose();
+    });
+  });
+
+  test("flips placement when the requested side collides with the viewport", () => {
+    createRoot((dispose) => {
+      const anchor = document.createElement("button");
+      const floatingElement = document.createElement("div");
+
+      setViewport(320, 240);
+      anchor.getBoundingClientRect = () =>
+        ({
+          bottom: 230,
+          height: 32,
+          left: 120,
+          right: 200,
+          top: 198,
+          width: 80,
+        }) as DOMRect;
+      floatingElement.getBoundingClientRect = () =>
+        ({
+          bottom: 0,
+          height: 80,
+          left: 0,
+          right: 0,
+          top: 0,
+          width: 120,
+        }) as DOMRect;
+
+      const floating = createFloatingAdapter({
+        anchor: () => anchor,
+        floating: () => floatingElement,
+        gutter: () => 8,
+        placement: () => "bottom",
+      });
+
+      floating.update();
+
+      expect(floating.side()).toBe("top");
+      expect(floating.align()).toBe("center");
+      expect(floatingElement.style.top).toBe("110px");
+      expect(floatingElement.style.getPropertyValue("--keystone-available-height")).toBe("186px");
+      expect(floating.getFloatingProps()["data-side"]).toBe("top");
+      dispose();
+    });
+  });
+
+  test("shifts cross-axis coordinates to keep content inside the viewport", () => {
+    createRoot((dispose) => {
+      const anchor = document.createElement("button");
+      const floatingElement = document.createElement("div");
+
+      setViewport(320, 240);
+      anchor.getBoundingClientRect = () =>
+        ({
+          bottom: 70,
+          height: 32,
+          left: 280,
+          right: 316,
+          top: 38,
+          width: 36,
+        }) as DOMRect;
+      floatingElement.getBoundingClientRect = () =>
+        ({
+          bottom: 0,
+          height: 64,
+          left: 0,
+          right: 0,
+          top: 0,
+          width: 120,
+        }) as DOMRect;
+
+      const floating = createFloatingAdapter({
+        anchor: () => anchor,
+        floating: () => floatingElement,
+        placement: () => "bottom-end",
+      });
+
+      floating.update();
+
+      expect(floating.side()).toBe("bottom");
+      expect(floating.align()).toBe("end");
+      expect(floatingElement.style.left).toBe("196px");
+      expect(floatingElement.style.getPropertyValue("--keystone-arrow-x")).toBe("102px");
+      dispose();
+    });
+  });
+
+  test("uses scroll offsets for absolute strategy and viewport coordinates for fixed strategy", () => {
+    createRoot((dispose) => {
+      const anchor = document.createElement("button");
+      const absoluteElement = document.createElement("div");
+      const fixedElement = document.createElement("div");
+
+      setViewport(800, 600);
+      Object.defineProperty(window, "scrollX", {
+        configurable: true,
+        value: 30,
+      });
+      Object.defineProperty(window, "scrollY", {
+        configurable: true,
+        value: 50,
+      });
+      anchor.getBoundingClientRect = () =>
+        ({
+          bottom: 70,
+          height: 40,
+          left: 20,
+          right: 140,
+          top: 30,
+          width: 120,
+        }) as DOMRect;
+      const floatingRect = () =>
+        ({
+          bottom: 0,
+          height: 80,
+          left: 0,
+          right: 0,
+          top: 0,
+          width: 100,
+        }) as DOMRect;
+      absoluteElement.getBoundingClientRect = floatingRect;
+      fixedElement.getBoundingClientRect = floatingRect;
+
+      const absolute = createFloatingAdapter({
+        anchor: () => anchor,
+        floating: () => absoluteElement,
+        placement: () => "bottom-start",
+        strategy: () => "absolute",
+      });
+      const fixed = createFloatingAdapter({
+        anchor: () => anchor,
+        floating: () => fixedElement,
+        placement: () => "bottom-start",
+        strategy: () => "fixed",
+      });
+
+      absolute.update();
+      fixed.update();
+
+      expect(absoluteElement.style.left).toBe("50px");
+      expect(absoluteElement.style.top).toBe("124px");
+      expect(fixedElement.style.left).toBe("20px");
+      expect(fixedElement.style.top).toBe("74px");
+      expect(fixed.getFloatingProps().style).toMatchObject({ position: "fixed" });
+      dispose();
+    });
+  });
+
+  test("updates geometry from window resize and scroll triggers", async () => {
+    await new Promise<void>((resolve) => {
+      createRoot((dispose) => {
+        const anchor = document.createElement("button");
+        const floatingElement = document.createElement("div");
+        let left = 20;
+
+        setViewport(800, 600);
+        Object.defineProperty(window, "scrollX", {
+          configurable: true,
+          value: 0,
+        });
+        Object.defineProperty(window, "scrollY", {
+          configurable: true,
+          value: 0,
+        });
+        anchor.getBoundingClientRect = () =>
+          ({
+            bottom: 70,
+            height: 40,
+            left,
+            right: left + 120,
+            top: 30,
+            width: 120,
+          }) as DOMRect;
+        floatingElement.getBoundingClientRect = () =>
+          ({
+            bottom: 0,
+            height: 80,
+            left: 0,
+            right: 0,
+            top: 0,
+            width: 100,
+          }) as DOMRect;
+
+        createFloatingAdapter({
+          anchor: () => anchor,
+          floating: () => floatingElement,
+          placement: () => "bottom-start",
+        });
+
+        queueMicrotask(() => {
+          expect(floatingElement.style.left).toBe("20px");
+          left = 44;
+          window.dispatchEvent(new Event("resize"));
+          expect(floatingElement.style.left).toBe("44px");
+          left = 68;
+          window.dispatchEvent(new Event("scroll"));
+          expect(floatingElement.style.left).toBe("68px");
+          dispose();
+          resolve();
+        });
+      });
     });
   });
 });

--- a/packages/keystone/src/overlay/floating.ts
+++ b/packages/keystone/src/overlay/floating.ts
@@ -1,4 +1,11 @@
-import { createEffect, createMemo, onCleanup, type Accessor, type JSX } from "solid-js";
+import {
+  createEffect,
+  createMemo,
+  createSignal,
+  onCleanup,
+  type Accessor,
+  type JSX,
+} from "solid-js";
 
 export type FloatingPlacement =
   | "top"
@@ -37,21 +44,43 @@ export type FloatingAdapter = {
 };
 
 type FloatingGeometry = {
+  align: FloatingAlign;
+  arrowX: number | undefined;
+  arrowY: number | undefined;
   availableHeight: number;
   availableWidth: number;
   height: number;
   left: number;
+  side: FloatingSide;
   top: number;
   transformOrigin: string;
   width: number;
 };
 
+type FloatingPositioningInput = {
+  anchorRect: DOMRect;
+  floatingRect: DOMRect;
+  gutter: number;
+  placement: FloatingPlacement;
+  strategy: FloatingStrategy;
+  viewportHeight: number;
+  viewportWidth: number;
+  scrollX: number;
+  scrollY: number;
+};
+
+type FloatingPositioningEngine = {
+  compute: (input: FloatingPositioningInput) => FloatingGeometry;
+};
+
+const collisionPadding = 4;
+
 export function createFloatingAdapter(options: CreateFloatingAdapterOptions): FloatingAdapter {
   const placement = createMemo(() => options.placement?.() ?? "bottom-start");
-  const side = createMemo(() => placement().split("-")[0] as FloatingSide);
-  const align = createMemo(
-    () => (placement().split("-")[1] as "end" | "start" | undefined) ?? "center",
-  );
+  const [resolvedPlacement, setResolvedPlacement] = createSignal(parsePlacement(placement()));
+  const side = createMemo(() => resolvedPlacement().side);
+  const align = createMemo(() => resolvedPlacement().align);
+  const engine = createGeometryPositioningEngine();
   let geometry: FloatingGeometry | undefined;
 
   const update = () => {
@@ -66,15 +95,25 @@ export function createFloatingAdapter(options: CreateFloatingAdapterOptions): Fl
       return;
     }
 
-    geometry = computeFloatingGeometry({
-      align: align(),
+    geometry = engine.compute({
       anchorRect: anchor.getBoundingClientRect(),
       floatingRect: floating.getBoundingClientRect(),
       gutter: options.gutter?.() ?? 4,
-      side: side(),
+      placement: placement(),
+      strategy: options.strategy?.() ?? "absolute",
       viewportHeight: window.innerHeight,
       viewportWidth: window.innerWidth,
+      scrollX: window.scrollX,
+      scrollY: window.scrollY,
     });
+    setResolvedPlacement((current) =>
+      current.align === geometry?.align && current.side === geometry?.side
+        ? current
+        : {
+            align: geometry?.align ?? current.align,
+            side: geometry?.side ?? current.side,
+          },
+    );
 
     applyFloatingGeometry(floating, geometry);
   };
@@ -118,69 +157,190 @@ export function createFloatingAdapter(options: CreateFloatingAdapterOptions): Fl
   };
 }
 
-function computeFloatingGeometry(options: {
+function createGeometryPositioningEngine(): FloatingPositioningEngine {
+  return {
+    compute: computeFloatingGeometry,
+  };
+}
+
+function computeFloatingGeometry(input: FloatingPositioningInput): FloatingGeometry {
+  const requested = parsePlacement(input.placement);
+  const side = resolveCollisionSide(input, requested.side);
+  const availableWidth = getAvailableWidth(input, side);
+  const availableHeight = getAvailableHeight(input, side);
+  const raw = getRawCoordinates(input, side, requested.align);
+  const shifted = shiftCoordinates(input, side, raw);
+  const arrow = getArrowCoordinates(input, shifted);
+  const strategyOffsetX = input.strategy === "absolute" ? input.scrollX : 0;
+  const strategyOffsetY = input.strategy === "absolute" ? input.scrollY : 0;
+
+  return {
+    align: requested.align,
+    arrowX: arrow.x,
+    arrowY: arrow.y,
+    availableHeight,
+    availableWidth,
+    height: input.anchorRect.height,
+    left: shifted.left + strategyOffsetX,
+    side,
+    top: shifted.top + strategyOffsetY,
+    transformOrigin: getTransformOrigin(side, requested.align),
+    width: input.anchorRect.width,
+  };
+}
+
+function parsePlacement(placement: FloatingPlacement): {
   align: FloatingAlign;
-  anchorRect: DOMRect;
-  floatingRect: DOMRect;
-  gutter: number;
   side: FloatingSide;
-  viewportHeight: number;
-  viewportWidth: number;
-}): FloatingGeometry {
-  const width = options.anchorRect.width;
-  const height = options.anchorRect.height;
-  const availableWidth =
-    options.side === "left"
-      ? options.anchorRect.left - options.gutter
-      : options.viewportWidth - options.anchorRect.right - options.gutter;
-  const availableHeight =
-    options.side === "top"
-      ? options.anchorRect.top - options.gutter
-      : options.viewportHeight - options.anchorRect.bottom - options.gutter;
-  let left = options.anchorRect.left;
-  let top = options.anchorRect.bottom + options.gutter;
+} {
+  const [side, align] = placement.split("-") as [FloatingSide, "end" | "start" | undefined];
 
-  if (options.side === "top") {
-    top = options.anchorRect.top - options.floatingRect.height - options.gutter;
+  return {
+    align: align ?? "center",
+    side,
+  };
+}
+
+function resolveCollisionSide(input: FloatingPositioningInput, side: FloatingSide): FloatingSide {
+  const opposite = getOppositeSide(side);
+  const available = getAvailableMainAxis(input, side);
+  const oppositeAvailable = getAvailableMainAxis(input, opposite);
+  const floatingSize = isVerticalSide(side) ? input.floatingRect.height : input.floatingRect.width;
+
+  return available < floatingSize && oppositeAvailable > available ? opposite : side;
+}
+
+function getAvailableMainAxis(input: FloatingPositioningInput, side: FloatingSide): number {
+  if (side === "top") {
+    return Math.max(0, input.anchorRect.top - input.gutter - collisionPadding);
   }
 
-  if (options.side === "left") {
-    left = options.anchorRect.left - options.floatingRect.width - options.gutter;
-    top = alignCrossAxis(
-      options.align,
-      options.anchorRect.top,
-      options.anchorRect.height,
-      options.floatingRect.height,
+  if (side === "bottom") {
+    return Math.max(
+      0,
+      input.viewportHeight - input.anchorRect.bottom - input.gutter - collisionPadding,
     );
   }
 
-  if (options.side === "right") {
-    left = options.anchorRect.right + options.gutter;
+  if (side === "left") {
+    return Math.max(0, input.anchorRect.left - input.gutter - collisionPadding);
+  }
+
+  return Math.max(
+    0,
+    input.viewportWidth - input.anchorRect.right - input.gutter - collisionPadding,
+  );
+}
+
+function getAvailableWidth(input: FloatingPositioningInput, side: FloatingSide) {
+  if (side === "left") {
+    return getAvailableMainAxis(input, "left");
+  }
+
+  if (side === "right") {
+    return getAvailableMainAxis(input, "right");
+  }
+
+  return Math.max(0, input.viewportWidth - collisionPadding * 2);
+}
+
+function getAvailableHeight(input: FloatingPositioningInput, side: FloatingSide) {
+  if (side === "top") {
+    return getAvailableMainAxis(input, "top");
+  }
+
+  if (side === "bottom") {
+    return getAvailableMainAxis(input, "bottom");
+  }
+
+  return Math.max(0, input.viewportHeight - collisionPadding * 2);
+}
+
+function getRawCoordinates(
+  input: FloatingPositioningInput,
+  side: FloatingSide,
+  align: FloatingAlign,
+) {
+  let left = input.anchorRect.left;
+  let top = input.anchorRect.bottom + input.gutter;
+
+  if (side === "top") {
+    top = input.anchorRect.top - input.floatingRect.height - input.gutter;
+  }
+
+  if (side === "left") {
+    left = input.anchorRect.left - input.floatingRect.width - input.gutter;
     top = alignCrossAxis(
-      options.align,
-      options.anchorRect.top,
-      options.anchorRect.height,
-      options.floatingRect.height,
+      align,
+      input.anchorRect.top,
+      input.anchorRect.height,
+      input.floatingRect.height,
     );
   }
 
-  if (options.side === "bottom" || options.side === "top") {
+  if (side === "right") {
+    left = input.anchorRect.right + input.gutter;
+    top = alignCrossAxis(
+      align,
+      input.anchorRect.top,
+      input.anchorRect.height,
+      input.floatingRect.height,
+    );
+  }
+
+  if (isVerticalSide(side)) {
     left = alignCrossAxis(
-      options.align,
-      options.anchorRect.left,
-      options.anchorRect.width,
-      options.floatingRect.width,
+      align,
+      input.anchorRect.left,
+      input.anchorRect.width,
+      input.floatingRect.width,
     );
+  }
+
+  return { left, top };
+}
+
+function shiftCoordinates(
+  input: FloatingPositioningInput,
+  side: FloatingSide,
+  coordinates: { left: number; top: number },
+) {
+  if (isVerticalSide(side)) {
+    return {
+      left: clamp(
+        coordinates.left,
+        collisionPadding,
+        input.viewportWidth - input.floatingRect.width - collisionPadding,
+      ),
+      top: coordinates.top,
+    };
   }
 
   return {
-    availableHeight: Math.max(0, availableHeight),
-    availableWidth: Math.max(0, availableWidth),
-    height,
-    left,
-    top,
-    transformOrigin: getTransformOrigin(options.side, options.align),
-    width,
+    left: coordinates.left,
+    top: clamp(
+      coordinates.top,
+      collisionPadding,
+      input.viewportHeight - input.floatingRect.height - collisionPadding,
+    ),
+  };
+}
+
+function getArrowCoordinates(
+  input: FloatingPositioningInput,
+  coordinates: { left: number; top: number },
+): { x: number; y: number } {
+  return {
+    x: clamp(
+      input.anchorRect.left + input.anchorRect.width / 2 - coordinates.left,
+      0,
+      input.floatingRect.width,
+    ),
+    y: clamp(
+      input.anchorRect.top + input.anchorRect.height / 2 - coordinates.top,
+      0,
+      input.floatingRect.height,
+    ),
   };
 }
 
@@ -202,13 +362,27 @@ function alignCrossAxis(
 }
 
 function applyFloatingGeometry(element: HTMLElement, geometry: FloatingGeometry) {
-  element.style.setProperty("--keystone-anchor-width", `${geometry.width}px`);
-  element.style.setProperty("--keystone-anchor-height", `${geometry.height}px`);
-  element.style.setProperty("--keystone-available-width", `${geometry.availableWidth}px`);
-  element.style.setProperty("--keystone-available-height", `${geometry.availableHeight}px`);
-  element.style.setProperty("--keystone-transform-origin", geometry.transformOrigin);
-  element.style.left = `${geometry.left}px`;
-  element.style.top = `${geometry.top}px`;
+  setStyleProperty(element, "--keystone-anchor-width", `${geometry.width}px`);
+  setStyleProperty(element, "--keystone-anchor-height", `${geometry.height}px`);
+  setStyleProperty(element, "--keystone-available-width", `${geometry.availableWidth}px`);
+  setStyleProperty(element, "--keystone-available-height", `${geometry.availableHeight}px`);
+  setStyleProperty(element, "--keystone-arrow-x", `${geometry.arrowX}px`);
+  setStyleProperty(element, "--keystone-arrow-y", `${geometry.arrowY}px`);
+  setStyleProperty(element, "--keystone-transform-origin", geometry.transformOrigin);
+  setElementStyleValue(element, "left", `${geometry.left}px`);
+  setElementStyleValue(element, "top", `${geometry.top}px`);
+}
+
+function setStyleProperty(element: HTMLElement, property: string, value: string) {
+  if (element.style.getPropertyValue(property) !== value) {
+    element.style.setProperty(property, value);
+  }
+}
+
+function setElementStyleValue(element: HTMLElement, property: "left" | "top", value: string) {
+  if (element.style[property] !== value) {
+    element.style[property] = value;
+  }
 }
 
 function mergeFloatingStyle(
@@ -224,17 +398,27 @@ function mergeFloatingStyle(
     "--keystone-anchor-height": geometry ? `${geometry.height}px` : undefined,
     "--keystone-available-width": geometry ? `${geometry.availableWidth}px` : undefined,
     "--keystone-available-height": geometry ? `${geometry.availableHeight}px` : undefined,
+    "--keystone-arrow-x": geometry ? `${geometry.arrowX}px` : undefined,
+    "--keystone-arrow-y": geometry ? `${geometry.arrowY}px` : undefined,
     "--keystone-transform-origin": geometry?.transformOrigin,
   } as JSX.CSSProperties;
 
   if (!style || typeof style === "string") {
-    return style ? `${style}; position: ${strategy}` : floatingStyle;
+    const serialized = serializeFloatingStyle(floatingStyle);
+    return style ? `${style}; ${serialized}` : floatingStyle;
   }
 
   return {
     ...floatingStyle,
     ...style,
   };
+}
+
+function serializeFloatingStyle(style: JSX.CSSProperties): string {
+  return Object.entries(style)
+    .filter((entry): entry is [string, string | number] => entry[1] !== undefined)
+    .map(([property, value]) => `${property}: ${value}`)
+    .join("; ");
 }
 
 function getTransformOrigin(side: FloatingSide, align: FloatingAlign) {
@@ -253,4 +437,32 @@ function getTransformOrigin(side: FloatingSide, align: FloatingAlign) {
   }
 
   return `left ${crossAxis}`;
+}
+
+function getOppositeSide(side: FloatingSide): FloatingSide {
+  if (side === "top") {
+    return "bottom";
+  }
+
+  if (side === "bottom") {
+    return "top";
+  }
+
+  if (side === "left") {
+    return "right";
+  }
+
+  return "left";
+}
+
+function isVerticalSide(side: FloatingSide) {
+  return side === "top" || side === "bottom";
+}
+
+function clamp(value: number, min: number, max: number) {
+  if (max < min) {
+    return min;
+  }
+
+  return Math.min(Math.max(value, min), max);
 }

--- a/packages/keystone/src/overlay/layer-kernel.tsx
+++ b/packages/keystone/src/overlay/layer-kernel.tsx
@@ -5,6 +5,7 @@ import {
   onCleanup,
   onMount,
   splitProps,
+  untrack,
   useContext,
   type Accessor,
   type JSX,
@@ -27,6 +28,7 @@ export type OverlayLayerEntry = {
 
 type OverlayLayerRegistration = OverlayLayerEntry & {
   element?: HTMLElement;
+  getElement?: Accessor<HTMLElement | undefined>;
   disableOutsidePointerEvents: Accessor<boolean>;
 };
 
@@ -103,8 +105,10 @@ export function createOverlayLayerStack(): OverlayLayerStack {
     const hasBlockingLayer = current.some((layer) => layer.disableOutsidePointerEvents());
 
     for (const layer of current) {
-      if (layer.element) {
-        layer.element.style.pointerEvents = "auto";
+      const element = untrack(() => layer.getElement?.() ?? layer.element);
+
+      if (element) {
+        element.style.pointerEvents = "auto";
       }
     }
 
@@ -156,12 +160,12 @@ export function createOverlayLayer(options: CreateOverlayLayerOptions): OverlayL
   const isTopLayer = createMemo(() => stack.isTopLayer(options.id));
 
   onMount(() => {
-    const element = options.element?.();
-    const ownerDocument = getOwnerDocument(element);
+    const ownerDocument = getOwnerDocument(options.element?.());
     const unregister = stack.register({
       id: options.id,
       modal: modal(),
-      element,
+      element: options.element?.(),
+      getElement: options.element,
       disableOutsidePointerEvents: () => options.disableOutsidePointerEvents?.() ?? modal(),
     });
     let isReady = false;
@@ -170,7 +174,25 @@ export function createOverlayLayer(options: CreateOverlayLayerOptions): OverlayL
     stack.syncPointerEvents(ownerDocument);
     queueMicrotask(() => {
       isReady = true;
+
+      const element = options.element?.();
+
+      if (!element || restoreFocus) {
+        return;
+      }
+
+      restoreFocus = mountLayerFocusLifecycle({
+        element,
+        isTopLayer,
+        restoreFocus: () => options.restoreFocus?.() ?? true,
+        trapFocus: () => options.trapFocus?.() ?? false,
+        onMountAutoFocus: options.onMountAutoFocus,
+        onUnmountAutoFocus: options.onUnmountAutoFocus,
+      });
+      stack.syncPointerEvents(getOwnerDocument(element));
     });
+
+    const element = options.element?.();
 
     if (element) {
       restoreFocus = mountLayerFocusLifecycle({
@@ -184,6 +206,8 @@ export function createOverlayLayer(options: CreateOverlayLayerOptions): OverlayL
     }
 
     const onPointerDown = (event: PointerEvent) => {
+      const element = options.element?.();
+
       if (
         handledOutsideEvents.has(event) ||
         !element ||
@@ -200,6 +224,8 @@ export function createOverlayLayer(options: CreateOverlayLayerOptions): OverlayL
     };
 
     const onFocusIn = (event: FocusEvent) => {
+      const element = options.element?.();
+
       if (
         handledOutsideEvents.has(event) ||
         !element ||

--- a/packages/keystone/src/popover/index.tsx
+++ b/packages/keystone/src/popover/index.tsx
@@ -1,21 +1,13 @@
-import { Show, createContext, createSignal, splitProps, useContext, type JSX } from "solid-js";
+import { Show, createContext, splitProps, useContext, type JSX } from "solid-js";
 import { Portal } from "solid-js/web";
-import { assignRef, contains } from "../overlay/dom";
 import {
   OverlayLayerProvider,
-  createFloatingAdapter,
-  createOverlayLayer,
   type FloatingAdapter,
   type FloatingPlacement,
   type OverlayLayerOutsideEvent,
 } from "../overlay/index";
-import {
-  composeEventHandlers,
-  createControllableBooleanSignal,
-  createStableId,
-  renderPolymorphic,
-  type PolymorphicProps,
-} from "../utils/index";
+import { createOverlayController } from "../overlay/controller";
+import { renderPolymorphic, type PolymorphicProps } from "../utils/index";
 
 export type PopoverOpenChangeDetail = {
   event?: Event;
@@ -77,102 +69,78 @@ export type CreatePopoverOptions = {
 const PopoverContext = createContext<PopoverApi>();
 
 export function createPopover(options: CreatePopoverOptions = {}): PopoverApi {
-  const triggerId = createStableId("popover-trigger");
-  const contentId = createStableId("popover-content");
-  const [triggerElement, setTriggerElement] = createSignal<HTMLButtonElement>();
-  const [contentElement, setContentElement] = createSignal<HTMLDivElement>();
-  const [positionerElement, setPositionerElement] = createSignal<HTMLDivElement>();
-  let lastDetail: PopoverOpenChangeDetail = { reason: "programmatic" };
-  const [open, setOpenState] = createControllableBooleanSignal({
-    value: options.open,
-    defaultValue: options.defaultOpen ?? false,
-    onChange: (next) => options.onOpenChange?.(next, lastDetail),
+  const overlay = createOverlayController<PopoverOpenChangeDetail["reason"]>({
+    scope: "popover",
+    open: options.open,
+    defaultOpen: options.defaultOpen,
+    modal: () => options.modal?.() ?? false,
+    onOpenChange: (open, detail) => options.onOpenChange?.(open, detail),
+    floating: {
+      placement: options.placement,
+    },
   });
-  const floating = createFloatingAdapter({
-    anchor: triggerElement,
-    floating: () => positionerElement() ?? contentElement(),
-    enabled: open,
-    placement: options.placement,
-  });
-  const setOpen = (next: boolean, detail: PopoverOpenChangeDetail) => {
-    lastDetail = detail;
-    setOpenState(next);
-  };
-  const state = () => (open() ? "open" : "closed");
+  const floating = overlay.floating as FloatingAdapter;
   const partProps = (part: string) => ({
-    "data-scope": "popover",
-    "data-part": part,
-    "data-state": state(),
+    ...overlay.getPartProps(part),
+    "data-side": floating.side(),
+    "data-align": floating.align(),
   });
 
   return {
-    contentId: contentId(),
+    contentId: overlay.contentId,
     floating,
     getContentProps: (props) => {
-      createOverlayLayer({
-        id: contentId(),
-        element: contentElement,
-        modal: () => options.modal?.() ?? false,
-        containsTarget: (target) => contains(triggerElement(), target),
-        disableOutsidePointerEvents: () => options.modal?.() ?? false,
-        onEscapeKeyDown: props.onEscapeKeyDown,
-        onPointerDownOutside: props.onPointerDownOutside,
-        onFocusOutside: props.onFocusOutside,
-        onInteractOutside: props.onInteractOutside,
-        onDismiss: (event) => {
-          setOpen(false, { event, reason: event.type === "keydown" ? "escape" : "outside" });
+      const [local, others] = splitProps(props, [
+        "ref",
+        "style",
+        "onEscapeKeyDown",
+        "onPointerDownOutside",
+        "onFocusOutside",
+        "onInteractOutside",
+      ]);
+      const layerProps = overlay.getContentLayerProps<HTMLDivElement>(
+        {
+          onEscapeKeyDown: local.onEscapeKeyDown,
+          onFocusOutside: local.onFocusOutside,
+          onInteractOutside: local.onInteractOutside,
+          onPointerDownOutside: local.onPointerDownOutside,
         },
+        {
+          containsTrigger: true,
+          modal: overlay.modal,
+          disableOutsidePointerEvents: overlay.modal,
+          dismissReason: (event) => (event.type === "keydown" ? "escape" : "outside"),
+        },
+      );
+      const floatingProps = overlay.getFloatingContentProps<HTMLDivElement>({
+        ref: local.ref,
+        style: local.style,
       });
 
-      const floatingProps = floating.getFloatingProps({ style: props.style });
       return {
-        ...props,
-        id: contentId(),
+        ...others,
+        ...layerProps,
+        ...floatingProps,
+        id: overlay.contentId,
         role: "dialog",
         tabindex: -1,
         ...partProps("content"),
-        "data-side": floating.side(),
-        "data-align": floating.align(),
-        style: floatingProps.style,
-        ref: (element: HTMLDivElement) => {
-          setContentElement(element);
-          assignRef(props.ref, element);
-          queueMicrotask(floating.update);
-        },
       };
     },
     getPositionerProps: (props) => {
-      const floatingProps = floating.getFloatingProps({ style: props.style });
+      const floatingProps = overlay.getFloatingPositionerProps<HTMLDivElement>(props);
       return {
-        ...props,
+        ...floatingProps,
         ...partProps("positioner"),
-        "data-side": floating.side(),
-        "data-align": floating.align(),
-        style: floatingProps.style,
-        ref: (element: HTMLDivElement) => {
-          setPositionerElement(element);
-          assignRef(props.ref, element);
-          queueMicrotask(floating.update);
-        },
       };
     },
-    getTriggerProps: (props) => ({
-      ...props,
-      id: triggerId(),
-      type: "button",
-      "aria-controls": contentId(),
-      "aria-expanded": open(),
-      "aria-haspopup": "dialog",
-      ...partProps("trigger"),
-      ref: (element: HTMLButtonElement) => {
-        setTriggerElement(element);
-        assignRef(props.ref, element);
-      },
-      onClick: composeEventHandlers(props.onClick, (event) => {
-        setOpen(!open(), { event, reason: "trigger" });
-      }),
-    }),
-    open,
+    getTriggerProps: (props) =>
+      overlay.getTriggerProps(props, {
+        action: "toggle",
+        ariaHasPopup: "dialog",
+        reason: "trigger",
+      }) as Record<string, unknown>,
+    open: overlay.open,
   };
 }
 
@@ -223,11 +191,12 @@ function PortalPart(props: PopoverPortalProps) {
 function Positioner(props: PopoverPositionerProps) {
   const popover = usePopover("Positioner");
   const [local, others] = splitProps(props, ["children", "ref", "style"]);
-  return (
-    <div {...popover.getPositionerProps({ ...others, ref: local.ref, style: local.style })}>
-      {local.children}
-    </div>
-  );
+  const positionerProps = popover.getPositionerProps({
+    ...others,
+    ref: local.ref,
+    style: local.style,
+  });
+  return <div {...positionerProps}>{local.children}</div>;
 }
 
 function Content(props: PopoverContentProps) {
@@ -241,21 +210,16 @@ function Content(props: PopoverContentProps) {
     "ref",
     "style",
   ]);
-  return (
-    <div
-      {...popover.getContentProps({
-        ...others,
-        onEscapeKeyDown: local.onEscapeKeyDown,
-        onFocusOutside: local.onFocusOutside,
-        onInteractOutside: local.onInteractOutside,
-        onPointerDownOutside: local.onPointerDownOutside,
-        ref: local.ref,
-        style: local.style,
-      })}
-    >
-      {local.children}
-    </div>
-  );
+  const contentProps = popover.getContentProps({
+    ...others,
+    onEscapeKeyDown: local.onEscapeKeyDown,
+    onFocusOutside: local.onFocusOutside,
+    onInteractOutside: local.onInteractOutside,
+    onPointerDownOutside: local.onPointerDownOutside,
+    ref: local.ref,
+    style: local.style,
+  });
+  return <div {...contentProps}>{local.children}</div>;
 }
 
 export const Popover = {

--- a/packages/keystone/src/select/index.tsx
+++ b/packages/keystone/src/select/index.tsx
@@ -1,6 +1,7 @@
 import { Show, createContext, createSignal, splitProps, useContext, type JSX } from "solid-js";
 import { Portal } from "solid-js/web";
 import { createFormControl, type FormControlApi } from "../form/index";
+import { createListboxInteraction, type ListboxInteractionApi } from "../listbox/index";
 import { assignRef } from "../overlay/dom";
 import {
   createFloatingAdapter,
@@ -10,7 +11,6 @@ import {
 import {
   composeEventHandlers,
   createControllableBooleanSignal,
-  createListInteractionKernel,
   createStableId,
   dataBoolean,
   renderPolymorphic,
@@ -129,6 +129,7 @@ export type SelectApi = {
   invalid: () => boolean;
   itemId: (value: string) => string;
   list: ListInteractionKernelApi<SelectItemData, SelectChangeDetail>;
+  listbox: ListboxInteractionApi<SelectItemData, SelectChangeDetail>;
   listboxId: string;
   open: () => boolean;
   placeholder: () => string | undefined;
@@ -156,7 +157,15 @@ export function createSelect(options: CreateSelectOptions = {}): SelectApi {
   const disabled = () => options.disabled?.() ?? false;
   const invalid = () => options.invalid?.() ?? false;
   const required = () => options.required?.() ?? false;
-  const list = createListInteractionKernel<SelectItemData, SelectChangeDetail>({
+  const itemId = (value: string) => `${listboxId()}-${value}`;
+  const listbox = createListboxInteraction<SelectItemData, SelectChangeDetail>({
+    id: listboxId,
+    labelledBy: triggerId,
+    optionId: itemId,
+    optionPart: "item",
+    optionSelectDetail: (event) => ({ event, reason: "item" }),
+    rootPart: "listbox",
+    scope: "select",
     value: options.value,
     defaultValue: options.defaultValue,
     programmaticDetail: { reason: "programmatic" },
@@ -171,12 +180,12 @@ export function createSelect(options: CreateSelectOptions = {}): SelectApi {
   const formControl = createFormControl({
     id: triggerId,
     name: options.name,
-    value: () => list.value() ?? null,
+    value: () => listbox.selection.value() ?? null,
     disabled,
     invalid,
     required,
     onReset: () => {
-      list.setValue(options.defaultValue, { reason: "programmatic" });
+      listbox.selection.setValue(options.defaultValue, { reason: "programmatic" });
     },
   });
   const floating = createFloatingAdapter({
@@ -191,7 +200,6 @@ export function createSelect(options: CreateSelectOptions = {}): SelectApi {
     setOpenState(next);
   };
   const state = () => (open() ? "open" : "closed");
-  const itemId = (value: string) => `${listboxId()}-${value}`;
   const partProps = (part: string) => ({
     "data-scope": "select",
     "data-part": part,
@@ -247,65 +255,23 @@ export function createSelect(options: CreateSelectOptions = {}): SelectApi {
         "value",
       ]);
 
-      list.registerItem({
+      return listbox.getOptionProps({
+        ...others,
         disabled: local.disabled,
         label: local.label,
+        onClick: local.onClick,
+        onPointerMove: local.onPointerMove,
         value: local.value,
       });
-
-      return {
-        ...others,
-        id: itemId(local.value),
-        role: "option",
-        "aria-disabled": local.disabled ? "true" : undefined,
-        get "aria-selected"() {
-          return list.isSelected(local.value);
-        },
-        ...partProps("item"),
-        "data-disabled": dataBoolean(local.disabled),
-        get "data-highlighted"() {
-          return dataBoolean(list.isHighlighted(local.value));
-        },
-        get "data-selected"() {
-          return dataBoolean(list.isSelected(local.value));
-        },
-        onPointerMove: composeEventHandlers(local.onPointerMove, () => {
-          if (!local.disabled) {
-            list.setHighlightedValue(local.value);
-          }
-        }),
-        onClick: composeEventHandlers(local.onClick, (event) => {
-          list.selectValue(local.value, { event, reason: "item" });
-        }),
-      };
     },
     getItemTextProps: (props) => ({
       ...props,
       ...partProps("item-text"),
     }),
-    getListboxProps: (props) => {
-      const highlightedItemId = () => {
-        const highlighted = list.highlightedValue();
-        return highlighted ? itemId(highlighted) : undefined;
-      };
-
-      return {
-        ...props,
-        id: listboxId(),
-        role: "listbox",
-        "aria-labelledby": triggerId(),
-        get "aria-activedescendant"() {
-          return highlightedItemId();
-        },
-        tabindex: -1,
-        ...partProps("listbox"),
-        onKeyDown: composeEventHandlers<KeyboardEvent>(props.onKeyDown, (event) => {
-          list.handleKeyDown(event, {
-            selectDetail: (event) => ({ event, reason: "keyboard" }),
-          });
-        }),
-      };
-    },
+    getListboxProps: (props) =>
+      listbox.getListboxProps(props, {
+        selectDetail: (event) => ({ event, reason: "keyboard" }),
+      }),
     getPositionerProps: (props) => {
       const floatingProps = floating.getFloatingProps({ style: props.style });
 
@@ -354,7 +320,7 @@ export function createSelect(options: CreateSelectOptions = {}): SelectApi {
         return dataBoolean(invalid());
       },
       get "data-placeholder"() {
-        return dataBoolean(list.value() === undefined);
+        return dataBoolean(listbox.selection.value() === undefined);
       },
       get "data-required"() {
         return dataBoolean(required());
@@ -367,13 +333,15 @@ export function createSelect(options: CreateSelectOptions = {}): SelectApi {
         setOpen(!open(), { event, reason: "trigger" });
       }),
       onKeyDown: composeEventHandlers<KeyboardEvent>(props.onKeyDown, (event) => {
-        if (event.key === "ArrowDown" || event.key === "Enter" || event.key === " ") {
+        const intent = listbox.keyboard.getTriggerOpenIntent(event);
+
+        if (intent === "open-and-highlight") {
           event.preventDefault();
           setOpen(true, { event, reason: "keyboard" });
-          list.highlight("selected-or-first");
+          listbox.keyboard.highlight("selected-or-first");
         }
 
-        if (event.key === "Escape") {
+        if (intent === "close") {
           setOpen(false, { event, reason: "escape" });
         }
       }),
@@ -382,19 +350,20 @@ export function createSelect(options: CreateSelectOptions = {}): SelectApi {
       ...props,
       ...partProps("value"),
       get "data-placeholder"() {
-        return dataBoolean(list.value() === undefined);
+        return dataBoolean(listbox.selection.value() === undefined);
       },
     }),
     invalid,
     itemId,
-    list,
+    list: listbox.interaction,
+    listbox,
     listboxId: listboxId(),
     open,
     placeholder: () => options.placeholder?.(),
     required,
     setOpen,
     triggerId: triggerId(),
-    value: list.value,
+    value: listbox.selection.value,
   };
 }
 
@@ -467,7 +436,7 @@ function Value(props: SelectValueProps) {
   const [local, others] = splitProps(props, ["children", "placeholder"]);
   const text = () =>
     local.children ??
-    select.list.selectedItem()?.label ??
+    select.listbox.selection.selectedItem()?.label ??
     local.placeholder ??
     select.placeholder();
 

--- a/packages/keystone/src/sheet/index.tsx
+++ b/packages/keystone/src/sheet/index.tsx
@@ -1,19 +1,8 @@
-import { Show, createContext, createSignal, splitProps, useContext, type JSX } from "solid-js";
+import { Show, createContext, splitProps, useContext, type JSX } from "solid-js";
 import { Portal } from "solid-js/web";
-import { assignRef } from "../overlay/dom";
-import {
-  OverlayLayerProvider,
-  createOverlayLayer,
-  type OverlayLayerApi,
-  type OverlayLayerOutsideEvent,
-} from "../overlay/index";
-import {
-  composeEventHandlers,
-  createControllableBooleanSignal,
-  createStableId,
-  renderPolymorphic,
-  type PolymorphicProps,
-} from "../utils/index";
+import { OverlayLayerProvider, type OverlayLayerOutsideEvent } from "../overlay/index";
+import { createOverlayController } from "../overlay/controller";
+import { renderPolymorphic, type PolymorphicProps } from "../utils/index";
 
 export type SheetChangeDetail = {
   event?: Event;
@@ -68,16 +57,24 @@ export type SheetTitleProps = SheetPartProps<HTMLHeadingElement> &
 export type SheetDescriptionProps = SheetPartProps<HTMLParagraphElement> &
   Omit<JSX.HTMLAttributes<HTMLParagraphElement>, "children" | "ref">;
 
+export type SheetTriggerContractProps = Omit<SheetTriggerProps, "as" | "children">;
+export type SheetCloseContractProps = Omit<SheetCloseProps, "as" | "children">;
+export type SheetContentContractProps = Omit<SheetContentProps, "children">;
+export type SheetBackdropContractProps = Omit<SheetBackdropProps, "children">;
+export type SheetPositionerContractProps = Omit<SheetPositionerProps, "children">;
+export type SheetTitleContractProps = Omit<SheetTitleProps, "children">;
+export type SheetDescriptionContractProps = Omit<SheetDescriptionProps, "children">;
+
 type SheetApi = {
   contentId: string;
   descriptionId: string;
-  getBackdropProps: () => Record<string, unknown>;
-  getCloseProps: (props: { onClick?: SheetCloseProps["onClick"] }) => Record<string, unknown>;
-  getContentProps: (options: { layer: OverlayLayerApi }) => Record<string, unknown>;
-  getDescriptionProps: () => Record<string, unknown>;
-  getPositionerProps: () => Record<string, unknown>;
-  getTitleProps: () => Record<string, unknown>;
-  getTriggerProps: (props: { onClick?: SheetTriggerProps["onClick"] }) => Record<string, unknown>;
+  getBackdropProps: (props: SheetBackdropContractProps) => Record<string, unknown>;
+  getCloseProps: (props: SheetCloseContractProps) => Record<string, unknown>;
+  getContentProps: (props: SheetContentContractProps) => Record<string, unknown>;
+  getDescriptionProps: (props: SheetDescriptionContractProps) => Record<string, unknown>;
+  getPositionerProps: (props: SheetPositionerContractProps) => Record<string, unknown>;
+  getTitleProps: (props: SheetTitleContractProps) => Record<string, unknown>;
+  getTriggerProps: (props: SheetTriggerContractProps) => Record<string, unknown>;
   modal: () => boolean;
   open: () => boolean;
   setOpen: (open: boolean, detail: SheetChangeDetail) => void;
@@ -96,77 +93,99 @@ export type CreateSheetOptions = {
 const SheetContext = createContext<SheetApi>();
 
 export function createSheet(options: CreateSheetOptions = {}): SheetApi {
-  const titleId = createStableId("sheet-title");
-  const descriptionId = createStableId("sheet-description");
-  const contentId = createStableId("sheet-content");
-  let lastDetail: SheetChangeDetail = { reason: "programmatic" };
-  const [open, setOpenState] = createControllableBooleanSignal({
-    value: options.open,
-    defaultValue: options.defaultOpen ?? false,
-    onChange: (next) => options.onOpenChange?.(next, lastDetail),
+  const overlay = createOverlayController<SheetChangeDetail["reason"]>({
+    scope: "sheet",
+    open: options.open,
+    defaultOpen: options.defaultOpen,
+    modal: () => options.modal?.() ?? true,
+    onOpenChange: (open, detail) => options.onOpenChange?.(open, detail),
   });
-  const setOpen = (next: boolean, detail: SheetChangeDetail) => {
-    lastDetail = detail;
-    setOpenState(next);
-  };
   const side = () => options.side?.() ?? "right";
-  const modal = () => options.modal?.() ?? true;
-  const state = () => (open() ? "open" : "closed");
   const partProps = (part: string) => ({
-    "data-scope": "sheet",
-    "data-part": part,
+    ...overlay.getPartProps(part),
     "data-side": side(),
-    "data-state": state(),
   });
 
   return {
-    contentId: contentId(),
-    descriptionId: descriptionId(),
-    getBackdropProps: () => partProps("backdrop"),
+    contentId: overlay.contentId,
+    descriptionId: overlay.descriptionId,
+    getBackdropProps: (props) => ({
+      ...props,
+      ...partProps("backdrop"),
+    }),
     getCloseProps: (props) => ({
-      type: "button",
+      ...overlay.getCloseProps(props, "close"),
       ...partProps("close"),
-      onClick: composeEventHandlers(props.onClick, (event) => {
-        setOpen(false, { event, reason: "close" });
-      }),
     }),
-    getContentProps: ({ layer }) => ({
-      id: contentId(),
-      tabIndex: -1,
-      role: "dialog",
-      "aria-modal": modal() ? "true" : undefined,
-      "aria-labelledby": titleId(),
-      "aria-describedby": descriptionId(),
-      "data-layer-id": layer.id,
-      "data-layer-index": layer.index(),
-      "data-top-layer": layer.isTopLayer() ? "" : undefined,
-      ...partProps("content"),
-    }),
-    getDescriptionProps: () => ({
-      id: descriptionId(),
+    getContentProps: (props) => {
+      const [local, others] = splitProps(props, [
+        "ref",
+        "onEscapeKeyDown",
+        "onPointerDownOutside",
+        "onFocusOutside",
+        "onInteractOutside",
+        "onMountAutoFocus",
+        "onUnmountAutoFocus",
+      ]);
+      const layerProps = overlay.getContentLayerProps<HTMLDivElement>(
+        {
+          ref: local.ref,
+          onEscapeKeyDown: local.onEscapeKeyDown,
+          onFocusOutside: local.onFocusOutside,
+          onInteractOutside: local.onInteractOutside,
+          onMountAutoFocus: local.onMountAutoFocus,
+          onPointerDownOutside: local.onPointerDownOutside,
+          onUnmountAutoFocus: local.onUnmountAutoFocus,
+        },
+        {
+          modal: overlay.modal,
+          disableOutsidePointerEvents: overlay.modal,
+          trapFocus: overlay.modal,
+          restoreFocus: () => true,
+          dismissReason: (event) => (event.type === "keydown" ? "escape" : "outside"),
+        },
+      );
+
+      return {
+        ...others,
+        ...layerProps,
+        id: overlay.contentId,
+        tabIndex: -1,
+        role: "dialog",
+        "aria-modal": overlay.modal() ? "true" : undefined,
+        "aria-labelledby": overlay.titleId,
+        "aria-describedby": overlay.descriptionId,
+        ...partProps("content"),
+      };
+    },
+    getDescriptionProps: (props) => ({
+      ...props,
+      id: overlay.descriptionId,
       "data-scope": "sheet",
       "data-part": "description",
     }),
-    getPositionerProps: () => partProps("positioner"),
-    getTitleProps: () => ({
-      id: titleId(),
+    getPositionerProps: (props) => ({
+      ...props,
+      ...partProps("positioner"),
+    }),
+    getTitleProps: (props) => ({
+      ...props,
+      id: overlay.titleId,
       "data-scope": "sheet",
       "data-part": "title",
     }),
     getTriggerProps: (props) => ({
-      type: "button",
-      "aria-controls": contentId(),
-      "aria-expanded": open(),
-      ...partProps("trigger"),
-      onClick: composeEventHandlers(props.onClick, (event) => {
-        setOpen(true, { event, reason: "trigger" });
+      ...overlay.getTriggerProps(props, {
+        action: "open",
+        reason: "trigger",
       }),
+      ...partProps("trigger"),
     }),
-    modal,
-    open,
-    setOpen,
+    modal: overlay.modal,
+    open: overlay.open,
+    setOpen: overlay.setOpen,
     side,
-    titleId: titleId(),
+    titleId: overlay.titleId,
   };
 }
 
@@ -194,8 +213,8 @@ function Root(props: SheetRootProps) {
 
 function Trigger(props: SheetTriggerProps) {
   const sheet = useSheet("Trigger");
-  const [local, others] = splitProps(props, ["as", "children", "onClick"]);
-  const triggerProps = { ...others, ...sheet.getTriggerProps({ onClick: local.onClick }) };
+  const [local, others] = splitProps(props, ["as", "children"]);
+  const triggerProps = sheet.getTriggerProps(others);
   if (!local.as) return <button {...triggerProps}>{local.children}</button>;
   return renderPolymorphic(local.as, "button", { ...triggerProps, children: local.children });
 }
@@ -212,92 +231,40 @@ function PortalPart(props: SheetPortalProps) {
 function Backdrop(props: SheetBackdropProps) {
   const sheet = useSheet("Backdrop");
   const [local, others] = splitProps(props, ["children"]);
-  return (
-    <div {...others} {...sheet.getBackdropProps()}>
-      {local.children}
-    </div>
-  );
+  return <div {...sheet.getBackdropProps(others)}>{local.children}</div>;
 }
 
 function Positioner(props: SheetPositionerProps) {
   const sheet = useSheet("Positioner");
   const [local, others] = splitProps(props, ["children"]);
-  return (
-    <div {...others} {...sheet.getPositionerProps()}>
-      {local.children}
-    </div>
-  );
+  const positionerProps = sheet.getPositionerProps(others);
+  return <div {...positionerProps}>{local.children}</div>;
 }
 
 function Content(props: SheetContentProps) {
   const sheet = useSheet("Content");
-  const [local, others] = splitProps(props, [
-    "children",
-    "ref",
-    "onEscapeKeyDown",
-    "onPointerDownOutside",
-    "onFocusOutside",
-    "onInteractOutside",
-    "onMountAutoFocus",
-    "onUnmountAutoFocus",
-  ]);
-  const [content, setContent] = createSignal<HTMLDivElement>();
-  const layer = createOverlayLayer({
-    id: sheet.contentId,
-    element: content,
-    modal: sheet.modal,
-    disableOutsidePointerEvents: sheet.modal,
-    trapFocus: sheet.modal,
-    restoreFocus: () => true,
-    onEscapeKeyDown: local.onEscapeKeyDown,
-    onPointerDownOutside: local.onPointerDownOutside,
-    onFocusOutside: local.onFocusOutside,
-    onInteractOutside: local.onInteractOutside,
-    onDismiss: (event) => {
-      sheet.setOpen(false, { event, reason: event.type === "keydown" ? "escape" : "outside" });
-    },
-    onMountAutoFocus: local.onMountAutoFocus,
-    onUnmountAutoFocus: local.onUnmountAutoFocus,
-  });
+  const [local, others] = splitProps(props, ["children"]);
+  const contentProps = sheet.getContentProps(others);
 
-  return (
-    <div
-      {...others}
-      {...sheet.getContentProps({ layer })}
-      ref={(node) => {
-        setContent(node);
-        assignRef(local.ref, node);
-      }}
-    >
-      {local.children}
-    </div>
-  );
+  return <div {...contentProps}>{local.children}</div>;
 }
 
 function Title(props: SheetTitleProps) {
   const sheet = useSheet("Title");
   const [local, others] = splitProps(props, ["children"]);
-  return (
-    <h2 {...others} {...sheet.getTitleProps()}>
-      {local.children}
-    </h2>
-  );
+  return <h2 {...sheet.getTitleProps(others)}>{local.children}</h2>;
 }
 
 function Description(props: SheetDescriptionProps) {
   const sheet = useSheet("Description");
   const [local, others] = splitProps(props, ["children"]);
-  return (
-    <p {...others} {...sheet.getDescriptionProps()}>
-      {local.children}
-    </p>
-  );
+  return <p {...sheet.getDescriptionProps(others)}>{local.children}</p>;
 }
 
 function Close(props: SheetCloseProps) {
   const sheet = useSheet("Close");
-  const [local, others] = splitProps(props, ["as", "children", "onClick"]);
-  const closeProps = { ...others, ...sheet.getCloseProps({ onClick: local.onClick }) };
+  const [local, others] = splitProps(props, ["as", "children"]);
+  const closeProps = sheet.getCloseProps(others);
   if (!local.as) return <button {...closeProps}>{local.children}</button>;
   return renderPolymorphic(local.as, "button", { ...closeProps, children: local.children });
 }

--- a/packages/keystone/src/tooltip/index.tsx
+++ b/packages/keystone/src/tooltip/index.tsx
@@ -1,20 +1,12 @@
-import { Show, createContext, createSignal, splitProps, useContext, type JSX } from "solid-js";
+import { Show, createContext, splitProps, useContext, type JSX } from "solid-js";
 import { Portal } from "solid-js/web";
-import { assignRef, contains } from "../overlay/dom";
 import {
   OverlayLayerProvider,
-  createFloatingAdapter,
-  createOverlayLayer,
   type FloatingAdapter,
   type FloatingPlacement,
 } from "../overlay/index";
-import {
-  composeEventHandlers,
-  createControllableBooleanSignal,
-  createStableId,
-  renderPolymorphic,
-  type PolymorphicProps,
-} from "../utils/index";
+import { createOverlayController } from "../overlay/controller";
+import { callEventHandler, renderPolymorphic, type PolymorphicProps } from "../utils/index";
 
 export type TooltipOpenChangeDetail = {
   event?: Event;
@@ -69,101 +61,66 @@ export type CreateTooltipOptions = {
 const TooltipContext = createContext<TooltipApi>();
 
 export function createTooltip(options: CreateTooltipOptions = {}): TooltipApi {
-  const contentId = createStableId("tooltip-content");
-  const [triggerElement, setTriggerElement] = createSignal<HTMLButtonElement>();
-  const [contentElement, setContentElement] = createSignal<HTMLDivElement>();
-  const [positionerElement, setPositionerElement] = createSignal<HTMLDivElement>();
-  let lastDetail: TooltipOpenChangeDetail = { reason: "programmatic" };
-  const [open, setOpenState] = createControllableBooleanSignal({
-    value: options.open,
-    defaultValue: options.defaultOpen ?? false,
-    onChange: (next) => options.onOpenChange?.(next, lastDetail),
+  const overlay = createOverlayController<TooltipOpenChangeDetail["reason"]>({
+    scope: "tooltip",
+    open: options.open,
+    defaultOpen: options.defaultOpen,
+    onOpenChange: (open, detail) => options.onOpenChange?.(open, detail),
+    floating: {
+      placement: options.placement,
+    },
   });
-  const floating = createFloatingAdapter({
-    anchor: triggerElement,
-    floating: () => positionerElement() ?? contentElement(),
-    enabled: open,
-    placement: options.placement,
-  });
-  const setOpen = (next: boolean, detail: TooltipOpenChangeDetail) => {
-    lastDetail = detail;
-    setOpenState(next);
-  };
-  const state = () => (open() ? "open" : "closed");
+  const floating = overlay.floating as FloatingAdapter;
   const partProps = (part: string) => ({
-    "data-scope": "tooltip",
-    "data-part": part,
-    "data-state": state(),
+    ...overlay.getPartProps(part),
+    "data-side": floating.side(),
+    "data-align": floating.align(),
   });
 
   return {
-    contentId: contentId(),
+    contentId: overlay.contentId,
     floating,
     getContentProps: (props) => {
-      createOverlayLayer({
-        id: contentId(),
-        element: contentElement,
-        containsTarget: (target) => contains(triggerElement(), target),
-        onEscapeKeyDown: (event) => {
-          event.preventDefault();
-          setOpen(false, { event, reason: "escape" });
+      overlay.getContentLayerProps<HTMLDivElement>(
+        {},
+        {
+          containsTrigger: true,
+          onDismiss: (event) => {
+            overlay.close(event, "escape");
+          },
         },
-      });
+      );
+      const floatingProps = overlay.getFloatingContentProps<HTMLDivElement>(props);
 
-      const floatingProps = floating.getFloatingProps({ style: props.style });
       return {
-        ...props,
-        id: contentId(),
+        ...floatingProps,
+        id: overlay.contentId,
         role: "tooltip",
         ...partProps("content"),
-        "data-side": floating.side(),
-        "data-align": floating.align(),
-        style: floatingProps.style,
-        ref: (element: HTMLDivElement) => {
-          setContentElement(element);
-          assignRef(props.ref, element);
-          queueMicrotask(floating.update);
+        onKeyDown: (event: KeyboardEvent) => {
+          callEventHandler(props.onKeyDown, event);
+          if (event.defaultPrevented || event.key !== "Escape") {
+            return;
+          }
+
+          event.preventDefault();
+          overlay.close(event, "escape");
         },
       };
     },
     getPositionerProps: (props) => {
-      const floatingProps = floating.getFloatingProps({ style: props.style });
+      const floatingProps = overlay.getFloatingPositionerProps<HTMLDivElement>(props);
       return {
-        ...props,
+        ...floatingProps,
         ...partProps("positioner"),
-        "data-side": floating.side(),
-        "data-align": floating.align(),
-        style: floatingProps.style,
-        ref: (element: HTMLDivElement) => {
-          setPositionerElement(element);
-          assignRef(props.ref, element);
-          queueMicrotask(floating.update);
-        },
       };
     },
-    getTriggerProps: (props) => ({
-      ...props,
-      type: "button",
-      "aria-describedby": contentId(),
-      ...partProps("trigger"),
-      ref: (element: HTMLButtonElement) => {
-        setTriggerElement(element);
-        assignRef(props.ref, element);
-      },
-      onBlur: composeEventHandlers<FocusEvent>(props.onBlur, (event) => {
-        setOpen(false, { event, reason: "focus" });
-      }),
-      onFocus: composeEventHandlers<FocusEvent>(props.onFocus, (event) => {
-        setOpen(true, { event, reason: "focus" });
-      }),
-      onPointerEnter: composeEventHandlers<PointerEvent>(props.onPointerEnter, (event) => {
-        setOpen(true, { event, reason: "pointer" });
-      }),
-      onPointerLeave: composeEventHandlers<PointerEvent>(props.onPointerLeave, (event) => {
-        setOpen(false, { event, reason: "pointer" });
-      }),
-    }),
-    open,
+    getTriggerProps: (props) =>
+      overlay.getHoverFocusTriggerProps(props, {
+        focusReason: "focus",
+        pointerReason: "pointer",
+      }) as Record<string, unknown>,
+    open: overlay.open,
   };
 }
 
@@ -223,21 +180,19 @@ function PortalPart(props: TooltipPortalProps) {
 function Positioner(props: TooltipPositionerProps) {
   const tooltip = useTooltip("Positioner");
   const [local, others] = splitProps(props, ["children", "ref", "style"]);
-  return (
-    <div {...tooltip.getPositionerProps({ ...others, ref: local.ref, style: local.style })}>
-      {local.children}
-    </div>
-  );
+  const positionerProps = tooltip.getPositionerProps({
+    ...others,
+    ref: local.ref,
+    style: local.style,
+  });
+  return <div {...positionerProps}>{local.children}</div>;
 }
 
 function Content(props: TooltipContentProps) {
   const tooltip = useTooltip("Content");
   const [local, others] = splitProps(props, ["children", "ref", "style"]);
-  return (
-    <div {...tooltip.getContentProps({ ...others, ref: local.ref, style: local.style })}>
-      {local.children}
-    </div>
-  );
+  const contentProps = tooltip.getContentProps({ ...others, ref: local.ref, style: local.style });
+  return <div {...contentProps}>{local.children}</div>;
 }
 
 export const Tooltip = {

--- a/packages/keystone/src/utils/index.ts
+++ b/packages/keystone/src/utils/index.ts
@@ -307,6 +307,7 @@ export type ListInteractionKernelApi<T extends CollectionItem, Detail> = {
   selectValue: (value: string, detail: Detail) => T | undefined;
   selectedItem: Accessor<T | undefined>;
   setHighlightedValue: (value: string | undefined) => void;
+  typeahead: TypeaheadApi;
   value: Accessor<string | undefined>;
 };
 
@@ -452,6 +453,7 @@ export function createListInteractionKernel<T extends CollectionItem, Detail>(
     selectValue,
     selectedItem,
     setHighlightedValue,
+    typeahead,
     value,
   };
 }

--- a/packages/keystone/src/utils/kernel.test.tsx
+++ b/packages/keystone/src/utils/kernel.test.tsx
@@ -77,12 +77,12 @@ describe("Keystone kernel utilities", () => {
         new KeyboardEvent("keydown", { cancelable: true, key: "ArrowDown" }),
       );
       expect(select.open()).toBe(true);
-      expect(select.list.highlightedValue()).toBe("alpha");
+      expect(select.listbox.activeDescendant.highlightedValue()).toBe("alpha");
 
       (listbox.onKeyDown as (event: KeyboardEvent) => void)(
         new KeyboardEvent("keydown", { cancelable: true, key: "ArrowDown" }),
       );
-      expect(select.list.highlightedValue()).toBe("bravo");
+      expect(select.listbox.activeDescendant.highlightedValue()).toBe("bravo");
 
       (alpha.onClick as (event: MouseEvent) => void)(new MouseEvent("click", { cancelable: true }));
       expect(select.value()).toBe("alpha");

--- a/packages/keystone/test/overlay-vertical.behavior.test.tsx
+++ b/packages/keystone/test/overlay-vertical.behavior.test.tsx
@@ -115,8 +115,12 @@ describe("Popover, Tooltip, and Sheet overlay vertical", () => {
     await settled();
 
     const content = getByPart("sheet", "content");
+    const title = getByPart("sheet", "title");
+    const description = getByPart("sheet", "description");
     expect(content.getAttribute("role")).toBe("dialog");
     expect(content.getAttribute("aria-modal")).toBe("true");
+    expect(content.getAttribute("aria-labelledby")).toBe(title.id);
+    expect(content.getAttribute("aria-describedby")).toBe(description.id);
     expect(content.getAttribute("data-side")).toBe("left");
     expect(document.activeElement).toBe(document.querySelector("[data-testid='field']"));
     expect(document.body.style.pointerEvents).toBe("none");
@@ -127,5 +131,37 @@ describe("Popover, Tooltip, and Sheet overlay vertical", () => {
     expect(queryByPart("sheet", "content")).toBeNull();
     expect(document.activeElement).toBe(trigger);
     expect(document.body.style.pointerEvents).toBe("");
+  });
+
+  test("sheet inherits preventable modal content dismissal", async () => {
+    render(() => (
+      <>
+        <button data-testid="outside">Outside</button>
+        <Sheet.Root>
+          <Sheet.Trigger>Open sheet</Sheet.Trigger>
+          <Sheet.Portal>
+            <Sheet.Content
+              onEscapeKeyDown={(event) => event.preventDefault()}
+              onInteractOutside={(event) => event.preventDefault()}
+            >
+              <Sheet.Title>Filters</Sheet.Title>
+              <Sheet.Description>Choose visible filters.</Sheet.Description>
+            </Sheet.Content>
+          </Sheet.Portal>
+        </Sheet.Root>
+      </>
+    ));
+
+    click(getByPart("sheet", "trigger"));
+    await settled();
+
+    const content = getByPart("sheet", "content");
+    keyDown(content, "Escape");
+    await settled();
+    expect(queryByPart("sheet", "content")).not.toBeNull();
+
+    pointerDown(document.querySelector<HTMLElement>("[data-testid='outside']")!);
+    await settled();
+    expect(queryByPart("sheet", "content")).not.toBeNull();
   });
 });

--- a/packages/mason-cli/src/install/plan.ts
+++ b/packages/mason-cli/src/install/plan.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
@@ -17,13 +18,29 @@ export type FileWrite = {
   target: string;
   absoluteTarget: string;
   content: string;
+  contentHash: string;
+  existing: FileTargetState;
+  conflict: WritePlanConflict | null;
   mode: "create" | "overwrite" | "merge-json" | "append-css";
+};
+
+export type FileTargetState = {
+  exists: boolean;
+  hash: string | null;
+  size: number | null;
+};
+
+export type WritePlanConflict = {
+  kind: "duplicate-target" | "target-exists";
+  target: string;
+  message: string;
 };
 
 export type InstalledItemRecord = {
   name: string;
   version: string;
   files: string[];
+  fileHashes: Record<string, string>;
 };
 
 export type WritePlan = {
@@ -32,6 +49,7 @@ export type WritePlan = {
   dependencies: DependencyChange[];
   devDependencies: DependencyChange[];
   installedItems: InstalledItemRecord[];
+  conflicts: WritePlanConflict[];
 };
 
 async function readJson(file: string): Promise<unknown> {
@@ -99,6 +117,23 @@ async function contentForFile(
   return readFile(path.join(path.resolve(registry), file.path), "utf8");
 }
 
+function hashContent(content: string): string {
+  return `sha256:${createHash("sha256").update(content).digest("hex")}`;
+}
+
+async function readTargetState(absoluteTarget: string): Promise<FileTargetState> {
+  if (!existsSync(absoluteTarget)) {
+    return { exists: false, hash: null, size: null };
+  }
+
+  const content = await readFile(absoluteTarget, "utf8");
+  return {
+    exists: true,
+    hash: hashContent(content),
+    size: Buffer.byteLength(content),
+  };
+}
+
 function collectDependencyChanges(
   project: ProjectShape,
   items: RegistryItem[],
@@ -134,7 +169,7 @@ function installedItemNames(project: ProjectShape): Set<string> {
 
 export async function createWritePlan(
   project: ProjectShape,
-  options: { item: string; registry: string },
+  options: { allowConflicts?: boolean; item: string; registry: string },
 ): Promise<WritePlan> {
   const config = await readMasonConfig(project.cwd);
   const items = await resolveItems(options.registry, options.item);
@@ -147,24 +182,44 @@ export async function createWritePlan(
     for (const file of item.files) {
       const target = targetForFile(config, item, file);
       const absoluteTarget = resolveProjectTarget(project.cwd, target);
+      const content = await contentForFile(options.registry, file);
+      const existing = await readTargetState(absoluteTarget);
+      const mode = file.mode ?? "create";
+      const conflict =
+        mode !== "create" || !existing.exists
+          ? null
+          : {
+              kind: "target-exists" as const,
+              target,
+              message: `Refusing to overwrite existing file: ${target}`,
+            };
       files.push({
         item: item.name,
         source: file.path,
         target,
         absoluteTarget,
-        content: await contentForFile(options.registry, file),
-        mode: file.mode ?? "create",
+        content,
+        contentHash: hashContent(content),
+        existing,
+        conflict,
+        mode,
       });
     }
   }
   const seenTargets = new Set<string>();
+  const conflicts = files.flatMap((file) => (file.conflict ? [file.conflict] : []));
   for (const file of files) {
-    if (seenTargets.has(file.absoluteTarget))
-      throw new Error(`Multiple registry files target ${file.target}`);
-    seenTargets.add(file.absoluteTarget);
-    if (file.mode === "create" && existsSync(file.absoluteTarget)) {
-      throw new Error(`Refusing to overwrite existing file: ${file.target}`);
+    if (seenTargets.has(file.absoluteTarget)) {
+      conflicts.push({
+        kind: "duplicate-target",
+        target: file.target,
+        message: `Multiple registry files target ${file.target}`,
+      });
     }
+    seenTargets.add(file.absoluteTarget);
+  }
+  if (!options.allowConflicts && conflicts.length > 0) {
+    throw new Error(conflicts.map((conflict) => conflict.message).join("\n"));
   }
   return {
     items,
@@ -178,6 +233,13 @@ export async function createWritePlan(
         .filter((file) => file.item === item.name)
         .map((file) => file.target)
         .sort(),
+      fileHashes: Object.fromEntries(
+        files
+          .filter((file) => file.item === item.name)
+          .sort((a, b) => a.target.localeCompare(b.target))
+          .map((file) => [file.target, file.contentHash]),
+      ),
     })),
+    conflicts,
   };
 }

--- a/packages/mason-cli/src/install/write.ts
+++ b/packages/mason-cli/src/install/write.ts
@@ -41,6 +41,7 @@ export async function applyWritePlan(project: ProjectShape, plan: WritePlan): Pr
           {
             version: item.version,
             files: item.files,
+            fileHashes: item.fileHashes,
           },
         ]),
       ),

--- a/packages/mason-cli/test/mason-cli.test.ts
+++ b/packages/mason-cli/test/mason-cli.test.ts
@@ -1,4 +1,4 @@
-import { cp, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { cp, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, test } from "bun:test";
@@ -127,6 +127,39 @@ describe("add planning and writes", () => {
     );
   });
 
+  test("write planning records target state, hashes, and conflicts before apply", async () => {
+    const app = await fixtureApp();
+    await initCommand({ cwd: app, yes: true });
+    await mkdir(path.join(app, "src/components/ui"), { recursive: true });
+    await writeFile(path.join(app, "src/components/ui/button.tsx"), "user-owned\n");
+    const project = await detectProject(app);
+    const plan = await createWritePlan(project, {
+      item: "button",
+      registry,
+      allowConflicts: true,
+    });
+    const buttonFile = plan.files.find((file) => file.target === "src/components/ui/button.tsx");
+    expect(buttonFile).toBeDefined();
+    if (!buttonFile) throw new Error("Expected button file in write plan");
+    expect(buttonFile.conflict).toBeDefined();
+    if (!buttonFile.conflict) throw new Error("Expected button file conflict");
+
+    expect(buttonFile.contentHash).toMatch(/^sha256:/);
+    expect(buttonFile.existing).toMatchObject({
+      exists: true,
+      size: Buffer.byteLength("user-owned\n"),
+    });
+    expect(buttonFile.existing.hash).toMatch(/^sha256:/);
+    expect(buttonFile.conflict).toMatchObject({
+      kind: "target-exists",
+      target: "src/components/ui/button.tsx",
+    });
+    expect(plan.conflicts).toEqual([buttonFile.conflict]);
+    expect(plan.installedItems.find((item) => item.name === "button")?.fileHashes).toEqual({
+      "src/components/ui/button.tsx": buttonFile.contentHash,
+    });
+  });
+
   test("generated Solid app typechecks and builds after add", async () => {
     const app = await fixtureApp();
     await installFixtureAppDependencies(app);
@@ -194,6 +227,42 @@ describe("add planning and writes", () => {
     );
   });
 
+  test("real default registry block installs composed source and dependencies", async () => {
+    const app = await fixtureApp();
+    await installFixtureAppDependencies(app);
+    await initCommand({ cwd: app, yes: true });
+    const output = await addCommand({
+      cwd: app,
+      item: "account-settings",
+      registry: defaultRegistry,
+      dryRun: true,
+    });
+
+    expect(output).toBe(
+      [
+        "Mason dry run plan for account-settings:",
+        "create src/components/blocks/account-settings.tsx",
+        "create src/components/ui/badge.tsx",
+        "create src/components/ui/button.tsx",
+        "create src/components/ui/card.tsx",
+        "create src/components/ui/field.tsx",
+        "create src/components/ui/input.tsx",
+        "create src/components/ui/label.tsx",
+        "create src/components/ui/separator.tsx",
+        "create src/lib/cn.ts",
+      ].join("\n"),
+    );
+
+    await addCommand({ cwd: app, item: "account-settings", registry: defaultRegistry });
+
+    expect(
+      await readFile(path.join(app, "src/components/blocks/account-settings.tsx"), "utf8"),
+    ).toContain("export function AccountSettingsBlock");
+
+    await runAppScript(app, "check-types");
+    await runAppScript(app, "build");
+  });
+
   test("write application honors append-css, merge-json, and overwrite modes", async () => {
     const app = await fixtureApp();
     const project = await detectProject(app);
@@ -207,6 +276,7 @@ describe("add planning and writes", () => {
       dependencies: [],
       devDependencies: [],
       installedItems: [],
+      conflicts: [],
       files: [
         {
           item: "theme",
@@ -214,6 +284,9 @@ describe("add planning and writes", () => {
           target: "src/styles.css",
           absoluteTarget: path.join(app, "src/styles.css"),
           content: ".mason-button { color: red; }\n",
+          contentHash: "sha256:test-theme",
+          existing: { exists: true, hash: null, size: null },
+          conflict: null,
           mode: "append-css",
         },
         {
@@ -222,6 +295,9 @@ describe("add planning and writes", () => {
           target: "src/settings.json",
           absoluteTarget: path.join(app, "src/settings.json"),
           content: '{"theme":{"radius":"8px"},"enabled":true}',
+          contentHash: "sha256:test-settings",
+          existing: { exists: true, hash: null, size: null },
+          conflict: null,
           mode: "merge-json",
         },
         {
@@ -230,6 +306,9 @@ describe("add planning and writes", () => {
           target: "src/readme.md",
           absoluteTarget: path.join(app, "src/readme.md"),
           content: "installed\n",
+          contentHash: "sha256:test-readme",
+          existing: { exists: false, hash: null, size: null },
+          conflict: null,
           mode: "overwrite",
         },
       ],

--- a/packages/mason-registry/src/registry-validation.test.ts
+++ b/packages/mason-registry/src/registry-validation.test.ts
@@ -70,6 +70,7 @@ describe("Mason registry validation tracer", () => {
     }
 
     expect(validatedNames).toEqual([
+      "account-settings",
       "badge",
       "button",
       "card",
@@ -215,6 +216,26 @@ describe("Mason registry validation tracer", () => {
       expect(installResult.errors.map((error) => error.code)).toContain(
         "item.unsupportedForInstall",
       );
+    }
+  });
+
+  test("requires explicit targets for block source files", () => {
+    const result = validateItem({
+      ...button,
+      name: "account-settings",
+      type: "registry:block",
+      files: [
+        {
+          path: "blocks/account-settings.tsx",
+          type: "registry:block",
+        },
+      ],
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors.map((error) => error.code)).toContain("schema.invalid");
+      expect(result.errors.some((error) => error.path?.includes("target"))).toBe(true);
     }
   });
 

--- a/packages/mason-registry/src/schema.ts
+++ b/packages/mason-registry/src/schema.ts
@@ -16,6 +16,7 @@ export const registryItemTypes = [
 
 export const installSupportedItemTypes = [
   "registry:ui",
+  "registry:block",
   "registry:hook",
   "registry:lib",
   "registry:theme",
@@ -24,6 +25,7 @@ export const installSupportedItemTypes = [
 ] as const;
 
 export const targetRequiredFileTypes = [
+  "registry:block",
   "registry:page",
   "registry:config",
   "registry:rule",

--- a/registry/default/blocks/account-settings.tsx
+++ b/registry/default/blocks/account-settings.tsx
@@ -1,0 +1,80 @@
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Field, FieldDescription, FieldLabel } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import { Separator } from "@/components/ui/separator";
+
+export type AccountSettingsBlockProps = {
+  email?: string;
+  name?: string;
+  plan?: string;
+};
+
+export function AccountSettingsBlock(props: AccountSettingsBlockProps) {
+  const name = () => props.name ?? "Charlotte Mason";
+  const email = () => props.email ?? "charlotte@example.com";
+  const plan = () => props.plan ?? "Preview";
+
+  return (
+    <section
+      data-scope="mason-block"
+      data-part="account-settings"
+      class="mason-block-account-settings"
+    >
+      <Card>
+        <CardHeader>
+          <div class="mason-block-account-settings-heading">
+            <div>
+              <CardTitle>Account settings</CardTitle>
+              <CardDescription>Profile details used across your workspace.</CardDescription>
+            </div>
+            <Badge variant="muted">{plan()}</Badge>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <div class="mason-block-account-settings-grid">
+            <Field>
+              <FieldLabel for="account-settings-name">Name</FieldLabel>
+              <Input id="account-settings-name" value={name()} autocomplete="name" />
+              <FieldDescription>Shown on shared project activity.</FieldDescription>
+            </Field>
+            <Field>
+              <FieldLabel for="account-settings-email">Email</FieldLabel>
+              <Input
+                id="account-settings-email"
+                type="email"
+                value={email()}
+                autocomplete="email"
+              />
+              <FieldDescription>Used for invites and product updates.</FieldDescription>
+            </Field>
+          </div>
+          <Separator />
+          <div class="mason-block-account-settings-row">
+            <div>
+              <p class="mason-block-account-settings-label">Two-step verification</p>
+              <p class="mason-block-account-settings-copy">
+                Require a second factor for new devices.
+              </p>
+            </div>
+            <Badge variant="outline">Recommended</Badge>
+          </div>
+        </CardContent>
+        <CardFooter>
+          <Button type="button">Save changes</Button>
+          <Button type="button" variant="ghost">
+            Cancel
+          </Button>
+        </CardFooter>
+      </Card>
+    </section>
+  );
+}

--- a/registry/default/items/account-settings.json
+++ b/registry/default/items/account-settings.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://mason.build/schema/registry-item.json",
+  "name": "account-settings",
+  "type": "registry:block",
+  "title": "AccountSettingsBlock",
+  "description": "Account settings form block composed from Mason base components.",
+  "version": "0.1.0",
+  "compatibility": {
+    "mason": ">=0.1.0 <0.2.0",
+    "solid": ">=1.9.0 <2.0.0"
+  },
+  "categories": ["settings", "form", "block"],
+  "keywords": ["account-settings", "settings", "profile", "form", "block"],
+  "docs": "https://mason.build/docs/blocks/account-settings",
+  "registryDependencies": ["badge", "button", "card", "field", "input", "separator"],
+  "meta": {
+    "install": "mason add account-settings",
+    "customization": "Customize the generated block through mason-block-account-settings classes while base controls stay owned source.",
+    "sourceFiles": ["registry/default/blocks/account-settings.tsx"],
+    "dependencies": ["badge", "button", "card", "field", "input", "separator"]
+  },
+  "files": [
+    {
+      "path": "blocks/account-settings.tsx",
+      "type": "registry:block",
+      "target": "src/components/blocks/account-settings.tsx"
+    }
+  ]
+}

--- a/registry/default/registry.json
+++ b/registry/default/registry.json
@@ -4,6 +4,12 @@
   "homepage": "https://mason.build",
   "items": [
     {
+      "name": "account-settings",
+      "type": "registry:block",
+      "title": "AccountSettingsBlock",
+      "description": "Account settings form block composed from Mason base components."
+    },
+    {
       "name": "cn",
       "type": "registry:lib",
       "title": "Class Name Utility",


### PR DESCRIPTION
## Summary

Ship the next Keystone overlay and Mason registry/block verticals for the 0.1.0 preview.

## Core changes

- Add a shared Keystone overlay controller and refactor Dialog, Popover, Sheet, Tooltip, and Select overlay wiring around it.
- Deepen floating geometry behavior with side/align, CSS variable, transform-origin, arrow, and viewport tests.
- Add a reusable listbox interaction module with keyboard, active-descendant, typeahead, and selection contracts.
- Extend Mason install planning with file hashes, existing target state, installed item file hashes, and conflict records before writes.
- Add install support for registry blocks and the first `account-settings` block item/source.
- Update public and agent documentation for the current registry/block and task-selection state.

## Behavior / invariants

- User-owned target conflicts are represented in the write plan before apply and still fail closed unless conflicts are explicitly allowed.
- Mason block files require explicit targets and are install-supported registry item types.
- Keystone overlay parts continue to expose stable data attributes and top-layer metadata.

## Known limitations

- Mason still uses an explicit local registry path for this preview flow.
- Templates, themes, and a public registry remain deferred.

## Validation

- `bun run verify:release`
