### PR TITLE
[codex] Add Keystone primitives and Mason registry items

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ import { Popover } from "@keystone-ui/keystone/popover";
 import { Select } from "@keystone-ui/keystone/select";
 import { Sheet } from "@keystone-ui/keystone/sheet";
 import { Tooltip } from "@keystone-ui/keystone/tooltip";
+import { Toast, toaster } from "@keystone-ui/keystone/toast";
 import { createFormControl } from "@keystone-ui/keystone/form";
 ```
 
@@ -34,7 +35,7 @@ mason add button --registry <local-registry-path>
 mason add account-settings --registry <local-registry-path>
 ```
 
-The default local registry currently includes base components (`button`, `badge`, `card`, `field`, `input`, `label`, `separator`, `textarea`, `cn`), Keystone-backed overlays and menus (`dialog`, `popover`, `sheet`, `tooltip`, `menu`, `dropdown-menu`, `context-menu`, `menubar`), TanStack Form field examples (`text-field`, `select-field`), and the first block tracer (`account-settings`).
+The default local registry currently includes base components (`button`, `badge`, `card`, `field`, `input`, `label`, `separator`, `textarea`, `cn`), Keystone-backed overlays, menus, and feedback primitives (`dialog`, `popover`, `sheet`, `tooltip`, `menu`, `dropdown-menu`, `context-menu`, `menubar`, `toast`), TanStack Form field examples (`text-field`, `select-field`), and the first block tracer (`account-settings`).
 
 Mason install planning records target files, content hashes, existing target state, dependency changes, installed-item metadata, and conflicts before applying writes.
 

--- a/apps/docs/src/routeTree.gen.ts
+++ b/apps/docs/src/routeTree.gen.ts
@@ -8,171 +8,170 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from './routes/__root'
-import { Route as IndexRouteImport } from './routes/index'
-import { Route as DocsOverlayPopoverTooltipSheetRouteImport } from './routes/docs.overlay.popover-tooltip-sheet'
-import { Route as DocsMasonTextFieldRouteImport } from './routes/docs.mason.text-field'
-import { Route as DocsMasonSelectFieldRouteImport } from './routes/docs.mason.select-field'
-import { Route as DocsMasonDialogRouteImport } from './routes/docs.mason.dialog'
-import { Route as DocsMasonDataTableRouteImport } from './routes/docs.mason.data-table'
-import { Route as DocsKeystoneDialogRouteImport } from './routes/docs.keystone.dialog'
+import { Route as rootRouteImport } from "./routes/__root";
+import { Route as IndexRouteImport } from "./routes/index";
+import { Route as DocsOverlayPopoverTooltipSheetRouteImport } from "./routes/docs.overlay.popover-tooltip-sheet";
+import { Route as DocsMasonTextFieldRouteImport } from "./routes/docs.mason.text-field";
+import { Route as DocsMasonSelectFieldRouteImport } from "./routes/docs.mason.select-field";
+import { Route as DocsMasonDialogRouteImport } from "./routes/docs.mason.dialog";
+import { Route as DocsMasonDataTableRouteImport } from "./routes/docs.mason.data-table";
+import { Route as DocsKeystoneDialogRouteImport } from "./routes/docs.keystone.dialog";
 
 const IndexRoute = IndexRouteImport.update({
-  id: '/',
-  path: '/',
+  id: "/",
+  path: "/",
   getParentRoute: () => rootRouteImport,
-} as any)
-const DocsOverlayPopoverTooltipSheetRoute =
-  DocsOverlayPopoverTooltipSheetRouteImport.update({
-    id: '/docs/overlay/popover-tooltip-sheet',
-    path: '/docs/overlay/popover-tooltip-sheet',
-    getParentRoute: () => rootRouteImport,
-  } as any)
+} as any);
+const DocsOverlayPopoverTooltipSheetRoute = DocsOverlayPopoverTooltipSheetRouteImport.update({
+  id: "/docs/overlay/popover-tooltip-sheet",
+  path: "/docs/overlay/popover-tooltip-sheet",
+  getParentRoute: () => rootRouteImport,
+} as any);
 const DocsMasonTextFieldRoute = DocsMasonTextFieldRouteImport.update({
-  id: '/docs/mason/text-field',
-  path: '/docs/mason/text-field',
+  id: "/docs/mason/text-field",
+  path: "/docs/mason/text-field",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const DocsMasonSelectFieldRoute = DocsMasonSelectFieldRouteImport.update({
-  id: '/docs/mason/select-field',
-  path: '/docs/mason/select-field',
+  id: "/docs/mason/select-field",
+  path: "/docs/mason/select-field",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const DocsMasonDialogRoute = DocsMasonDialogRouteImport.update({
-  id: '/docs/mason/dialog',
-  path: '/docs/mason/dialog',
+  id: "/docs/mason/dialog",
+  path: "/docs/mason/dialog",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const DocsMasonDataTableRoute = DocsMasonDataTableRouteImport.update({
-  id: '/docs/mason/data-table',
-  path: '/docs/mason/data-table',
+  id: "/docs/mason/data-table",
+  path: "/docs/mason/data-table",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const DocsKeystoneDialogRoute = DocsKeystoneDialogRouteImport.update({
-  id: '/docs/keystone/dialog',
-  path: '/docs/keystone/dialog',
+  id: "/docs/keystone/dialog",
+  path: "/docs/keystone/dialog",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 
 export interface FileRoutesByFullPath {
-  '/': typeof IndexRoute
-  '/docs/keystone/dialog': typeof DocsKeystoneDialogRoute
-  '/docs/mason/data-table': typeof DocsMasonDataTableRoute
-  '/docs/mason/dialog': typeof DocsMasonDialogRoute
-  '/docs/mason/select-field': typeof DocsMasonSelectFieldRoute
-  '/docs/mason/text-field': typeof DocsMasonTextFieldRoute
-  '/docs/overlay/popover-tooltip-sheet': typeof DocsOverlayPopoverTooltipSheetRoute
+  "/": typeof IndexRoute;
+  "/docs/keystone/dialog": typeof DocsKeystoneDialogRoute;
+  "/docs/mason/data-table": typeof DocsMasonDataTableRoute;
+  "/docs/mason/dialog": typeof DocsMasonDialogRoute;
+  "/docs/mason/select-field": typeof DocsMasonSelectFieldRoute;
+  "/docs/mason/text-field": typeof DocsMasonTextFieldRoute;
+  "/docs/overlay/popover-tooltip-sheet": typeof DocsOverlayPopoverTooltipSheetRoute;
 }
 export interface FileRoutesByTo {
-  '/': typeof IndexRoute
-  '/docs/keystone/dialog': typeof DocsKeystoneDialogRoute
-  '/docs/mason/data-table': typeof DocsMasonDataTableRoute
-  '/docs/mason/dialog': typeof DocsMasonDialogRoute
-  '/docs/mason/select-field': typeof DocsMasonSelectFieldRoute
-  '/docs/mason/text-field': typeof DocsMasonTextFieldRoute
-  '/docs/overlay/popover-tooltip-sheet': typeof DocsOverlayPopoverTooltipSheetRoute
+  "/": typeof IndexRoute;
+  "/docs/keystone/dialog": typeof DocsKeystoneDialogRoute;
+  "/docs/mason/data-table": typeof DocsMasonDataTableRoute;
+  "/docs/mason/dialog": typeof DocsMasonDialogRoute;
+  "/docs/mason/select-field": typeof DocsMasonSelectFieldRoute;
+  "/docs/mason/text-field": typeof DocsMasonTextFieldRoute;
+  "/docs/overlay/popover-tooltip-sheet": typeof DocsOverlayPopoverTooltipSheetRoute;
 }
 export interface FileRoutesById {
-  __root__: typeof rootRouteImport
-  '/': typeof IndexRoute
-  '/docs/keystone/dialog': typeof DocsKeystoneDialogRoute
-  '/docs/mason/data-table': typeof DocsMasonDataTableRoute
-  '/docs/mason/dialog': typeof DocsMasonDialogRoute
-  '/docs/mason/select-field': typeof DocsMasonSelectFieldRoute
-  '/docs/mason/text-field': typeof DocsMasonTextFieldRoute
-  '/docs/overlay/popover-tooltip-sheet': typeof DocsOverlayPopoverTooltipSheetRoute
+  __root__: typeof rootRouteImport;
+  "/": typeof IndexRoute;
+  "/docs/keystone/dialog": typeof DocsKeystoneDialogRoute;
+  "/docs/mason/data-table": typeof DocsMasonDataTableRoute;
+  "/docs/mason/dialog": typeof DocsMasonDialogRoute;
+  "/docs/mason/select-field": typeof DocsMasonSelectFieldRoute;
+  "/docs/mason/text-field": typeof DocsMasonTextFieldRoute;
+  "/docs/overlay/popover-tooltip-sheet": typeof DocsOverlayPopoverTooltipSheetRoute;
 }
 export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath
+  fileRoutesByFullPath: FileRoutesByFullPath;
   fullPaths:
-    | '/'
-    | '/docs/keystone/dialog'
-    | '/docs/mason/data-table'
-    | '/docs/mason/dialog'
-    | '/docs/mason/select-field'
-    | '/docs/mason/text-field'
-    | '/docs/overlay/popover-tooltip-sheet'
-  fileRoutesByTo: FileRoutesByTo
+    | "/"
+    | "/docs/keystone/dialog"
+    | "/docs/mason/data-table"
+    | "/docs/mason/dialog"
+    | "/docs/mason/select-field"
+    | "/docs/mason/text-field"
+    | "/docs/overlay/popover-tooltip-sheet";
+  fileRoutesByTo: FileRoutesByTo;
   to:
-    | '/'
-    | '/docs/keystone/dialog'
-    | '/docs/mason/data-table'
-    | '/docs/mason/dialog'
-    | '/docs/mason/select-field'
-    | '/docs/mason/text-field'
-    | '/docs/overlay/popover-tooltip-sheet'
+    | "/"
+    | "/docs/keystone/dialog"
+    | "/docs/mason/data-table"
+    | "/docs/mason/dialog"
+    | "/docs/mason/select-field"
+    | "/docs/mason/text-field"
+    | "/docs/overlay/popover-tooltip-sheet";
   id:
-    | '__root__'
-    | '/'
-    | '/docs/keystone/dialog'
-    | '/docs/mason/data-table'
-    | '/docs/mason/dialog'
-    | '/docs/mason/select-field'
-    | '/docs/mason/text-field'
-    | '/docs/overlay/popover-tooltip-sheet'
-  fileRoutesById: FileRoutesById
+    | "__root__"
+    | "/"
+    | "/docs/keystone/dialog"
+    | "/docs/mason/data-table"
+    | "/docs/mason/dialog"
+    | "/docs/mason/select-field"
+    | "/docs/mason/text-field"
+    | "/docs/overlay/popover-tooltip-sheet";
+  fileRoutesById: FileRoutesById;
 }
 export interface RootRouteChildren {
-  IndexRoute: typeof IndexRoute
-  DocsKeystoneDialogRoute: typeof DocsKeystoneDialogRoute
-  DocsMasonDataTableRoute: typeof DocsMasonDataTableRoute
-  DocsMasonDialogRoute: typeof DocsMasonDialogRoute
-  DocsMasonSelectFieldRoute: typeof DocsMasonSelectFieldRoute
-  DocsMasonTextFieldRoute: typeof DocsMasonTextFieldRoute
-  DocsOverlayPopoverTooltipSheetRoute: typeof DocsOverlayPopoverTooltipSheetRoute
+  IndexRoute: typeof IndexRoute;
+  DocsKeystoneDialogRoute: typeof DocsKeystoneDialogRoute;
+  DocsMasonDataTableRoute: typeof DocsMasonDataTableRoute;
+  DocsMasonDialogRoute: typeof DocsMasonDialogRoute;
+  DocsMasonSelectFieldRoute: typeof DocsMasonSelectFieldRoute;
+  DocsMasonTextFieldRoute: typeof DocsMasonTextFieldRoute;
+  DocsOverlayPopoverTooltipSheetRoute: typeof DocsOverlayPopoverTooltipSheetRoute;
 }
 
-declare module '@tanstack/solid-router' {
+declare module "@tanstack/solid-router" {
   interface FileRoutesByPath {
-    '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof IndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/docs/overlay/popover-tooltip-sheet': {
-      id: '/docs/overlay/popover-tooltip-sheet'
-      path: '/docs/overlay/popover-tooltip-sheet'
-      fullPath: '/docs/overlay/popover-tooltip-sheet'
-      preLoaderRoute: typeof DocsOverlayPopoverTooltipSheetRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/docs/mason/text-field': {
-      id: '/docs/mason/text-field'
-      path: '/docs/mason/text-field'
-      fullPath: '/docs/mason/text-field'
-      preLoaderRoute: typeof DocsMasonTextFieldRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/docs/mason/select-field': {
-      id: '/docs/mason/select-field'
-      path: '/docs/mason/select-field'
-      fullPath: '/docs/mason/select-field'
-      preLoaderRoute: typeof DocsMasonSelectFieldRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/docs/mason/dialog': {
-      id: '/docs/mason/dialog'
-      path: '/docs/mason/dialog'
-      fullPath: '/docs/mason/dialog'
-      preLoaderRoute: typeof DocsMasonDialogRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/docs/mason/data-table': {
-      id: '/docs/mason/data-table'
-      path: '/docs/mason/data-table'
-      fullPath: '/docs/mason/data-table'
-      preLoaderRoute: typeof DocsMasonDataTableRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/docs/keystone/dialog': {
-      id: '/docs/keystone/dialog'
-      path: '/docs/keystone/dialog'
-      fullPath: '/docs/keystone/dialog'
-      preLoaderRoute: typeof DocsKeystoneDialogRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+    "/": {
+      id: "/";
+      path: "/";
+      fullPath: "/";
+      preLoaderRoute: typeof IndexRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/docs/overlay/popover-tooltip-sheet": {
+      id: "/docs/overlay/popover-tooltip-sheet";
+      path: "/docs/overlay/popover-tooltip-sheet";
+      fullPath: "/docs/overlay/popover-tooltip-sheet";
+      preLoaderRoute: typeof DocsOverlayPopoverTooltipSheetRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/docs/mason/text-field": {
+      id: "/docs/mason/text-field";
+      path: "/docs/mason/text-field";
+      fullPath: "/docs/mason/text-field";
+      preLoaderRoute: typeof DocsMasonTextFieldRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/docs/mason/select-field": {
+      id: "/docs/mason/select-field";
+      path: "/docs/mason/select-field";
+      fullPath: "/docs/mason/select-field";
+      preLoaderRoute: typeof DocsMasonSelectFieldRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/docs/mason/dialog": {
+      id: "/docs/mason/dialog";
+      path: "/docs/mason/dialog";
+      fullPath: "/docs/mason/dialog";
+      preLoaderRoute: typeof DocsMasonDialogRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/docs/mason/data-table": {
+      id: "/docs/mason/data-table";
+      path: "/docs/mason/data-table";
+      fullPath: "/docs/mason/data-table";
+      preLoaderRoute: typeof DocsMasonDataTableRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/docs/keystone/dialog": {
+      id: "/docs/keystone/dialog";
+      path: "/docs/keystone/dialog";
+      fullPath: "/docs/keystone/dialog";
+      preLoaderRoute: typeof DocsKeystoneDialogRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
   }
 }
 
@@ -184,16 +183,16 @@ const rootRouteChildren: RootRouteChildren = {
   DocsMasonSelectFieldRoute: DocsMasonSelectFieldRoute,
   DocsMasonTextFieldRoute: DocsMasonTextFieldRoute,
   DocsOverlayPopoverTooltipSheetRoute: DocsOverlayPopoverTooltipSheetRoute,
-}
+};
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
-  ._addFileTypes<FileRouteTypes>()
+  ._addFileTypes<FileRouteTypes>();
 
-import type { getRouter } from './router.tsx'
-import type { createStart } from '@tanstack/solid-start'
-declare module '@tanstack/solid-start' {
+import type { getRouter } from "./router.tsx";
+import type { createStart } from "@tanstack/solid-start";
+declare module "@tanstack/solid-start" {
   interface Register {
-    ssr: true
-    router: Awaited<ReturnType<typeof getRouter>>
+    ssr: true;
+    router: Awaited<ReturnType<typeof getRouter>>;
   }
 }

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -14,6 +14,7 @@ Start with:
 - [Mason Registry RFC](../rfcs/mason-registry.md)
 - [End-state primitive/component inventory](./end-state-primitive-component-inventory.md)
 - [Keystone internal kernel guidance](./keystone-internal-kernel-guidance.md)
+- [Accordion and Collapsible vertical](./accordion-collapsible-vertical.md)
 
 The current strategic PRD is stored in `.context/attachments/pasted_text_2026-05-03_14-26-48.txt`.
 

--- a/docs/agents/accordion-collapsible-vertical.md
+++ b/docs/agents/accordion-collapsible-vertical.md
@@ -1,0 +1,37 @@
+# Accordion And Collapsible Vertical
+
+## Scope
+
+This vertical establishes the delivery standard for disclosure primitives:
+
+- Compare Keystone and Mason against Kobalte and Base UI.
+- Ship the thin Keystone primitive over a shared disclosure controller.
+- Add Mason copy-paste wrappers and registry metadata.
+- Add behavior tests for the core accessibility and state contract.
+- Record parity gaps before deepening.
+
+## Current Keystone Contract
+
+Collapsible:
+
+- `Collapsible.Root` supports `open`, `defaultOpen`, `disabled`, and `onOpenChange`.
+- `Collapsible.Trigger` exposes `aria-expanded`, `aria-controls`, `data-scope`, `data-part`, `data-state`, and `data-disabled`.
+- `Collapsible.Content` owns the controlled content id and exposes `data-state`.
+- User click handlers run first; internal toggle behavior skips when the event is default-prevented.
+
+Accordion:
+
+- `Accordion.Root` supports controlled and uncontrolled `value`, `defaultValue`, `multiple`, `disabled`, `orientation`, and `loopFocus`.
+- `Accordion.Item` coordinates item value state over the shared disclosure controller.
+- `Accordion.Trigger` exposes trigger/content ARIA relationships and roves focus with vertical arrow keys, Home, and End.
+- `Accordion.Content` renders a region labelled by the trigger.
+
+## Mason Surface
+
+- `registry/default/ui/collapsible.tsx` wraps Keystone Collapsible with `mason-collapsible-*` styling hooks.
+- `registry/default/ui/accordion.tsx` wraps Keystone Accordion with `mason-accordion-*` styling hooks and app-owned content markup.
+- Registry metadata records dependencies, parts, install command, source files, customization notes, and parity gaps.
+
+## Parity Notes
+
+Kobalte and Base UI both go deeper than this first vertical in transition and browser edge behavior. The next parity pass should add measured panel CSS variables, hidden-until-found or equivalent browser-find handling, transition lifecycle data attributes, RTL-aware horizontal keyboard behavior, disabled-but-focusable trigger policy decisions, and broader edge-case tests.

--- a/packages/keystone/package.json
+++ b/packages/keystone/package.json
@@ -5,16 +5,22 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
+    "./accordion": "./src/accordion/index.tsx",
+    "./autocomplete": "./src/autocomplete/index.ts",
+    "./combobox": "./src/combobox/index.tsx",
     "./context-menu": "./src/context-menu/index.ts",
+    "./collapsible": "./src/collapsible/index.tsx",
     "./dialog": "./src/dialog/index.tsx",
     "./dropdown-menu": "./src/dropdown-menu/index.ts",
     "./form": "./src/form/index.tsx",
+    "./hover-card": "./src/hover-card/index.tsx",
     "./menu": "./src/menu/index.tsx",
     "./menubar": "./src/menubar/index.ts",
     "./popover": "./src/popover/index.tsx",
     "./sheet": "./src/sheet/index.tsx",
     "./tooltip": "./src/tooltip/index.tsx",
-    "./select": "./src/select/index.tsx"
+    "./select": "./src/select/index.tsx",
+    "./toast": "./src/toast/index.tsx"
   },
   "scripts": {
     "check-types": "tsc --noEmit",

--- a/packages/keystone/src/accordion/index.tsx
+++ b/packages/keystone/src/accordion/index.tsx
@@ -1,0 +1,370 @@
+import {
+  Show,
+  createContext,
+  createMemo,
+  createUniqueId,
+  onCleanup,
+  splitProps,
+  useContext,
+  type Accessor,
+  type JSX,
+} from "solid-js";
+import { createDisclosureController, type DisclosureChangeDetail } from "../disclosure/controller";
+import {
+  createControllableSignal,
+  callEventHandler,
+  dataBoolean,
+  partDataAttributes,
+  renderPolymorphic,
+  type PolymorphicProps,
+} from "../utils/index";
+
+export type AccordionValue = string[];
+export type AccordionOrientation = "horizontal" | "vertical";
+export type AccordionValueChangeDetail = DisclosureChangeDetail<"trigger" | "programmatic">;
+
+export type AccordionRootProps = AccordionPartProps<HTMLDivElement> &
+  Omit<JSX.HTMLAttributes<HTMLDivElement>, "children" | "ref"> & {
+    children?: JSX.Element;
+    defaultValue?: AccordionValue;
+    disabled?: boolean;
+    loopFocus?: boolean;
+    multiple?: boolean;
+    onValueChange?: (value: AccordionValue, detail: AccordionValueChangeDetail) => void;
+    orientation?: AccordionOrientation;
+    value?: AccordionValue;
+  };
+
+export type AccordionPartProps<T extends HTMLElement = HTMLElement> = {
+  children?: JSX.Element;
+  class?: string;
+  id?: string;
+  ref?: T | ((element: T) => void);
+  style?: JSX.CSSProperties | string;
+};
+
+export type AccordionItemProps = AccordionPartProps<HTMLDivElement> &
+  Omit<JSX.HTMLAttributes<HTMLDivElement>, "children" | "ref"> & {
+    disabled?: boolean;
+    value: string;
+  };
+export type AccordionHeaderProps = AccordionPartProps<HTMLHeadingElement> &
+  Omit<JSX.HTMLAttributes<HTMLHeadingElement>, "children" | "ref">;
+export type AccordionTriggerProps = AccordionPartProps<HTMLButtonElement> &
+  PolymorphicProps<HTMLButtonElement> &
+  Omit<JSX.ButtonHTMLAttributes<HTMLButtonElement>, "children" | "ref">;
+export type AccordionContentProps = AccordionPartProps<HTMLDivElement> &
+  Omit<JSX.HTMLAttributes<HTMLDivElement>, "children" | "ref"> & {
+    forceMount?: boolean;
+  };
+
+type TriggerRecord = {
+  disabled: Accessor<boolean>;
+  element: HTMLButtonElement;
+};
+
+type AccordionApi = {
+  disabled: () => boolean;
+  loopFocus: () => boolean;
+  multiple: () => boolean;
+  openValue: (value: string) => boolean;
+  orientation: () => AccordionOrientation;
+  registerTrigger: (element: HTMLButtonElement, disabled: Accessor<boolean>) => () => void;
+  setItemOpen: (value: string, open: boolean, detail: AccordionValueChangeDetail) => AccordionValue;
+  triggers: () => TriggerRecord[];
+  value: () => AccordionValue;
+};
+
+type AccordionItemApi = {
+  contentId: string;
+  disabled: () => boolean;
+  getContentProps: (
+    props: Omit<AccordionContentProps, "children" | "forceMount">,
+  ) => Record<string, unknown>;
+  getTriggerProps: (
+    props: Omit<AccordionTriggerProps, "as" | "children">,
+  ) => Record<string, unknown>;
+  headerId: string;
+  open: () => boolean;
+  setTriggerElement: (element: HTMLButtonElement) => void;
+  triggerId: string;
+  value: string;
+};
+
+const AccordionContext = createContext<AccordionApi>();
+const AccordionItemContext = createContext<AccordionItemApi>();
+
+export function createAccordion(
+  options: {
+    defaultValue?: AccordionValue;
+    disabled?: () => boolean | undefined;
+    loopFocus?: () => boolean | undefined;
+    multiple?: () => boolean | undefined;
+    onValueChange?: (value: AccordionValue, detail: AccordionValueChangeDetail) => void;
+    orientation?: () => AccordionOrientation | undefined;
+    value?: () => AccordionValue | undefined;
+  } = {},
+): AccordionApi {
+  let pendingDetail: AccordionValueChangeDetail | undefined;
+  const [value, setValueState] = createControllableSignal<AccordionValue>({
+    value: options.value,
+    defaultValue: options.defaultValue ?? [],
+    onChange: (nextValue) => {
+      options.onValueChange?.(nextValue, pendingDetail ?? { reason: "programmatic" });
+      pendingDetail = undefined;
+    },
+  });
+  const disabled = createMemo(() => options.disabled?.() ?? false);
+  const loopFocus = createMemo(() => options.loopFocus?.() ?? true);
+  const multiple = createMemo(() => options.multiple?.() ?? false);
+  const orientation = createMemo(() => options.orientation?.() ?? "vertical");
+  const triggerRecords: TriggerRecord[] = [];
+
+  return {
+    disabled,
+    loopFocus,
+    multiple,
+    openValue: (itemValue) => value().includes(itemValue),
+    orientation,
+    registerTrigger: (element, triggerDisabled) => {
+      const record = { disabled: triggerDisabled, element };
+      triggerRecords.push(record);
+
+      return () => {
+        const index = triggerRecords.indexOf(record);
+        if (index >= 0) triggerRecords.splice(index, 1);
+      };
+    },
+    setItemOpen: (itemValue, open, detail) => {
+      pendingDetail = detail;
+      const nextValue = setValueState((currentValue) => {
+        if (multiple()) {
+          if (open)
+            return currentValue.includes(itemValue) ? currentValue : [...currentValue, itemValue];
+          return currentValue.filter((candidate) => candidate !== itemValue);
+        }
+
+        if (open) return [itemValue];
+        return currentValue.includes(itemValue) ? [] : currentValue;
+      });
+      pendingDetail = undefined;
+      return nextValue;
+    },
+    triggers: () => triggerRecords,
+    value,
+  };
+}
+
+function useAccordion(part: string) {
+  const accordion = useContext(AccordionContext);
+  if (!accordion) throw new Error(`Accordion.${part} must be used within Accordion.Root`);
+  return accordion;
+}
+
+function useAccordionItem(part: string) {
+  const item = useContext(AccordionItemContext);
+  if (!item) throw new Error(`Accordion.${part} must be used within Accordion.Item`);
+  return item;
+}
+
+function Root(props: AccordionRootProps) {
+  const [local, others] = splitProps(props, [
+    "children",
+    "defaultValue",
+    "disabled",
+    "loopFocus",
+    "multiple",
+    "onValueChange",
+    "orientation",
+    "value",
+  ]);
+  const accordion = createAccordion({
+    defaultValue: local.defaultValue,
+    disabled: () => local.disabled,
+    loopFocus: () => local.loopFocus,
+    multiple: () => local.multiple,
+    onValueChange: local.onValueChange,
+    orientation: () => local.orientation,
+    value: () => local.value,
+  });
+
+  return (
+    <AccordionContext.Provider value={accordion}>
+      <div
+        {...others}
+        data-disabled={dataBoolean(accordion.disabled())}
+        data-orientation={accordion.orientation()}
+        {...partDataAttributes("accordion", "root")}
+      >
+        {local.children}
+      </div>
+    </AccordionContext.Provider>
+  );
+}
+
+function Item(props: AccordionItemProps) {
+  const accordion = useAccordion("Item");
+  const [local, others] = splitProps(props, ["children", "disabled", "value"]);
+  const itemDisabled = createMemo(() => accordion.disabled() || (local.disabled ?? false));
+  const open = createMemo(() => accordion.openValue(local.value));
+  const contentId = `keystone-accordion-content-${createUniqueId()}`;
+  const triggerId = `keystone-accordion-trigger-${createUniqueId()}`;
+  const headerId = `keystone-accordion-header-${createUniqueId()}`;
+  let unregisterTrigger: (() => void) | undefined;
+
+  const disclosure = createDisclosureController({
+    scope: "accordion",
+    contentId: () => contentId,
+    disabled: itemDisabled,
+    open,
+    onOpenChange: (nextOpen, detail) => accordion.setItemOpen(local.value, nextOpen, detail),
+  });
+
+  const itemApi: AccordionItemApi = {
+    contentId,
+    disabled: itemDisabled,
+    getContentProps: (contentProps) => {
+      const props = disclosure.getContentProps(contentProps);
+      Object.defineProperties(props, {
+        "aria-labelledby": { configurable: true, enumerable: true, value: triggerId },
+        role: { configurable: true, enumerable: true, value: "region" },
+        "data-orientation": {
+          configurable: true,
+          enumerable: true,
+          get: () => accordion.orientation(),
+        },
+      });
+      return props;
+    },
+    getTriggerProps: (triggerProps) => {
+      const props = disclosure.getTriggerProps(triggerProps);
+      Object.defineProperties(props, {
+        id: { configurable: true, enumerable: true, value: triggerId },
+        "data-orientation": {
+          configurable: true,
+          enumerable: true,
+          get: () => accordion.orientation(),
+        },
+      });
+      return props;
+    },
+    headerId,
+    open,
+    setTriggerElement: (element) => {
+      unregisterTrigger?.();
+      unregisterTrigger = accordion.registerTrigger(element, itemDisabled);
+    },
+    triggerId,
+    value: local.value,
+  };
+
+  onCleanup(() => unregisterTrigger?.());
+
+  return (
+    <AccordionItemContext.Provider value={itemApi}>
+      <div
+        {...others}
+        data-disabled={dataBoolean(itemDisabled())}
+        data-orientation={accordion.orientation()}
+        data-state={open() ? "open" : "closed"}
+        {...partDataAttributes("accordion", "item")}
+      >
+        {local.children}
+      </div>
+    </AccordionItemContext.Provider>
+  );
+}
+
+function Header(props: AccordionHeaderProps) {
+  const item = useAccordionItem("Header");
+  const [local, others] = splitProps(props, ["children"]);
+
+  return (
+    <h3
+      {...others}
+      id={item.headerId}
+      data-disabled={dataBoolean(item.disabled())}
+      data-state={item.open() ? "open" : "closed"}
+      {...partDataAttributes("accordion", "header")}
+    >
+      {local.children}
+    </h3>
+  );
+}
+
+function Trigger(props: AccordionTriggerProps) {
+  const accordion = useAccordion("Trigger");
+  const item = useAccordionItem("Trigger");
+  const [local, others] = splitProps(props, ["as", "children", "onKeyDown", "ref"]);
+  const triggerProps = item.getTriggerProps({
+    ...others,
+    onKeyDown: (event) => {
+      callEventHandler(local.onKeyDown, event);
+      if (!event.defaultPrevented) moveFocus(event, accordion);
+    },
+    ref: (element) => {
+      if (typeof local.ref === "function") local.ref(element);
+      item.setTriggerElement(element);
+    },
+  });
+
+  if (!local.as) return <button {...triggerProps}>{local.children}</button>;
+
+  return renderPolymorphic(local.as, "button", {
+    ...triggerProps,
+    children: local.children,
+  });
+}
+
+function Content(props: AccordionContentProps) {
+  const item = useAccordionItem("Content");
+  const [local, others] = splitProps(props, ["children", "forceMount"]);
+  const contentProps = item.getContentProps(others);
+
+  return (
+    <Show when={local.forceMount || item.open()}>
+      <div {...contentProps}>{local.children}</div>
+    </Show>
+  );
+}
+
+function moveFocus(event: KeyboardEvent, accordion: AccordionApi) {
+  const keys = ["ArrowDown", "ArrowUp", "ArrowRight", "ArrowLeft", "Home", "End"];
+  if (!keys.includes(event.key)) return;
+
+  const horizontal = accordion.orientation() === "horizontal";
+  const nextKey = horizontal ? "ArrowRight" : "ArrowDown";
+  const previousKey = horizontal ? "ArrowLeft" : "ArrowUp";
+
+  if (![nextKey, previousKey, "Home", "End"].includes(event.key)) return;
+
+  const triggers = accordion
+    .triggers()
+    .filter((record) => !record.disabled())
+    .map((record) => record.element);
+  const currentIndex = triggers.indexOf(event.currentTarget as HTMLButtonElement);
+  if (currentIndex < 0) return;
+
+  event.preventDefault();
+
+  const lastIndex = triggers.length - 1;
+  let nextIndex = currentIndex;
+
+  if (event.key === "Home") nextIndex = 0;
+  else if (event.key === "End") nextIndex = lastIndex;
+  else if (event.key === nextKey) nextIndex = currentIndex + 1;
+  else if (event.key === previousKey) nextIndex = currentIndex - 1;
+
+  if (nextIndex > lastIndex) nextIndex = accordion.loopFocus() ? 0 : lastIndex;
+  if (nextIndex < 0) nextIndex = accordion.loopFocus() ? lastIndex : 0;
+
+  triggers[nextIndex]?.focus();
+}
+
+export const Accordion = {
+  Root,
+  Item,
+  Header,
+  Trigger,
+  Content,
+};

--- a/packages/keystone/src/autocomplete/index.ts
+++ b/packages/keystone/src/autocomplete/index.ts
@@ -1,0 +1,22 @@
+export { Autocomplete, createAutocomplete } from "../combobox/index";
+export type {
+  ComboboxApi as AutocompleteApi,
+  ComboboxChangeDetail as AutocompleteChangeDetail,
+  ComboboxClearProps as AutocompleteClearProps,
+  ComboboxContentProps as AutocompleteContentProps,
+  ComboboxGroupLabelProps as AutocompleteGroupLabelProps,
+  ComboboxGroupProps as AutocompleteGroupProps,
+  ComboboxInputProps as AutocompleteInputProps,
+  ComboboxItemData as AutocompleteItemData,
+  ComboboxItemIndicatorProps as AutocompleteItemIndicatorProps,
+  ComboboxItemProps as AutocompleteItemProps,
+  ComboboxItemTextProps as AutocompleteItemTextProps,
+  ComboboxListboxProps as AutocompleteListboxProps,
+  ComboboxOpenChangeDetail as AutocompleteOpenChangeDetail,
+  ComboboxPartProps as AutocompletePartProps,
+  ComboboxPortalProps as AutocompletePortalProps,
+  ComboboxPositionerProps as AutocompletePositionerProps,
+  ComboboxRootProps as AutocompleteRootProps,
+  ComboboxTriggerProps as AutocompleteTriggerProps,
+  CreateComboboxOptions as CreateAutocompleteOptions,
+} from "../combobox/index";

--- a/packages/keystone/src/collapsible/index.tsx
+++ b/packages/keystone/src/collapsible/index.tsx
@@ -1,0 +1,122 @@
+import { Show, createContext, splitProps, useContext, type JSX } from "solid-js";
+import { createDisclosureController, type DisclosureChangeDetail } from "../disclosure/controller";
+import { renderPolymorphic, type PolymorphicProps } from "../utils/index";
+
+export type CollapsibleOpenChangeDetail = DisclosureChangeDetail<"trigger" | "programmatic">;
+
+export type CollapsibleRootProps = {
+  children?: JSX.Element;
+  defaultOpen?: boolean;
+  disabled?: boolean;
+  onOpenChange?: (open: boolean, detail: CollapsibleOpenChangeDetail) => void;
+  open?: boolean;
+};
+
+export type CollapsiblePartProps<T extends HTMLElement = HTMLElement> = {
+  children?: JSX.Element;
+  class?: string;
+  id?: string;
+  ref?: T | ((element: T) => void);
+  style?: JSX.CSSProperties | string;
+};
+
+export type CollapsibleTriggerProps = CollapsiblePartProps<HTMLButtonElement> &
+  PolymorphicProps<HTMLButtonElement> &
+  Omit<JSX.ButtonHTMLAttributes<HTMLButtonElement>, "children" | "ref">;
+
+export type CollapsibleContentProps = CollapsiblePartProps<HTMLDivElement> &
+  Omit<JSX.HTMLAttributes<HTMLDivElement>, "children" | "ref"> & {
+    forceMount?: boolean;
+  };
+
+export type CollapsibleTriggerContractProps = Omit<CollapsibleTriggerProps, "as" | "children">;
+export type CollapsibleContentContractProps = Omit<
+  CollapsibleContentProps,
+  "children" | "forceMount"
+>;
+
+export type CollapsibleApi = {
+  contentId: () => string;
+  disabled: () => boolean;
+  getContentProps: (props: CollapsibleContentContractProps) => Record<string, unknown>;
+  getTriggerProps: (props: CollapsibleTriggerContractProps) => Record<string, unknown>;
+  open: () => boolean;
+  setOpen: (open: boolean, detail: CollapsibleOpenChangeDetail) => boolean;
+};
+
+export type CreateCollapsibleOptions = {
+  defaultOpen?: boolean;
+  disabled?: () => boolean | undefined;
+  onOpenChange?: (open: boolean, detail: CollapsibleOpenChangeDetail) => void;
+  open?: () => boolean | undefined;
+};
+
+const CollapsibleContext = createContext<CollapsibleApi>();
+
+export function createCollapsible(options: CreateCollapsibleOptions = {}): CollapsibleApi {
+  const disclosure = createDisclosureController({
+    scope: "collapsible",
+    defaultOpen: options.defaultOpen,
+    disabled: options.disabled,
+    onOpenChange: options.onOpenChange,
+    open: options.open,
+  });
+
+  return disclosure;
+}
+
+function useCollapsible(part: string) {
+  const collapsible = useContext(CollapsibleContext);
+
+  if (!collapsible) {
+    throw new Error(`Collapsible.${part} must be used within Collapsible.Root`);
+  }
+
+  return collapsible;
+}
+
+function Root(props: CollapsibleRootProps) {
+  const collapsible = createCollapsible({
+    defaultOpen: props.defaultOpen,
+    disabled: () => props.disabled,
+    onOpenChange: props.onOpenChange,
+    open: () => props.open,
+  });
+
+  return (
+    <CollapsibleContext.Provider value={collapsible}>{props.children}</CollapsibleContext.Provider>
+  );
+}
+
+function Trigger(props: CollapsibleTriggerProps) {
+  const collapsible = useCollapsible("Trigger");
+  const [local, others] = splitProps(props, ["as", "children"]);
+  const triggerProps = collapsible.getTriggerProps(others);
+
+  if (!local.as) {
+    return <button {...triggerProps}>{local.children}</button>;
+  }
+
+  return renderPolymorphic(local.as, "button", {
+    ...triggerProps,
+    children: local.children,
+  });
+}
+
+function Content(props: CollapsibleContentProps) {
+  const collapsible = useCollapsible("Content");
+  const [local, others] = splitProps(props, ["children", "forceMount"]);
+  const contentProps = collapsible.getContentProps(others);
+
+  return (
+    <Show when={local.forceMount || collapsible.open()}>
+      <div {...contentProps}>{local.children}</div>
+    </Show>
+  );
+}
+
+export const Collapsible = {
+  Root,
+  Trigger,
+  Content,
+};

--- a/packages/keystone/src/combobox/index.tsx
+++ b/packages/keystone/src/combobox/index.tsx
@@ -1,0 +1,941 @@
+import {
+  For,
+  Show,
+  createContext,
+  createEffect,
+  createMemo,
+  createSignal,
+  splitProps,
+  useContext,
+  type JSX,
+} from "solid-js";
+import { Portal } from "solid-js/web";
+import { createFormControl, type FormControlApi } from "../form/index";
+import { createListboxInteraction, type ListboxInteractionApi } from "../listbox/index";
+import type { ListInteractionKernelApi } from "../listbox/interaction-kernel";
+import { getPartDataAttributes } from "../metadata/index";
+import { assignRef } from "../overlay/dom";
+import {
+  createFloatingAdapter,
+  type FloatingAdapter,
+  type FloatingCollisionBoundary,
+  type FloatingPlacement,
+  type FloatingRootBoundary,
+  type FloatingSticky,
+  type FloatingStrategy,
+} from "../overlay/index";
+import {
+  composeEventHandlers,
+  createControllableBooleanSignal,
+  createControllableSignal,
+  createStableId,
+  dataBoolean,
+  renderPolymorphic,
+  type PolymorphicProps,
+} from "../utils/index";
+
+export type ComboboxChangeDetail = {
+  event?: Event;
+  reason: "input" | "item" | "keyboard" | "clear" | "programmatic";
+};
+
+export type ComboboxOpenChangeDetail = {
+  event?: Event;
+  reason: "input" | "trigger" | "keyboard" | "select" | "escape" | "programmatic";
+};
+
+export type ComboboxItemData = {
+  disabled?: boolean;
+  group?: string;
+  label: string;
+  value: string;
+};
+
+export type ComboboxRootProps = {
+  children?: JSX.Element;
+  arrowPadding?: number;
+  collisionBoundary?: FloatingCollisionBoundary;
+  collisionPadding?: number;
+  defaultInputValue?: string;
+  defaultOpen?: boolean;
+  defaultValue?: string;
+  disabled?: boolean;
+  fitViewport?: boolean;
+  form?: string;
+  gutter?: number;
+  inputValue?: string;
+  invalid?: boolean;
+  name?: string;
+  onInputValueChange?: (value: string, detail: ComboboxChangeDetail) => void;
+  onOpenChange?: (open: boolean, detail: ComboboxOpenChangeDetail) => void;
+  onValueChange?: (value: string | undefined, detail: ComboboxChangeDetail) => void;
+  open?: boolean;
+  placement?: FloatingPlacement;
+  placeholder?: string;
+  readOnly?: boolean;
+  required?: boolean;
+  rootBoundary?: FloatingRootBoundary;
+  sameWidth?: boolean;
+  sticky?: FloatingSticky;
+  strategy?: FloatingStrategy;
+  value?: string;
+};
+
+export type ComboboxPartProps<T extends HTMLElement = HTMLElement> = {
+  children?: JSX.Element;
+  class?: string;
+  id?: string;
+  ref?: T | ((element: T) => void);
+  style?: JSX.CSSProperties | string;
+};
+
+export type ComboboxInputProps = ComboboxPartProps<HTMLInputElement> &
+  PolymorphicProps<HTMLInputElement> &
+  Omit<JSX.InputHTMLAttributes<HTMLInputElement>, "children" | "ref" | "value">;
+export type ComboboxTriggerProps = ComboboxPartProps<HTMLButtonElement> &
+  PolymorphicProps<HTMLButtonElement> &
+  Omit<JSX.ButtonHTMLAttributes<HTMLButtonElement>, "children" | "ref">;
+export type ComboboxClearProps = ComboboxPartProps<HTMLButtonElement> &
+  PolymorphicProps<HTMLButtonElement> &
+  Omit<JSX.ButtonHTMLAttributes<HTMLButtonElement>, "children" | "ref">;
+export type ComboboxPortalProps = {
+  children?: JSX.Element;
+  forceMount?: boolean;
+  mount?: Node;
+};
+export type ComboboxContentProps = ComboboxPartProps<HTMLDivElement> &
+  Omit<JSX.HTMLAttributes<HTMLDivElement>, "children" | "ref">;
+export type ComboboxPositionerProps = ComboboxPartProps<HTMLDivElement> &
+  Omit<JSX.HTMLAttributes<HTMLDivElement>, "children" | "ref">;
+export type ComboboxListboxProps = ComboboxPartProps<HTMLDivElement> &
+  Omit<JSX.HTMLAttributes<HTMLDivElement>, "children" | "ref">;
+export type ComboboxGroupProps = ComboboxPartProps<HTMLDivElement> &
+  Omit<JSX.HTMLAttributes<HTMLDivElement>, "children" | "ref" | "value"> & {
+    disabled?: boolean;
+    label?: string;
+    value: string;
+  };
+export type ComboboxGroupLabelProps = ComboboxPartProps<HTMLDivElement> &
+  Omit<JSX.HTMLAttributes<HTMLDivElement>, "children" | "ref">;
+export type ComboboxItemProps = ComboboxPartProps<HTMLDivElement> &
+  Omit<JSX.HTMLAttributes<HTMLDivElement>, "children" | "ref" | "value"> & {
+    disabled?: boolean;
+    group?: string;
+    label?: string;
+    value: string;
+  };
+export type ComboboxItemTextProps = ComboboxPartProps<HTMLSpanElement> &
+  Omit<JSX.HTMLAttributes<HTMLSpanElement>, "children" | "ref">;
+export type ComboboxItemIndicatorProps = ComboboxPartProps<HTMLSpanElement> &
+  Omit<JSX.HTMLAttributes<HTMLSpanElement>, "children" | "ref">;
+
+export type ComboboxInputContractProps = Omit<ComboboxInputProps, "as" | "children">;
+export type ComboboxTriggerContractProps = Omit<ComboboxTriggerProps, "as" | "children">;
+export type ComboboxClearContractProps = Omit<ComboboxClearProps, "as" | "children">;
+export type ComboboxContentContractProps = Omit<ComboboxContentProps, "children">;
+export type ComboboxPositionerContractProps = Omit<ComboboxPositionerProps, "children">;
+export type ComboboxListboxContractProps = Omit<ComboboxListboxProps, "children">;
+export type ComboboxGroupContractProps = Omit<ComboboxGroupProps, "children" | "label"> & {
+  label?: string;
+};
+export type ComboboxGroupLabelContractProps = Omit<ComboboxGroupLabelProps, "children">;
+export type ComboboxItemContractProps = Omit<ComboboxItemProps, "children" | "label"> & {
+  group?: string;
+  label: string;
+};
+export type ComboboxItemTextContractProps = Omit<ComboboxItemTextProps, "children">;
+export type ComboboxItemIndicatorContractProps = Omit<ComboboxItemIndicatorProps, "children">;
+
+export type CreateComboboxOptions = {
+  arrowPadding?: () => number | undefined;
+  collisionBoundary?: () => FloatingCollisionBoundary | undefined;
+  collisionPadding?: () => number | undefined;
+  defaultInputValue?: string;
+  defaultOpen?: boolean;
+  defaultValue?: string;
+  disabled?: () => boolean | undefined;
+  fitViewport?: () => boolean | undefined;
+  form?: () => string | undefined;
+  gutter?: () => number | undefined;
+  inputValue?: () => string | undefined;
+  invalid?: () => boolean | undefined;
+  name?: () => string | undefined;
+  onInputValueChange?: (value: string, detail: ComboboxChangeDetail) => void;
+  onOpenChange?: (open: boolean, detail: ComboboxOpenChangeDetail) => void;
+  onValueChange?: (value: string | undefined, detail: ComboboxChangeDetail) => void;
+  open?: () => boolean | undefined;
+  placement?: () => FloatingPlacement | undefined;
+  placeholder?: () => string | undefined;
+  readOnly?: () => boolean | undefined;
+  required?: () => boolean | undefined;
+  rootBoundary?: () => FloatingRootBoundary | undefined;
+  sameWidth?: () => boolean | undefined;
+  scope?: string;
+  sticky?: () => FloatingSticky | undefined;
+  strategy?: () => FloatingStrategy | undefined;
+  value?: () => string | undefined;
+};
+
+export type ComboboxApi = {
+  contentId: string;
+  disabled: () => boolean;
+  floating: FloatingAdapter;
+  formControl: FormControlApi;
+  formValue: ComboboxValueFormApi;
+  getClearProps: (props: ComboboxClearContractProps) => Record<string, unknown>;
+  getContentProps: (props: ComboboxContentContractProps) => Record<string, unknown>;
+  getGroupLabelProps: (props: ComboboxGroupLabelContractProps) => Record<string, unknown>;
+  getGroupProps: (props: ComboboxGroupContractProps) => Record<string, unknown>;
+  getInputProps: (props: ComboboxInputContractProps) => Record<string, unknown>;
+  getItemIndicatorProps: (props: ComboboxItemIndicatorContractProps) => Record<string, unknown>;
+  getItemProps: (props: ComboboxItemContractProps) => Record<string, unknown>;
+  getItemTextProps: (props: ComboboxItemTextContractProps) => Record<string, unknown>;
+  getListboxProps: (props: ComboboxListboxContractProps) => Record<string, unknown>;
+  getPositionerProps: (props: ComboboxPositionerContractProps) => Record<string, unknown>;
+  getTriggerProps: (props: ComboboxTriggerContractProps) => Record<string, unknown>;
+  groupId: (value: string) => string;
+  groupLabelId: (value: string) => string;
+  inputId: string;
+  inputValue: () => string;
+  invalid: () => boolean;
+  itemId: (value: string) => string;
+  list: ListInteractionKernelApi<ComboboxItemData, ComboboxChangeDetail>;
+  listbox: ListboxInteractionApi<ComboboxItemData, ComboboxChangeDetail>;
+  listboxId: string;
+  open: () => boolean;
+  placeholder: () => string | undefined;
+  readOnly: () => boolean;
+  required: () => boolean;
+  scope: string;
+  setInputValue: (value: string, detail: ComboboxChangeDetail) => void;
+  setOpen: (open: boolean, detail: ComboboxOpenChangeDetail) => void;
+  triggerId: string;
+  value: () => string | undefined;
+};
+
+type ComboboxHiddenInputDescriptor = {
+  disabled?: boolean;
+  name: string;
+  value: string;
+};
+
+export type ComboboxValueFormApi = {
+  hiddenInputs: () => readonly ComboboxHiddenInputDescriptor[];
+  reset: () => void;
+  syncInputValue: (value: string) => void;
+  value: () => string | undefined;
+};
+
+type ComboboxFactoryOptions = {
+  scope: string;
+};
+
+const ComboboxContext = createContext<ComboboxApi>();
+const ComboboxGroupContext = createContext<{ disabled?: boolean; value: string }>();
+
+export function createCombobox(options: CreateComboboxOptions = {}): ComboboxApi {
+  return createScopedCombobox({ ...options, scope: options.scope ?? "combobox" });
+}
+
+export function createAutocomplete(options: CreateComboboxOptions = {}): ComboboxApi {
+  return createScopedCombobox({ ...options, scope: options.scope ?? "autocomplete" });
+}
+
+function createScopedCombobox(options: CreateComboboxOptions = {}): ComboboxApi {
+  const scope = options.scope ?? "combobox";
+  const inputId = createStableId(`${scope}-input`);
+  const triggerId = createStableId(`${scope}-trigger`);
+  const contentId = createStableId(`${scope}-content`);
+  const listboxId = createStableId(`${scope}-listbox`);
+  const [inputElement, setInputElement] = createSignal<HTMLInputElement>();
+  const [contentElement, setContentElement] = createSignal<HTMLDivElement>();
+  const [positionerElement, setPositionerElement] = createSignal<HTMLDivElement>();
+  let lastOpenDetail: ComboboxOpenChangeDetail = { reason: "programmatic" };
+  let lastInputDetail: ComboboxChangeDetail = { reason: "programmatic" };
+  const [open, setOpenState] = createControllableBooleanSignal({
+    value: options.open,
+    defaultValue: options.defaultOpen ?? false,
+    onChange: (next) => options.onOpenChange?.(next, lastOpenDetail),
+  });
+  const [inputValue, setInputValueState] = createControllableSignal<string>({
+    value: options.inputValue,
+    defaultValue: options.defaultInputValue ?? "",
+    onChange: (next) => options.onInputValueChange?.(next, lastInputDetail),
+  });
+  const disabled = () => options.disabled?.() ?? false;
+  const invalid = () => options.invalid?.() ?? false;
+  const readOnly = () => options.readOnly?.() ?? false;
+  const required = () => options.required?.() ?? false;
+  const itemId = (value: string) => `${listboxId()}-${value}`;
+  const groupId = (value: string) => `${listboxId()}-group-${value}`;
+  const groupLabelId = (value: string) => `${listboxId()}-group-${value}-label`;
+  const setOpen = (next: boolean, detail: ComboboxOpenChangeDetail) => {
+    lastOpenDetail = detail;
+    setOpenState(next);
+  };
+  const setInputValue = (next: string, detail: ComboboxChangeDetail) => {
+    lastInputDetail = detail;
+    setInputValueState(next);
+  };
+  const listbox = createListboxInteraction<ComboboxItemData, ComboboxChangeDetail>({
+    id: listboxId,
+    labelledBy: inputId,
+    groupId,
+    groupLabelId,
+    optionId: itemId,
+    optionPart: "item",
+    optionSelectDetail: (event) => ({ event, reason: "item" }),
+    rootPart: "listbox",
+    scope,
+    selectionMode: "single",
+    value: options.value,
+    defaultValue: options.defaultValue,
+    programmaticDetail: { reason: "programmatic" },
+    onSelectionChange: options.onValueChange,
+    onValueSelect: (item, detail) => {
+      setInputValue(item.label, detail);
+      setOpen(false, {
+        event: detail.event,
+        reason: detail.reason === "keyboard" ? "keyboard" : "select",
+      });
+    },
+  });
+  const formValue = createComboboxValueForm({
+    defaultValue: () => options.defaultValue,
+    name: options.name,
+    onValueChange: (value) => listbox.selection.setValue(value, { reason: "programmatic" }),
+    value: listbox.selection.value,
+  });
+  const formControl = createFormControl({
+    form: options.form,
+    id: inputId,
+    name: options.name,
+    value: () => formValue.value() ?? null,
+    disabled,
+    invalid,
+    readonly: readOnly,
+    required,
+    onReset: formValue.reset,
+  });
+  const floating = createFloatingAdapter({
+    anchor: inputElement,
+    floating: () => positionerElement() ?? contentElement(),
+    enabled: open,
+    arrowPadding: options.arrowPadding,
+    collisionBoundary: options.collisionBoundary,
+    collisionPadding: options.collisionPadding,
+    fitViewport: () => options.fitViewport?.() ?? true,
+    gutter: options.gutter,
+    placement: options.placement,
+    rootBoundary: options.rootBoundary,
+    sameWidth: () => options.sameWidth?.() ?? true,
+    sticky: options.sticky,
+    strategy: options.strategy,
+  });
+  const state = () => (open() ? "open" : "closed");
+  const partProps = (part: string) => ({
+    ...getPartDataAttributes(scope, part),
+  });
+
+  return {
+    contentId: contentId(),
+    disabled,
+    floating,
+    formControl,
+    formValue,
+    getClearProps: (props) => ({
+      ...props,
+      type: "button",
+      ...partProps("clear"),
+      get "data-disabled"() {
+        return dataBoolean(disabled());
+      },
+      onClick: composeEventHandlers<MouseEvent>(props.onClick, (event) => {
+        if (disabled() || readOnly()) {
+          event.preventDefault();
+          return;
+        }
+
+        setInputValue("", { event, reason: "clear" });
+        listbox.selection.setValue(undefined, { event, reason: "clear" });
+        setOpen(false, { event, reason: "programmatic" });
+        queueMicrotask(() => inputElement()?.focus());
+      }),
+    }),
+    getContentProps: (props) => {
+      const floatingProps = floating.getFloatingProps({ style: props.style });
+
+      return {
+        ...props,
+        id: contentId(),
+        ...partProps("content"),
+        get "data-state"() {
+          return state();
+        },
+        get "data-side"() {
+          return floating.side();
+        },
+        get "data-align"() {
+          return floating.align();
+        },
+        style: floatingProps.style,
+        ref: (element: HTMLDivElement) => {
+          setContentElement(element);
+          assignRef(props.ref, element);
+          queueMicrotask(floating.update);
+        },
+        onKeyDown: composeEventHandlers<KeyboardEvent>(props.onKeyDown, (event) => {
+          if (event.key === "Escape") {
+            event.preventDefault();
+            setOpen(false, { event, reason: "escape" });
+          }
+        }),
+      };
+    },
+    getGroupProps: (props) => listbox.getGroupProps(props),
+    getGroupLabelProps: (props) => listbox.getGroupLabelProps(props),
+    getInputProps: (props) => ({
+      ...formControl.getControlProps<HTMLInputElement>({
+        ...props,
+        id: inputId(),
+      }),
+      role: "combobox",
+      type: props.type ?? "text",
+      autocomplete: props.autocomplete ?? "off",
+      autocorrect: "off",
+      spellcheck: "false",
+      "aria-autocomplete": "list",
+      "aria-controls": listboxId(),
+      get "aria-expanded"() {
+        return open();
+      },
+      "aria-haspopup": "listbox",
+      get "aria-activedescendant"() {
+        return listbox.activeDescendant.id();
+      },
+      get disabled() {
+        return disabled();
+      },
+      get readOnly() {
+        return readOnly();
+      },
+      get required() {
+        return required();
+      },
+      get value() {
+        return inputValue();
+      },
+      placeholder: props.placeholder ?? options.placeholder?.(),
+      ...partProps("input"),
+      get "data-state"() {
+        return state();
+      },
+      get "data-disabled"() {
+        return dataBoolean(disabled());
+      },
+      get "data-invalid"() {
+        return dataBoolean(invalid());
+      },
+      get "data-placeholder"() {
+        return dataBoolean(inputValue() === "");
+      },
+      get "data-readonly"() {
+        return dataBoolean(readOnly());
+      },
+      get "data-required"() {
+        return dataBoolean(required());
+      },
+      ref: (element: HTMLInputElement) => {
+        setInputElement(element);
+        assignRef(props.ref, element);
+      },
+      onInput: composeEventHandlers<InputEvent>(props.onInput, (event) => {
+        if (disabled() || readOnly()) {
+          event.preventDefault();
+          return;
+        }
+
+        const target = event.currentTarget as HTMLInputElement;
+        setInputValue(target.value, { event, reason: "input" });
+        setOpen(true, { event, reason: "input" });
+        listbox.activeDescendant.setHighlightedValue(undefined);
+      }),
+      onFocus: composeEventHandlers<FocusEvent>(props.onFocus, () => {
+        if (!disabled() && !readOnly() && inputValue()) {
+          setOpen(true, { reason: "input" });
+        }
+      }),
+      onKeyDown: composeEventHandlers<KeyboardEvent>(props.onKeyDown, (event) => {
+        if (disabled() || readOnly()) {
+          return;
+        }
+
+        if (event.key === "Escape") {
+          if (open()) {
+            event.preventDefault();
+            setOpen(false, { event, reason: "escape" });
+            return;
+          }
+
+          setInputValue("", { event, reason: "clear" });
+          listbox.selection.setValue(undefined, { event, reason: "clear" });
+          return;
+        }
+
+        if (event.key === "ArrowDown") {
+          event.preventDefault();
+          setOpen(true, { event, reason: "keyboard" });
+          listbox.keyboard.highlight("next");
+          return;
+        }
+
+        if (event.key === "ArrowUp") {
+          event.preventDefault();
+          setOpen(true, { event, reason: "keyboard" });
+          listbox.keyboard.highlight("previous");
+          return;
+        }
+
+        if (event.key === "Enter" && open()) {
+          event.preventDefault();
+          listbox.selection.selectHighlighted({ event, reason: "keyboard" });
+        }
+      }),
+    }),
+    getItemIndicatorProps: (props) => ({
+      ...props,
+      ...partProps("item-indicator"),
+    }),
+    getItemProps: (props) => {
+      const [local, others] = splitProps(props, [
+        "disabled",
+        "group",
+        "label",
+        "onClick",
+        "onPointerMove",
+        "value",
+      ]);
+
+      return listbox.getOptionProps({
+        ...others,
+        disabled: local.disabled,
+        group: local.group,
+        label: local.label,
+        onClick: composeEventHandlers<MouseEvent>(local.onClick, (event) => {
+          if (readOnly()) {
+            event.preventDefault();
+          }
+        }),
+        onPointerMove: local.onPointerMove,
+        value: local.value,
+      });
+    },
+    getItemTextProps: (props) => ({
+      ...props,
+      ...partProps("item-text"),
+    }),
+    getListboxProps: (props) =>
+      listbox.getListboxProps(
+        {
+          ...props,
+          onKeyDown: composeEventHandlers<KeyboardEvent>(props.onKeyDown, (event) => {
+            if (readOnly()) {
+              event.preventDefault();
+            }
+          }),
+        },
+        {
+          selectDetail: (event) => ({ event, reason: "keyboard" }),
+        },
+      ),
+    getPositionerProps: (props) => {
+      const floatingProps = floating.getFloatingProps({ style: props.style });
+
+      return {
+        ...props,
+        ...partProps("positioner"),
+        get "data-state"() {
+          return state();
+        },
+        get "data-side"() {
+          return floating.side();
+        },
+        get "data-align"() {
+          return floating.align();
+        },
+        style: floatingProps.style,
+        ref: (element: HTMLDivElement) => {
+          setPositionerElement(element);
+          assignRef(props.ref, element);
+          queueMicrotask(floating.update);
+        },
+      };
+    },
+    getTriggerProps: (props) => ({
+      ...props,
+      type: "button",
+      "aria-controls": listboxId(),
+      get "aria-expanded"() {
+        return open();
+      },
+      "aria-haspopup": "listbox",
+      ...partProps("trigger"),
+      get "data-state"() {
+        return state();
+      },
+      get "data-disabled"() {
+        return dataBoolean(disabled());
+      },
+      ref: (element: HTMLButtonElement) => {
+        assignRef(props.ref, element);
+      },
+      onClick: composeEventHandlers<MouseEvent>(props.onClick, (event) => {
+        if (disabled() || readOnly()) {
+          event.preventDefault();
+          return;
+        }
+
+        setOpen(!open(), { event, reason: "trigger" });
+        queueMicrotask(() => inputElement()?.focus());
+      }),
+    }),
+    groupId,
+    groupLabelId,
+    inputId: inputId(),
+    inputValue,
+    invalid,
+    itemId,
+    list: listbox.interaction,
+    listbox,
+    listboxId: listboxId(),
+    open,
+    placeholder: () => options.placeholder?.(),
+    readOnly,
+    required,
+    scope,
+    setInputValue,
+    setOpen,
+    triggerId: triggerId(),
+    value: listbox.selection.value,
+  };
+}
+
+function createComboboxValueForm(options: {
+  defaultValue?: () => string | undefined;
+  name?: () => string | undefined;
+  onValueChange: (value: string | undefined) => void;
+  value: () => string | undefined;
+}): ComboboxValueFormApi {
+  const hiddenInputs = createMemo<readonly ComboboxHiddenInputDescriptor[]>(() => {
+    const name = options.name?.();
+
+    if (!name) {
+      return [];
+    }
+
+    return [{ name, value: options.value() ?? "" }];
+  });
+  const reset = () => options.onValueChange(options.defaultValue?.());
+  const syncInputValue = (next: string) => options.onValueChange(next || undefined);
+
+  return {
+    hiddenInputs,
+    reset,
+    syncInputValue,
+    value: options.value,
+  };
+}
+
+function useCombobox(part: string) {
+  const combobox = useContext(ComboboxContext);
+
+  if (!combobox) {
+    throw new Error(`Combobox.${part} must be used within Combobox.Root`);
+  }
+
+  return combobox;
+}
+
+function createComboboxNamespace(factoryOptions: ComboboxFactoryOptions) {
+  function Root(props: ComboboxRootProps) {
+    const combobox = createScopedCombobox({
+      arrowPadding: () => props.arrowPadding,
+      collisionBoundary: () => props.collisionBoundary,
+      collisionPadding: () => props.collisionPadding,
+      defaultInputValue: props.defaultInputValue,
+      defaultOpen: props.defaultOpen,
+      defaultValue: props.defaultValue,
+      disabled: () => props.disabled,
+      fitViewport: () => props.fitViewport,
+      form: () => props.form,
+      gutter: () => props.gutter,
+      inputValue: () => props.inputValue,
+      invalid: () => props.invalid,
+      name: () => props.name,
+      onInputValueChange: props.onInputValueChange,
+      onOpenChange: props.onOpenChange,
+      onValueChange: props.onValueChange,
+      open: () => props.open,
+      placement: () => props.placement,
+      placeholder: () => props.placeholder,
+      readOnly: () => props.readOnly,
+      required: () => props.required,
+      rootBoundary: () => props.rootBoundary,
+      sameWidth: () => props.sameWidth,
+      scope: factoryOptions.scope,
+      sticky: () => props.sticky,
+      strategy: () => props.strategy,
+      value: () => props.value,
+    });
+
+    return (
+      <ComboboxContext.Provider value={combobox}>
+        <Show when={props.name}>
+          <For each={combobox.formValue.hiddenInputs()}>
+            {(input) => <HiddenInput input={input} combobox={combobox} />}
+          </For>
+        </Show>
+        {props.children}
+      </ComboboxContext.Provider>
+    );
+  }
+
+  function HiddenInput(props: {
+    input: ReturnType<ComboboxApi["formValue"]["hiddenInputs"]>[number];
+    combobox: ComboboxApi;
+  }) {
+    let inputElement: HTMLInputElement | undefined;
+
+    createEffect(() => {
+      if (inputElement) {
+        inputElement.value = props.input.value;
+      }
+    });
+
+    return (
+      <input
+        {...props.combobox.formControl.getHiddenInputProps({
+          name: props.input.name,
+          disabled: props.input.disabled,
+          ref: (element) => {
+            inputElement = element;
+            element.value = props.input.value;
+            props.combobox.formControl.registerFormReset(() => element);
+            props.combobox.formControl.registerFormValueSync(
+              () => element,
+              props.combobox.formValue.syncInputValue,
+            );
+          },
+        })}
+      />
+    );
+  }
+
+  function Input(props: ComboboxInputProps) {
+    const combobox = useCombobox("Input");
+    const [local, others] = splitProps(props, ["as", "onFocus", "onInput", "onKeyDown", "ref"]);
+    const inputProps = combobox.getInputProps({
+      ...others,
+      onFocus: local.onFocus,
+      onInput: local.onInput,
+      onKeyDown: local.onKeyDown,
+      ref: local.ref,
+    });
+
+    if (!local.as) {
+      return <input {...inputProps} />;
+    }
+
+    return renderPolymorphic(local.as, "input", inputProps);
+  }
+
+  function Trigger(props: ComboboxTriggerProps) {
+    const combobox = useCombobox("Trigger");
+    const [local, others] = splitProps(props, ["as", "children", "onClick", "ref"]);
+    const triggerProps = combobox.getTriggerProps({
+      ...others,
+      onClick: local.onClick,
+      ref: local.ref,
+    });
+
+    if (!local.as) {
+      return <button {...triggerProps}>{local.children}</button>;
+    }
+
+    return renderPolymorphic(local.as, "button", { ...triggerProps, children: local.children });
+  }
+
+  function Clear(props: ComboboxClearProps) {
+    const combobox = useCombobox("Clear");
+    const [local, others] = splitProps(props, ["as", "children", "onClick", "ref"]);
+    const clearProps = combobox.getClearProps({
+      ...others,
+      onClick: local.onClick,
+      ref: local.ref,
+    });
+
+    if (!local.as) {
+      return <button {...clearProps}>{local.children}</button>;
+    }
+
+    return renderPolymorphic(local.as, "button", { ...clearProps, children: local.children });
+  }
+
+  function PortalPart(props: ComboboxPortalProps) {
+    const combobox = useCombobox("Portal");
+
+    return (
+      <Show when={props.forceMount || combobox.open()}>
+        <Portal mount={props.mount}>{props.children}</Portal>
+      </Show>
+    );
+  }
+
+  function Content(props: ComboboxContentProps) {
+    const combobox = useCombobox("Content");
+    const [local, others] = splitProps(props, ["children", "onKeyDown", "ref", "style"]);
+
+    return (
+      <div
+        {...combobox.getContentProps({
+          ...others,
+          onKeyDown: local.onKeyDown,
+          ref: local.ref,
+          style: local.style,
+        })}
+      >
+        {local.children}
+      </div>
+    );
+  }
+
+  function Positioner(props: ComboboxPositionerProps) {
+    const combobox = useCombobox("Positioner");
+    const [local, others] = splitProps(props, ["children", "ref", "style"]);
+
+    return (
+      <div
+        {...combobox.getPositionerProps({
+          ...others,
+          ref: local.ref,
+          style: local.style,
+        })}
+      >
+        {local.children}
+      </div>
+    );
+  }
+
+  function Listbox(props: ComboboxListboxProps) {
+    const combobox = useCombobox("Listbox");
+    const [local, others] = splitProps(props, ["children", "onKeyDown"]);
+
+    return (
+      <div {...combobox.getListboxProps({ ...others, onKeyDown: local.onKeyDown })}>
+        {local.children}
+      </div>
+    );
+  }
+
+  function Group(props: ComboboxGroupProps) {
+    const combobox = useCombobox("Group");
+    const [local, others] = splitProps(props, ["children", "disabled", "label", "value"]);
+
+    return (
+      <ComboboxGroupContext.Provider value={{ disabled: local.disabled, value: local.value }}>
+        <div
+          {...combobox.getGroupProps({
+            ...others,
+            disabled: local.disabled,
+            label: local.label,
+            value: local.value,
+          })}
+        >
+          {local.children}
+        </div>
+      </ComboboxGroupContext.Provider>
+    );
+  }
+
+  function GroupLabel(props: ComboboxGroupLabelProps) {
+    const combobox = useCombobox("GroupLabel");
+    const group = useContext(ComboboxGroupContext);
+    const [local, others] = splitProps(props, ["children", "id"]);
+    const id = () => local.id ?? (group ? combobox.groupLabelId(group.value) : undefined);
+
+    return (
+      <div
+        {...combobox.getGroupLabelProps({
+          ...others,
+          id: id(),
+        })}
+      >
+        {local.children}
+      </div>
+    );
+  }
+
+  function Item(props: ComboboxItemProps) {
+    const combobox = useCombobox("Item");
+    const group = useContext(ComboboxGroupContext);
+    const [local, others] = splitProps(props, [
+      "children",
+      "disabled",
+      "group",
+      "label",
+      "onClick",
+      "onPointerMove",
+      "value",
+    ]);
+    const label = () => local.label ?? String(local.children ?? local.value);
+
+    return (
+      <div
+        {...combobox.getItemProps({
+          ...others,
+          disabled: local.disabled ?? group?.disabled,
+          group: local.group ?? group?.value,
+          label: label(),
+          onClick: local.onClick,
+          onPointerMove: local.onPointerMove,
+          value: local.value,
+        })}
+      >
+        {local.children}
+      </div>
+    );
+  }
+
+  function ItemText(props: ComboboxItemTextProps) {
+    const combobox = useCombobox("ItemText");
+    const [local, others] = splitProps(props, ["children"]);
+
+    return <span {...combobox.getItemTextProps(others)}>{local.children}</span>;
+  }
+
+  function ItemIndicator(props: ComboboxItemIndicatorProps) {
+    const combobox = useCombobox("ItemIndicator");
+    const [local, others] = splitProps(props, ["children"]);
+
+    return <span {...combobox.getItemIndicatorProps(others)}>{local.children}</span>;
+  }
+
+  return {
+    Root,
+    Input,
+    Trigger,
+    Clear,
+    Portal: PortalPart,
+    Positioner,
+    Content,
+    Listbox,
+    Group,
+    GroupLabel,
+    Item,
+    ItemText,
+    ItemIndicator,
+  };
+}
+
+export const Combobox = createComboboxNamespace({ scope: "combobox" });
+export const Autocomplete = createComboboxNamespace({ scope: "autocomplete" });

--- a/packages/keystone/src/disclosure/controller.ts
+++ b/packages/keystone/src/disclosure/controller.ts
@@ -1,0 +1,120 @@
+import { createMemo, createUniqueId, splitProps, type JSX } from "solid-js";
+import {
+  composeEventHandlers,
+  createControllableBooleanSignal,
+  dataBoolean,
+  partDataAttributes,
+} from "../utils/index";
+
+export type DisclosureChangeDetail<TReason extends string = "trigger" | "programmatic"> = {
+  event?: Event;
+  reason: TReason;
+};
+
+export type DisclosureControllerOptions<TReason extends string = "trigger" | "programmatic"> = {
+  contentId?: () => string | undefined;
+  defaultOpen?: boolean;
+  disabled?: () => boolean | undefined;
+  onOpenChange?: (open: boolean, detail: DisclosureChangeDetail<TReason>) => void;
+  open?: () => boolean | undefined;
+  scope: string;
+};
+
+export type DisclosureTriggerProps = Omit<
+  JSX.ButtonHTMLAttributes<HTMLButtonElement>,
+  "children" | "ref"
+> & {
+  ref?: HTMLButtonElement | ((element: HTMLButtonElement) => void);
+};
+
+export type DisclosureContentProps = Omit<
+  JSX.HTMLAttributes<HTMLDivElement>,
+  "children" | "ref"
+> & {
+  ref?: HTMLDivElement | ((element: HTMLDivElement) => void);
+};
+
+export function createDisclosureController<TReason extends string = "trigger" | "programmatic">(
+  options: DisclosureControllerOptions<TReason>,
+) {
+  const fallbackContentId = `keystone-${options.scope}-content-${createUniqueId()}`;
+  const contentId = createMemo(() => options.contentId?.() ?? fallbackContentId);
+  const disabled = createMemo(() => options.disabled?.() ?? false);
+  let pendingDetail: DisclosureChangeDetail<TReason> | undefined;
+  const [open, setOpenState] = createControllableBooleanSignal({
+    value: options.open,
+    defaultValue: options.defaultOpen ?? false,
+    onChange: (nextOpen) => {
+      options.onOpenChange?.(nextOpen, pendingDetail ?? ({ reason: "programmatic" } as never));
+      pendingDetail = undefined;
+    },
+  });
+
+  const setOpen = (nextOpen: boolean, detail: DisclosureChangeDetail<TReason>) => {
+    if (disabled() && detail.reason !== "programmatic") {
+      return open();
+    }
+
+    pendingDetail = detail;
+    const result = setOpenState(nextOpen);
+    pendingDetail = undefined;
+    return result;
+  };
+
+  const getPartProps = (part: string) => ({
+    ...partDataAttributes(options.scope, part),
+    get "data-state"() {
+      return open() ? "open" : "closed";
+    },
+    get "data-disabled"() {
+      return dataBoolean(disabled());
+    },
+  });
+
+  return {
+    contentId,
+    disabled,
+    getContentProps: (props: DisclosureContentProps) => ({
+      ...props,
+      id: contentId(),
+      ...partDataAttributes(options.scope, "content"),
+      get hidden() {
+        return open() ? undefined : true;
+      },
+      get "data-state"() {
+        return open() ? "open" : "closed";
+      },
+      get "data-disabled"() {
+        return dataBoolean(disabled());
+      },
+    }),
+    getTriggerProps: (props: DisclosureTriggerProps) => {
+      const [local, others] = splitProps(props, ["disabled", "onClick"]);
+
+      return {
+        ...others,
+        type: others.type ?? "button",
+        ...partDataAttributes(options.scope, "trigger"),
+        get disabled() {
+          return local.disabled ?? disabled();
+        },
+        "aria-controls": contentId(),
+        get "aria-expanded"() {
+          return open();
+        },
+        onClick: composeEventHandlers(local.onClick, (event) =>
+          setOpen(!open(), { event, reason: "trigger" } as DisclosureChangeDetail<TReason>),
+        ),
+        get "data-state"() {
+          return open() ? "open" : "closed";
+        },
+        get "data-disabled"() {
+          return dataBoolean(disabled());
+        },
+      };
+    },
+    getPartProps,
+    open,
+    setOpen,
+  };
+}

--- a/packages/keystone/src/hover-card/index.tsx
+++ b/packages/keystone/src/hover-card/index.tsx
@@ -1,0 +1,575 @@
+import {
+  Show,
+  createContext,
+  onCleanup,
+  splitProps,
+  useContext,
+  type Accessor,
+  type JSX,
+} from "solid-js";
+import { Portal } from "solid-js/web";
+import {
+  OverlayLayerProvider,
+  type FloatingAdapter,
+  type FloatingCollisionBoundary,
+  type FloatingPlacement,
+  type FloatingRootBoundary,
+  type FloatingSticky,
+  type FloatingStrategy,
+  type OverlayLayerOutsideEvent,
+  type OverlayPresenceCompleteDetail,
+} from "../overlay/index";
+import { createOverlayController } from "../overlay/controller";
+import { composeEventHandlers, renderPolymorphic, type PolymorphicProps } from "../utils/index";
+
+export type HoverCardOpenChangeDetail = {
+  event?: Event;
+  reason: "pointer" | "focus" | "escape" | "outside" | "programmatic";
+};
+
+export type HoverCardRootProps = {
+  children?: JSX.Element;
+  arrowPadding?: number;
+  closeDelay?: number;
+  collisionBoundary?: FloatingCollisionBoundary;
+  collisionPadding?: number;
+  defaultOpen?: boolean;
+  fitViewport?: boolean;
+  gutter?: number;
+  hoverableContent?: boolean;
+  onOpenChange?: (open: boolean, detail: HoverCardOpenChangeDetail) => void;
+  onOpenChangeComplete?: (open: boolean, detail: OverlayPresenceCompleteDetail) => void;
+  open?: boolean;
+  openDelay?: number;
+  placement?: FloatingPlacement;
+  pointerGraceArea?: number;
+  rootBoundary?: FloatingRootBoundary;
+  sameWidth?: boolean;
+  sticky?: FloatingSticky;
+  strategy?: FloatingStrategy;
+};
+
+export type HoverCardPartProps<T extends HTMLElement = HTMLElement> = {
+  children?: JSX.Element;
+  class?: string;
+  id?: string;
+  ref?: T | ((element: T) => void);
+  style?: JSX.CSSProperties | string;
+};
+
+export type HoverCardTriggerProps = HoverCardPartProps<HTMLAnchorElement> &
+  PolymorphicProps<HTMLAnchorElement> &
+  Omit<JSX.AnchorHTMLAttributes<HTMLAnchorElement>, "children" | "ref">;
+export type HoverCardPortalProps = {
+  children?: JSX.Element;
+  forceMount?: boolean;
+  mount?: Node;
+};
+export type HoverCardPositionerProps = HoverCardPartProps<HTMLDivElement> &
+  Omit<JSX.HTMLAttributes<HTMLDivElement>, "children" | "ref">;
+export type HoverCardContentProps = HoverCardPartProps<HTMLDivElement> &
+  Omit<JSX.HTMLAttributes<HTMLDivElement>, "children" | "ref"> & {
+    onEscapeKeyDown?: (event: KeyboardEvent) => void;
+    onPointerDownOutside?: (event: OverlayLayerOutsideEvent) => void;
+    onFocusOutside?: (event: OverlayLayerOutsideEvent) => void;
+    onInteractOutside?: (event: OverlayLayerOutsideEvent) => void;
+  };
+
+type HoverCardApi = {
+  contentId: string;
+  floating: FloatingAdapter;
+  getContentProps: (props: Omit<HoverCardContentProps, "children">) => Record<string, unknown>;
+  getPositionerProps: (
+    props: Omit<HoverCardPositionerProps, "children">,
+  ) => Record<string, unknown>;
+  getTriggerProps: (
+    props: Omit<HoverCardTriggerProps, "as" | "children">,
+  ) => Record<string, unknown>;
+  open: () => boolean;
+  shouldMount: (forceMount?: boolean) => boolean;
+};
+
+export type CreateHoverCardOptions = {
+  arrowPadding?: () => number | undefined;
+  closeDelay?: () => number | undefined;
+  collisionBoundary?: () => FloatingCollisionBoundary | undefined;
+  collisionPadding?: () => number | undefined;
+  defaultOpen?: boolean;
+  fitViewport?: () => boolean | undefined;
+  gutter?: () => number | undefined;
+  hoverableContent?: () => boolean | undefined;
+  onOpenChange?: (open: boolean, detail: HoverCardOpenChangeDetail) => void;
+  onOpenChangeComplete?: (open: boolean, detail: OverlayPresenceCompleteDetail) => void;
+  open?: () => boolean | undefined;
+  openDelay?: () => number | undefined;
+  placement?: () => FloatingPlacement | undefined;
+  pointerGraceArea?: () => number | undefined;
+  rootBoundary?: () => FloatingRootBoundary | undefined;
+  sameWidth?: () => boolean | undefined;
+  sticky?: () => FloatingSticky | undefined;
+  strategy?: () => FloatingStrategy | undefined;
+};
+
+const HoverCardContext = createContext<HoverCardApi>();
+
+export function createHoverCard(options: CreateHoverCardOptions = {}): HoverCardApi {
+  const overlay = createOverlayController<HoverCardOpenChangeDetail["reason"]>({
+    scope: "hover-card",
+    open: options.open,
+    defaultOpen: options.defaultOpen,
+    onOpenChange: (open, detail) => options.onOpenChange?.(open, detail),
+    onOpenChangeComplete: options.onOpenChangeComplete,
+    floating: {
+      arrowPadding: options.arrowPadding,
+      collisionBoundary: options.collisionBoundary,
+      collisionPadding: options.collisionPadding,
+      fitViewport: options.fitViewport,
+      gutter: options.gutter,
+      placement: options.placement,
+      rootBoundary: options.rootBoundary,
+      sameWidth: options.sameWidth,
+      sticky: options.sticky,
+      strategy: options.strategy,
+    },
+  });
+  const floating = overlay.floating as FloatingAdapter;
+  const interaction = createHoverCardInteraction({
+    close: (event, reason) => overlay.close(event, reason),
+    closeDelay: () => options.closeDelay?.() ?? 0,
+    contentElement: overlay.contentElement,
+    hoverableContent: () => options.hoverableContent?.() ?? true,
+    open: overlay.open,
+    openCard: (event, reason) => overlay.setOpen(true, { event, reason }),
+    openDelay: () => options.openDelay?.() ?? 700,
+    pointerGraceArea: () => options.pointerGraceArea?.() ?? 8,
+    triggerElement: overlay.triggerElement,
+  });
+  const partProps = (part: string) => ({
+    ...overlay.getPartProps(part),
+    "data-side": floating.side(),
+    "data-align": floating.align(),
+  });
+
+  return {
+    contentId: overlay.contentId,
+    floating,
+    getContentProps: (props) => {
+      const [local, others] = splitProps(props, [
+        "ref",
+        "style",
+        "onEscapeKeyDown",
+        "onPointerDownOutside",
+        "onFocusOutside",
+        "onInteractOutside",
+      ]);
+      const layerProps = overlay.getContentLayerProps<HTMLDivElement>(
+        {
+          onEscapeKeyDown: local.onEscapeKeyDown,
+          onFocusOutside: local.onFocusOutside,
+          onInteractOutside: local.onInteractOutside,
+          onPointerDownOutside: local.onPointerDownOutside,
+        },
+        {
+          containsTrigger: true,
+          dismissReason: (event) => (event.type === "keydown" ? "escape" : "outside"),
+        },
+      );
+      const floatingProps = overlay.getFloatingContentProps<HTMLDivElement>(
+        interaction.getContentProps({
+          ref: local.ref,
+          style: local.style,
+        }),
+      );
+
+      return {
+        ...others,
+        ...layerProps,
+        ...floatingProps,
+        id: overlay.contentId,
+        "aria-hidden": "true",
+        tabindex: -1,
+        ...partProps("content"),
+      };
+    },
+    getPositionerProps: (props) => {
+      const floatingProps = overlay.getFloatingPositionerProps<HTMLDivElement>(props);
+      return {
+        ...floatingProps,
+        ...partProps("positioner"),
+      };
+    },
+    getTriggerProps: (props) => {
+      const triggerProps = overlay.getHoverFocusTriggerProps(props, {
+        deferOpenChange: true,
+        focusReason: "focus",
+        pointerReason: "pointer",
+      });
+
+      return interaction.getTriggerProps({
+        ...triggerProps,
+        "aria-describedby": undefined,
+        onKeyDown: composeEventHandlers<KeyboardEvent>(triggerProps.onKeyDown, (event) => {
+          if (event.key !== "Escape" || !overlay.open()) {
+            return;
+          }
+
+          event.preventDefault();
+          overlay.close(event, "escape");
+        }),
+      }) as Record<string, unknown>;
+    },
+    open: overlay.open,
+    shouldMount: overlay.shouldMount,
+  };
+}
+
+function useHoverCard(part: string) {
+  const hoverCard = useContext(HoverCardContext);
+  if (!hoverCard) throw new Error(`HoverCard.${part} must be used within HoverCard.Root`);
+  return hoverCard;
+}
+
+function Root(props: HoverCardRootProps) {
+  const hoverCard = createHoverCard({
+    arrowPadding: () => props.arrowPadding,
+    closeDelay: () => props.closeDelay,
+    collisionBoundary: () => props.collisionBoundary,
+    collisionPadding: () => props.collisionPadding,
+    defaultOpen: props.defaultOpen,
+    fitViewport: () => props.fitViewport,
+    gutter: () => props.gutter,
+    hoverableContent: () => props.hoverableContent,
+    onOpenChange: props.onOpenChange,
+    onOpenChangeComplete: props.onOpenChangeComplete,
+    open: () => props.open,
+    openDelay: () => props.openDelay,
+    placement: () => props.placement,
+    pointerGraceArea: () => props.pointerGraceArea,
+    rootBoundary: () => props.rootBoundary,
+    sameWidth: () => props.sameWidth,
+    sticky: () => props.sticky,
+    strategy: () => props.strategy,
+  });
+
+  return (
+    <OverlayLayerProvider>
+      <HoverCardContext.Provider value={hoverCard}>{props.children}</HoverCardContext.Provider>
+    </OverlayLayerProvider>
+  );
+}
+
+function Trigger(props: HoverCardTriggerProps) {
+  const hoverCard = useHoverCard("Trigger");
+  const [local, others] = splitProps(props, [
+    "as",
+    "children",
+    "onBlur",
+    "onFocus",
+    "onPointerEnter",
+    "onPointerLeave",
+    "ref",
+  ]);
+  const triggerProps = hoverCard.getTriggerProps({
+    ...others,
+    onBlur: local.onBlur,
+    onFocus: local.onFocus,
+    onPointerEnter: local.onPointerEnter,
+    onPointerLeave: local.onPointerLeave,
+    ref: local.ref,
+  }) as Record<string, unknown>;
+
+  if (!local.as) return <a {...triggerProps}>{local.children}</a>;
+  return renderPolymorphic(local.as, "a", { ...triggerProps, children: local.children });
+}
+
+function PortalPart(props: HoverCardPortalProps) {
+  const hoverCard = useHoverCard("Portal");
+  return (
+    <Show when={hoverCard.shouldMount(props.forceMount)}>
+      <Portal mount={props.mount}>{props.children}</Portal>
+    </Show>
+  );
+}
+
+function Positioner(props: HoverCardPositionerProps) {
+  const hoverCard = useHoverCard("Positioner");
+  const [local, others] = splitProps(props, ["children", "ref", "style"]);
+  const positionerProps = hoverCard.getPositionerProps({
+    ...others,
+    ref: local.ref,
+    style: local.style,
+  });
+  return <div {...positionerProps}>{local.children}</div>;
+}
+
+function Content(props: HoverCardContentProps) {
+  const hoverCard = useHoverCard("Content");
+  const [local, others] = splitProps(props, [
+    "children",
+    "onEscapeKeyDown",
+    "onFocusOutside",
+    "onInteractOutside",
+    "onPointerDownOutside",
+    "ref",
+    "style",
+  ]);
+  const contentProps = hoverCard.getContentProps({
+    ...others,
+    onEscapeKeyDown: local.onEscapeKeyDown,
+    onFocusOutside: local.onFocusOutside,
+    onInteractOutside: local.onInteractOutside,
+    onPointerDownOutside: local.onPointerDownOutside,
+    ref: local.ref,
+    style: local.style,
+  });
+  return <div {...contentProps}>{local.children}</div>;
+}
+
+export const HoverCard = {
+  Root,
+  Trigger,
+  Portal: PortalPart,
+  Positioner,
+  Content,
+};
+
+function createHoverCardInteraction(options: {
+  close: (event: Event | undefined, reason: HoverCardOpenChangeDetail["reason"]) => void;
+  closeDelay: Accessor<number>;
+  contentElement: Accessor<HTMLElement | undefined>;
+  hoverableContent: Accessor<boolean>;
+  open: Accessor<boolean>;
+  openCard: (event: Event | undefined, reason: HoverCardOpenChangeDetail["reason"]) => void;
+  openDelay: Accessor<number>;
+  pointerGraceArea: Accessor<number>;
+  triggerElement: Accessor<HTMLElement | undefined>;
+}) {
+  let openTimeout: ReturnType<typeof setTimeout> | undefined;
+  let closeTimeout: ReturnType<typeof setTimeout> | undefined;
+  let safeHoverCleanup: (() => void) | undefined;
+
+  const clearOpenTimer = () => {
+    if (openTimeout) {
+      clearTimeout(openTimeout);
+      openTimeout = undefined;
+    }
+  };
+  const clearCloseTimer = () => {
+    if (closeTimeout) {
+      clearTimeout(closeTimeout);
+      closeTimeout = undefined;
+    }
+  };
+  const clearSafeHover = () => {
+    safeHoverCleanup?.();
+    safeHoverCleanup = undefined;
+  };
+  const scheduleOpen = (event: Event, reason: HoverCardOpenChangeDetail["reason"]) => {
+    clearCloseTimer();
+    clearSafeHover();
+
+    const delay = options.openDelay();
+
+    if (delay <= 0) {
+      options.openCard(event, reason);
+      return;
+    }
+
+    clearOpenTimer();
+    openTimeout = setTimeout(() => {
+      openTimeout = undefined;
+      options.openCard(event, reason);
+    }, delay);
+  };
+  const scheduleClose = (event: Event, reason: HoverCardOpenChangeDetail["reason"]) => {
+    clearOpenTimer();
+    clearSafeHover();
+
+    const delay = options.closeDelay();
+
+    if (delay <= 0) {
+      options.close(event, reason);
+      return;
+    }
+
+    clearCloseTimer();
+    closeTimeout = setTimeout(() => {
+      closeTimeout = undefined;
+      options.close(event, reason);
+    }, delay);
+  };
+  const scheduleSafePointerClose = (
+    event: PointerEvent,
+    reason: HoverCardOpenChangeDetail["reason"],
+  ) => {
+    const trigger = options.triggerElement();
+    const content = options.contentElement();
+
+    if (!options.hoverableContent() || !options.open() || !trigger || !content) {
+      scheduleClose(event, reason);
+      return;
+    }
+
+    const area = createPointerGraceArea(event, trigger, content, options.pointerGraceArea());
+
+    if (!area) {
+      scheduleClose(event, reason);
+      return;
+    }
+
+    clearOpenTimer();
+    clearCloseTimer();
+    clearSafeHover();
+
+    const onPointerMove = (moveEvent: PointerEvent) => {
+      if (content.contains(moveEvent.target as Node)) {
+        clearSafeHover();
+        return;
+      }
+
+      if (!isPointInPolygon({ x: moveEvent.clientX, y: moveEvent.clientY }, area)) {
+        clearSafeHover();
+        scheduleClose(moveEvent, reason);
+      }
+    };
+
+    document.addEventListener("pointermove", onPointerMove);
+    safeHoverCleanup = () => document.removeEventListener("pointermove", onPointerMove);
+  };
+
+  onCleanup(() => {
+    clearOpenTimer();
+    clearCloseTimer();
+    clearSafeHover();
+  });
+
+  return {
+    getContentProps: <T extends HTMLElement>(props: JSX.HTMLAttributes<T>) => ({
+      ...props,
+      onPointerEnter: composeEventHandlers<PointerEvent>(props.onPointerEnter, () => {
+        if (!options.hoverableContent()) {
+          return;
+        }
+
+        clearOpenTimer();
+        clearCloseTimer();
+        clearSafeHover();
+      }),
+      onPointerLeave: composeEventHandlers<PointerEvent>(props.onPointerLeave, (event) => {
+        if (!options.hoverableContent()) {
+          return;
+        }
+
+        scheduleClose(event, "pointer");
+      }),
+    }),
+    getTriggerProps: <T extends HTMLElement>(props: JSX.HTMLAttributes<T>) => ({
+      ...props,
+      onBlur: composeEventHandlers<FocusEvent>(props.onBlur, (event) => {
+        scheduleClose(event, "focus");
+      }),
+      onFocus: composeEventHandlers<FocusEvent>(props.onFocus, (event) => {
+        scheduleOpen(event, "focus");
+      }),
+      onPointerEnter: composeEventHandlers<PointerEvent>(props.onPointerEnter, (event) => {
+        if (event.pointerType === "touch") {
+          return;
+        }
+
+        scheduleOpen(event, "pointer");
+      }),
+      onPointerLeave: composeEventHandlers<PointerEvent>(props.onPointerLeave, (event) => {
+        if (event.pointerType === "touch") {
+          return;
+        }
+
+        scheduleSafePointerClose(event, "pointer");
+      }),
+    }),
+  };
+}
+
+type Point = {
+  x: number;
+  y: number;
+};
+
+function createPointerGraceArea(
+  event: PointerEvent,
+  trigger: HTMLElement,
+  content: HTMLElement,
+  padding: number,
+): readonly Point[] | undefined {
+  const triggerRect = trigger.getBoundingClientRect();
+  const contentRect = content.getBoundingClientRect();
+
+  if (contentRect.width === 0 || contentRect.height === 0) {
+    return undefined;
+  }
+
+  const pointer = { x: event.clientX, y: event.clientY };
+  const paddedContent = {
+    bottom: contentRect.bottom + padding,
+    left: contentRect.left - padding,
+    right: contentRect.right + padding,
+    top: contentRect.top - padding,
+  };
+
+  if (contentRect.left >= triggerRect.right) {
+    return [
+      pointer,
+      { x: paddedContent.right, y: paddedContent.top },
+      { x: paddedContent.right, y: paddedContent.bottom },
+    ];
+  }
+
+  if (contentRect.right <= triggerRect.left) {
+    return [
+      pointer,
+      { x: paddedContent.left, y: paddedContent.bottom },
+      { x: paddedContent.left, y: paddedContent.top },
+    ];
+  }
+
+  if (contentRect.top >= triggerRect.bottom) {
+    return [
+      pointer,
+      { x: paddedContent.left, y: paddedContent.bottom },
+      { x: paddedContent.right, y: paddedContent.bottom },
+    ];
+  }
+
+  return [
+    pointer,
+    { x: paddedContent.right, y: paddedContent.top },
+    { x: paddedContent.left, y: paddedContent.top },
+  ];
+}
+
+function isPointInPolygon(point: Point, polygon: readonly Point[]): boolean {
+  let inside = false;
+
+  for (
+    let index = 0, previousIndex = polygon.length - 1;
+    index < polygon.length;
+    previousIndex = index++
+  ) {
+    const current = polygon[index];
+    const previous = polygon[previousIndex];
+
+    if (!current || !previous) {
+      continue;
+    }
+
+    const intersects =
+      current.y > point.y !== previous.y > point.y &&
+      point.x <
+        ((previous.x - current.x) * (point.y - current.y)) / (previous.y - current.y) + current.x;
+
+    if (intersects) {
+      inside = !inside;
+    }
+  }
+
+  return inside;
+}

--- a/packages/keystone/src/index.ts
+++ b/packages/keystone/src/index.ts
@@ -1,9 +1,55 @@
+export { Accordion, createAccordion } from "./accordion/index";
+export { Autocomplete, createAutocomplete } from "./autocomplete/index";
+export { Collapsible, createCollapsible } from "./collapsible/index";
+export { Combobox, createCombobox } from "./combobox/index";
 export { ContextMenu, createContextMenu } from "./context-menu/index";
 export { Dialog, createDialog } from "./dialog/index";
 export { DropdownMenu, createDropdownMenu } from "./dropdown-menu/index";
 export { createFieldValidity, createFormControl } from "./form/index";
+export { HoverCard, createHoverCard } from "./hover-card/index";
 export { Menu, createMenu } from "./menu/index";
 export { Menubar, createMenubar } from "./menubar/index";
+export type {
+  AccordionContentProps,
+  AccordionHeaderProps,
+  AccordionItemProps,
+  AccordionOrientation,
+  AccordionPartProps,
+  AccordionRootProps,
+  AccordionTriggerProps,
+  AccordionValue,
+  AccordionValueChangeDetail,
+} from "./accordion/index";
+export type {
+  CollapsibleApi,
+  CollapsibleContentProps,
+  CollapsibleOpenChangeDetail,
+  CollapsiblePartProps,
+  CollapsibleRootProps,
+  CollapsibleTriggerProps,
+  CreateCollapsibleOptions,
+} from "./collapsible/index";
+export type {
+  ComboboxApi,
+  ComboboxChangeDetail,
+  ComboboxClearProps,
+  ComboboxContentProps,
+  ComboboxGroupLabelProps,
+  ComboboxGroupProps,
+  ComboboxInputProps,
+  ComboboxItemData,
+  ComboboxItemIndicatorProps,
+  ComboboxItemProps,
+  ComboboxItemTextProps,
+  ComboboxListboxProps,
+  ComboboxOpenChangeDetail,
+  ComboboxPartProps,
+  ComboboxPortalProps,
+  ComboboxPositionerProps,
+  ComboboxRootProps,
+  ComboboxTriggerProps,
+  CreateComboboxOptions,
+} from "./combobox/index";
 export type {
   DialogChangeDetail,
   DialogCloseProps,
@@ -27,6 +73,16 @@ export type {
   FormControlApi,
   FormControlValue,
 } from "./form/index";
+export type {
+  CreateHoverCardOptions,
+  HoverCardContentProps,
+  HoverCardOpenChangeDetail,
+  HoverCardPartProps,
+  HoverCardPortalProps,
+  HoverCardPositionerProps,
+  HoverCardRootProps,
+  HoverCardTriggerProps,
+} from "./hover-card/index";
 export type {
   CreateMenuOptions,
   MenuApi,
@@ -95,6 +151,25 @@ export type {
   SheetTitleProps,
   SheetTriggerProps,
 } from "./sheet/index";
+export { Toast, createToastManager, toaster } from "./toast/index";
+export type {
+  CreateToastManagerOptions,
+  ToastAction,
+  ToastActionProps,
+  ToastCloseProps,
+  ToastData,
+  ToastDescriptionProps,
+  ToastInput,
+  ToastManager,
+  ToastPartProps,
+  ToastPriority,
+  ToastProviderProps,
+  ToastRootProps,
+  ToastStatus,
+  ToastTitleProps,
+  ToastType,
+  ToastViewportProps,
+} from "./toast/index";
 export { Tooltip, createTooltip } from "./tooltip/index";
 export type {
   CreateTooltipOptions,

--- a/packages/keystone/src/menu/index.tsx
+++ b/packages/keystone/src/menu/index.tsx
@@ -3,10 +3,12 @@ import {
   createContext,
   createMemo,
   createSignal,
+  onCleanup,
   splitProps,
   useContext,
   type JSX,
 } from "solid-js";
+import { focusWithoutScrolling } from "../overlay/dom";
 import { Portal } from "solid-js/web";
 import type { CollectionItem } from "../listbox/collection-registry";
 import { createListInteractionKernel } from "../listbox/interaction-kernel";
@@ -24,7 +26,7 @@ import {
 import { createOverlayController } from "../overlay/controller";
 import {
   composeEventHandlers,
-  createControllableBooleanSignal,
+  createControllableSignal,
   dataBoolean,
   renderPolymorphic,
   type PolymorphicProps,
@@ -41,13 +43,15 @@ export type MenuSelectDetail = {
 };
 
 export type MenuItemData = CollectionItem & {
-  checked?: boolean;
+  checked?: boolean | "indeterminate";
+  closeOnSelect?: boolean;
   type: "item" | "checkbox" | "radio";
 };
 
 export type MenuRootProps = {
   children?: JSX.Element;
   arrowPadding?: number;
+  closeOnSelect?: boolean;
   collisionBoundary?: FloatingCollisionBoundary;
   collisionPadding?: number;
   defaultOpen?: boolean;
@@ -87,7 +91,9 @@ export type MenuContentProps = MenuPartProps<HTMLDivElement> &
     onEscapeKeyDown?: (event: KeyboardEvent) => void;
     onFocusOutside?: (event: OverlayLayerOutsideEvent) => void;
     onInteractOutside?: (event: OverlayLayerOutsideEvent) => void;
+    onMountAutoFocus?: (event: Event) => void;
     onPointerDownOutside?: (event: OverlayLayerOutsideEvent) => void;
+    onUnmountAutoFocus?: (event: Event) => void;
   };
 export type MenuGroupProps = MenuPartProps<HTMLDivElement> &
   Omit<JSX.HTMLAttributes<HTMLDivElement>, "children" | "ref">;
@@ -97,14 +103,17 @@ export type MenuSeparatorProps = MenuPartProps<HTMLDivElement> &
   Omit<JSX.HTMLAttributes<HTMLDivElement>, "children" | "ref">;
 export type MenuItemProps = MenuPartProps<HTMLDivElement> &
   Omit<JSX.HTMLAttributes<HTMLDivElement>, "children" | "ref" | "onSelect" | "role"> & {
+    closeOnSelect?: boolean;
+    description?: string;
     disabled?: boolean;
     label?: string;
     onSelect?: (detail: MenuSelectDetail) => void;
+    textValue?: string;
     value: string;
   };
 export type MenuCheckboxItemProps = MenuItemProps & {
-  checked?: boolean;
-  defaultChecked?: boolean;
+  checked?: boolean | "indeterminate";
+  defaultChecked?: boolean | "indeterminate";
   onCheckedChange?: (checked: boolean, detail: MenuSelectDetail) => void;
 };
 export type MenuRadioGroupProps = {
@@ -117,6 +126,7 @@ export type MenuRadioItemProps = MenuItemProps;
 
 export type CreateMenuOptions = {
   arrowPadding?: () => number | undefined;
+  closeOnSelect?: () => boolean | undefined;
   collisionBoundary?: () => FloatingCollisionBoundary | undefined;
   collisionPadding?: () => number | undefined;
   defaultOpen?: boolean;
@@ -136,7 +146,11 @@ export type CreateMenuOptions = {
 
 export type MenuApi = {
   close: (event: Event | undefined, reason: MenuOpenChangeDetail["reason"]) => void;
+  closeOnSelect: () => boolean;
+  closeSubmenus: (except?: string) => void;
   contentId: string;
+  contentElement: () => HTMLElement | undefined;
+  focusTrigger: () => void;
   floating: FloatingAdapter;
   getContentProps: (props: Omit<MenuContentProps, "children">) => Record<string, unknown>;
   getGroupLabelProps: (props: Omit<MenuGroupLabelProps, "children">) => Record<string, unknown>;
@@ -146,7 +160,7 @@ export type MenuApi = {
   ) => Record<string, unknown>;
   getItemProps: (
     props: Omit<MenuItemProps, "children" | "label"> & {
-      checked?: boolean;
+      checked?: boolean | "indeterminate";
       label: string;
       role?: "menuitem" | "menuitemcheckbox" | "menuitemradio";
       type?: MenuItemData["type"];
@@ -159,8 +173,14 @@ export type MenuApi = {
   itemId: (value: string) => string;
   open: () => boolean;
   rootRole: () => "menu" | "menubar";
+  registerSubmenu: (submenu: SubmenuRegistration) => () => void;
   scope: string;
+  setOpen: (open: boolean, detail: MenuOpenChangeDetail) => void;
+  setVirtualAnchor: (
+    anchor: { contextElement?: Element; getBoundingClientRect: () => DOMRect } | undefined,
+  ) => void;
   shouldMount: (forceMount?: boolean) => boolean;
+  triggerElement: () => HTMLElement | undefined;
 };
 
 type MenuFactoryOptions = {
@@ -175,8 +195,68 @@ type RadioGroupContextValue = {
   setValue: (value: string, detail: MenuSelectDetail) => void;
 };
 
+type SubmenuRegistration = {
+  close: () => void;
+  id: string;
+};
+
+type SubmenuContextValue = {
+  child: MenuApi;
+  parent: MenuApi;
+};
+
+type MenuItemContextValue = {
+  descriptionId: string;
+  labelId: string;
+};
+
 const MenuContext = createContext<MenuContextValue>();
 const RadioGroupContext = createContext<RadioGroupContextValue>();
+const SubmenuContext = createContext<SubmenuContextValue>();
+const MenuItemContext = createContext<MenuItemContextValue>();
+
+const contextMenuLongPressStart = { x: 0, y: 0 };
+let contextMenuLongPressTimeout: ReturnType<typeof setTimeout> | undefined;
+
+function createPointAnchor(x: number, y: number, contextElement?: Element) {
+  return {
+    contextElement,
+    getBoundingClientRect: () =>
+      ({
+        bottom: y,
+        height: 0,
+        left: x,
+        right: x,
+        top: y,
+        width: 0,
+        x,
+        y,
+        toJSON: () => undefined,
+      }) as DOMRect,
+  };
+}
+
+function clearContextMenuLongPress() {
+  if (contextMenuLongPressTimeout !== undefined) {
+    clearTimeout(contextMenuLongPressTimeout);
+    contextMenuLongPressTimeout = undefined;
+  }
+}
+
+function scheduleContextMenuLongPress(
+  event: PointerEvent,
+  menu: Pick<MenuApi, "setOpen" | "setVirtualAnchor">,
+) {
+  clearContextMenuLongPress();
+  contextMenuLongPressStart.x = event.clientX;
+  contextMenuLongPressStart.y = event.clientY;
+  const target = event.currentTarget as Element | null;
+
+  contextMenuLongPressTimeout = setTimeout(() => {
+    menu.setVirtualAnchor(createPointAnchor(event.clientX, event.clientY, target ?? undefined));
+    menu.setOpen(true, { event, reason: "trigger" });
+  }, 700);
+}
 
 export function createMenu(options: CreateMenuOptions = {}): MenuApi {
   return createScopedMenu({ ...options, scope: options.scope ?? "menu" }, "menu");
@@ -218,10 +298,16 @@ function createScopedMenu(options: CreateMenuOptions, rootRole: "menu" | "menuba
   });
   const floating = overlay.floating as FloatingAdapter;
   const itemId = (value: string) => `${overlay.contentId}-${value}`;
+  const itemLabelId = (value: string) => `${itemId(value)}-label`;
+  const itemDescriptionId = (value: string) => `${itemId(value)}-description`;
+  const closeOnSelect = () => options.closeOnSelect?.() ?? true;
+  const submenuRegistrations = new Map<string, SubmenuRegistration>();
   const list = createListInteractionKernel<MenuItemData, MenuSelectDetail>({
     loop: true,
     onValueSelect: (item, detail) => {
-      if (item.type === "item") {
+      const shouldClose = item.closeOnSelect ?? (item.type === "item" ? closeOnSelect() : false);
+
+      if (shouldClose) {
         overlay.close(detail.event, detail.reason === "keyboard" ? "keyboard" : "item");
       }
     },
@@ -246,7 +332,22 @@ function createScopedMenu(options: CreateMenuOptions, rootRole: "menu" | "menuba
 
   return {
     close: overlay.close,
+    closeOnSelect,
+    closeSubmenus: (except) => {
+      for (const submenu of submenuRegistrations.values()) {
+        if (submenu.id !== except) {
+          submenu.close();
+        }
+      }
+    },
+    contentElement: overlay.contentElement,
     contentId: overlay.contentId,
+    focusTrigger: () => {
+      const trigger = overlay.triggerElement();
+      if (trigger) {
+        focusWithoutScrolling(trigger);
+      }
+    },
     floating,
     getContentProps: (props) => {
       const [local, others] = splitProps(props, [
@@ -254,7 +355,9 @@ function createScopedMenu(options: CreateMenuOptions, rootRole: "menu" | "menuba
         "onFocusOutside",
         "onInteractOutside",
         "onKeyDown",
+        "onMountAutoFocus",
         "onPointerDownOutside",
+        "onUnmountAutoFocus",
         "ref",
         "style",
       ]);
@@ -263,12 +366,16 @@ function createScopedMenu(options: CreateMenuOptions, rootRole: "menu" | "menuba
           onEscapeKeyDown: local.onEscapeKeyDown,
           onFocusOutside: local.onFocusOutside,
           onInteractOutside: local.onInteractOutside,
+          onMountAutoFocus: local.onMountAutoFocus,
           onPointerDownOutside: local.onPointerDownOutside,
+          onUnmountAutoFocus: local.onUnmountAutoFocus,
         },
         {
           containsTrigger: true,
           modal: overlay.modal,
           disableOutsidePointerEvents: overlay.modal,
+          restoreFocus: () => true,
+          trapFocus: overlay.modal,
           dismissReason: (event) => (event.type === "keydown" ? "escape" : "outside"),
         },
       );
@@ -292,6 +399,21 @@ function createScopedMenu(options: CreateMenuOptions, rootRole: "menu" | "menuba
           if (event.key === "Escape") {
             event.preventDefault();
             overlay.close(event, "escape");
+            queueMicrotask(() => {
+              if (!overlay.open()) {
+                return;
+              }
+
+              const trigger = overlay.triggerElement();
+              if (trigger) {
+                focusWithoutScrolling(trigger);
+              }
+            });
+            return;
+          }
+
+          if (event.key === "Tab") {
+            event.preventDefault();
             return;
           }
 
@@ -320,19 +442,28 @@ function createScopedMenu(options: CreateMenuOptions, rootRole: "menu" | "menuba
     getItemProps: (props) => {
       const [local, others] = splitProps(props, [
         "checked",
+        "closeOnSelect",
+        "description",
         "disabled",
         "label",
         "onClick",
         "onPointerMove",
         "onSelect",
         "role",
+        "textValue",
         "type",
         "value",
       ]);
+      const isCheckedItem = local.role === "menuitemcheckbox" || local.role === "menuitemradio";
+      const checked = local.checked === "indeterminate" ? "mixed" : Boolean(local.checked);
+      const itemRole = local.role ?? "menuitem";
+      const itemCloseOnSelect =
+        local.closeOnSelect ?? (itemRole === "menuitem" ? closeOnSelect() : false);
       list.registerItem({
         checked: local.checked,
+        closeOnSelect: itemCloseOnSelect,
         disabled: local.disabled,
-        label: local.label,
+        label: local.textValue ?? local.label,
         type: local.type ?? "item",
         value: local.value,
       });
@@ -340,19 +471,21 @@ function createScopedMenu(options: CreateMenuOptions, rootRole: "menu" | "menuba
       return {
         ...others,
         id: itemId(local.value),
-        role: local.role ?? "menuitem",
+        role: itemRole,
         "aria-disabled": local.disabled ? "true" : undefined,
-        "aria-checked":
-          local.role === "menuitemcheckbox" || local.role === "menuitemradio"
-            ? Boolean(local.checked)
-            : undefined,
+        "aria-checked": isCheckedItem ? checked : undefined,
+        "aria-labelledby": itemLabelId(local.value),
+        "aria-describedby": local.description ? itemDescriptionId(local.value) : undefined,
         ...partProps("item"),
         "data-disabled": dataBoolean(local.disabled),
         get "data-highlighted"() {
           return dataBoolean(list.isHighlighted(local.value));
         },
         get "data-checked"() {
-          return dataBoolean(local.checked);
+          return dataBoolean(local.checked === true);
+        },
+        get "data-indeterminate"() {
+          return dataBoolean(local.checked === "indeterminate");
         },
         "data-value": local.value,
         onPointerMove: composeEventHandlers<PointerEvent>(local.onPointerMove, () => {
@@ -370,7 +503,7 @@ function createScopedMenu(options: CreateMenuOptions, rootRole: "menu" | "menuba
           local.onSelect?.(detail);
           list.selectValue(local.value, detail);
 
-          if (local.role === "menuitem") {
+          if (itemCloseOnSelect) {
             overlay.close(event, "item");
           }
         }),
@@ -392,7 +525,31 @@ function createScopedMenu(options: CreateMenuOptions, rootRole: "menu" | "menuba
               ...props,
               onContextMenu: composeEventHandlers<MouseEvent>(props.onContextMenu, (event) => {
                 event.preventDefault();
+                overlay.setVirtualAnchor(
+                  createPointAnchor(event.clientX, event.clientY, event.currentTarget as Element),
+                );
                 overlay.setOpen(true, { event, reason: "trigger" });
+              }),
+              onPointerCancel: composeEventHandlers<PointerEvent>(props.onPointerCancel, () => {
+                clearContextMenuLongPress();
+              }),
+              onPointerDown: composeEventHandlers<PointerEvent>(props.onPointerDown, (event) => {
+                if (event.pointerType !== "touch" && event.pointerType !== "pen") {
+                  return;
+                }
+
+                scheduleContextMenuLongPress(event, overlay);
+              }),
+              onPointerMove: composeEventHandlers<PointerEvent>(props.onPointerMove, (event) => {
+                if (
+                  Math.abs(event.clientX - contextMenuLongPressStart.x) > 8 ||
+                  Math.abs(event.clientY - contextMenuLongPressStart.y) > 8
+                ) {
+                  clearContextMenuLongPress();
+                }
+              }),
+              onPointerUp: composeEventHandlers<PointerEvent>(props.onPointerUp, () => {
+                clearContextMenuLongPress();
               }),
             }
           : props,
@@ -405,9 +562,19 @@ function createScopedMenu(options: CreateMenuOptions, rootRole: "menu" | "menuba
     highlightedValue: list.highlightedValue,
     itemId,
     open: overlay.open,
+    registerSubmenu: (submenu) => {
+      submenuRegistrations.set(submenu.id, submenu);
+
+      return () => {
+        submenuRegistrations.delete(submenu.id);
+      };
+    },
     rootRole: () => rootRole,
     scope,
+    setOpen: overlay.setOpen,
+    setVirtualAnchor: overlay.setVirtualAnchor,
     shouldMount: overlay.shouldMount,
+    triggerElement: overlay.triggerElement,
   };
 }
 
@@ -422,6 +589,7 @@ function createMenuNamespace(factoryOptions: MenuFactoryOptions) {
     const menu = createScopedMenu(
       {
         arrowPadding: () => props.arrowPadding,
+        closeOnSelect: () => props.closeOnSelect,
         collisionBoundary: () => props.collisionBoundary,
         collisionPadding: () => props.collisionPadding,
         defaultOpen: props.defaultOpen,
@@ -490,7 +658,9 @@ function createMenuNamespace(factoryOptions: MenuFactoryOptions) {
       "onFocusOutside",
       "onInteractOutside",
       "onKeyDown",
+      "onMountAutoFocus",
       "onPointerDownOutside",
+      "onUnmountAutoFocus",
       "ref",
       "style",
     ]);
@@ -503,7 +673,9 @@ function createMenuNamespace(factoryOptions: MenuFactoryOptions) {
           onFocusOutside: local.onFocusOutside,
           onInteractOutside: local.onInteractOutside,
           onKeyDown: local.onKeyDown,
+          onMountAutoFocus: local.onMountAutoFocus,
           onPointerDownOutside: local.onPointerDownOutside,
+          onUnmountAutoFocus: local.onUnmountAutoFocus,
           ref: local.ref,
           style: local.style,
         })}
@@ -535,29 +707,44 @@ function createMenuNamespace(factoryOptions: MenuFactoryOptions) {
     const menu = useMenu("Item");
     const [local, others] = splitProps(props, [
       "children",
+      "closeOnSelect",
+      "description",
       "disabled",
       "label",
       "onClick",
       "onPointerMove",
       "onSelect",
+      "textValue",
       "value",
     ]);
-    const label = () => local.label ?? String(local.children ?? local.value);
+    const label = () => local.textValue ?? local.label ?? String(local.children ?? local.value);
+    const itemContext = createMemo(
+      () =>
+        ({
+          descriptionId: menu.itemId(local.value) + "-description",
+          labelId: menu.itemId(local.value) + "-label",
+        }) satisfies MenuItemContextValue,
+    );
 
     return (
-      <div
-        {...menu.getItemProps({
-          ...others,
-          disabled: local.disabled,
-          label: label(),
-          onClick: local.onClick,
-          onPointerMove: local.onPointerMove,
-          onSelect: local.onSelect,
-          value: local.value,
-        })}
-      >
-        {local.children}
-      </div>
+      <MenuItemContext.Provider value={itemContext()}>
+        <div
+          {...menu.getItemProps({
+            ...others,
+            closeOnSelect: local.closeOnSelect,
+            description: local.description,
+            disabled: local.disabled,
+            label: label(),
+            onClick: local.onClick,
+            onPointerMove: local.onPointerMove,
+            onSelect: local.onSelect,
+            textValue: local.textValue,
+            value: local.value,
+          })}
+        >
+          {local.children}
+        </div>
+      </MenuItemContext.Provider>
     );
   }
 
@@ -566,43 +753,58 @@ function createMenuNamespace(factoryOptions: MenuFactoryOptions) {
     const [local, others] = splitProps(props, [
       "checked",
       "children",
+      "closeOnSelect",
       "defaultChecked",
+      "description",
       "disabled",
       "label",
       "onCheckedChange",
       "onClick",
       "onPointerMove",
       "onSelect",
+      "textValue",
       "value",
     ]);
-    const [checked, setChecked] = createControllableBooleanSignal({
+    const [checked, setChecked] = createControllableSignal<boolean | "indeterminate">({
       value: () => local.checked,
       defaultValue: local.defaultChecked ?? false,
     });
-    const label = () => local.label ?? String(local.children ?? local.value);
+    const label = () => local.textValue ?? local.label ?? String(local.children ?? local.value);
+    const itemContext = createMemo(
+      () =>
+        ({
+          descriptionId: menu.itemId(local.value) + "-description",
+          labelId: menu.itemId(local.value) + "-label",
+        }) satisfies MenuItemContextValue,
+    );
 
     return (
-      <div
-        {...menu.getItemProps({
-          ...others,
-          checked: checked(),
-          disabled: local.disabled,
-          label: label(),
-          onClick: composeEventHandlers<MouseEvent>(local.onClick, (event) => {
-            const detail: MenuSelectDetail = { event, reason: "item" };
-            const next = !checked();
-            setChecked(next);
-            local.onCheckedChange?.(next, detail);
-          }),
-          onPointerMove: local.onPointerMove,
-          onSelect: local.onSelect,
-          role: "menuitemcheckbox",
-          type: "checkbox",
-          value: local.value,
-        })}
-      >
-        {local.children}
-      </div>
+      <MenuItemContext.Provider value={itemContext()}>
+        <div
+          {...menu.getItemProps({
+            ...others,
+            checked: checked(),
+            closeOnSelect: local.closeOnSelect,
+            description: local.description,
+            disabled: local.disabled,
+            label: label(),
+            onClick: composeEventHandlers<MouseEvent>(local.onClick, (event) => {
+              const detail: MenuSelectDetail = { event, reason: "item" };
+              const next = checked() === true ? false : true;
+              setChecked(next);
+              local.onCheckedChange?.(next, detail);
+            }),
+            onPointerMove: local.onPointerMove,
+            onSelect: local.onSelect,
+            role: "menuitemcheckbox",
+            textValue: local.textValue,
+            type: "checkbox",
+            value: local.value,
+          })}
+        >
+          {local.children}
+        </div>
+      </MenuItemContext.Provider>
     );
   }
 
@@ -627,35 +829,50 @@ function createMenuNamespace(factoryOptions: MenuFactoryOptions) {
     const group = useContext(RadioGroupContext);
     const [local, others] = splitProps(props, [
       "children",
+      "closeOnSelect",
+      "description",
       "disabled",
       "label",
       "onClick",
       "onPointerMove",
       "onSelect",
+      "textValue",
       "value",
     ]);
     const checked = () => group?.isChecked(local.value) ?? false;
-    const label = () => local.label ?? String(local.children ?? local.value);
+    const label = () => local.textValue ?? local.label ?? String(local.children ?? local.value);
+    const itemContext = createMemo(
+      () =>
+        ({
+          descriptionId: menu.itemId(local.value) + "-description",
+          labelId: menu.itemId(local.value) + "-label",
+        }) satisfies MenuItemContextValue,
+    );
 
     return (
-      <div
-        {...menu.getItemProps({
-          ...others,
-          checked: checked(),
-          disabled: local.disabled,
-          label: label(),
-          onClick: composeEventHandlers<MouseEvent>(local.onClick, (event) => {
-            group?.setValue(local.value, { event, reason: "item" });
-          }),
-          onPointerMove: local.onPointerMove,
-          onSelect: local.onSelect,
-          role: "menuitemradio",
-          type: "radio",
-          value: local.value,
-        })}
-      >
-        {local.children}
-      </div>
+      <MenuItemContext.Provider value={itemContext()}>
+        <div
+          {...menu.getItemProps({
+            ...others,
+            checked: checked(),
+            closeOnSelect: local.closeOnSelect,
+            description: local.description,
+            disabled: local.disabled,
+            label: label(),
+            onClick: composeEventHandlers<MouseEvent>(local.onClick, (event) => {
+              group?.setValue(local.value, { event, reason: "item" });
+            }),
+            onPointerMove: local.onPointerMove,
+            onSelect: local.onSelect,
+            role: "menuitemradio",
+            textValue: local.textValue,
+            type: "radio",
+            value: local.value,
+          })}
+        >
+          {local.children}
+        </div>
+      </MenuItemContext.Provider>
     );
   }
 
@@ -665,16 +882,173 @@ function createMenuNamespace(factoryOptions: MenuFactoryOptions) {
     return <span {...menu.getItemIndicatorProps(others)}>{local.children}</span>;
   }
 
+  function ItemLabel(props: MenuPartProps<HTMLSpanElement>) {
+    const item = useContext(MenuItemContext);
+    const menu = useMenu("ItemLabel");
+    const [local, others] = splitProps(props, ["children"]);
+
+    return (
+      <span id={item?.labelId} {...others} data-scope={menu.scope} data-part="item-label">
+        {local.children}
+      </span>
+    );
+  }
+
+  function ItemDescription(props: MenuPartProps<HTMLSpanElement>) {
+    const item = useContext(MenuItemContext);
+    const menu = useMenu("ItemDescription");
+    const [local, others] = splitProps(props, ["children"]);
+
+    return (
+      <span
+        id={item?.descriptionId}
+        {...others}
+        data-scope={menu.scope}
+        data-part="item-description"
+      >
+        {local.children}
+      </span>
+    );
+  }
+
   function SubRoot(props: MenuRootProps) {
-    return <Root {...props} />;
+    const parent = useMenu("SubRoot");
+    const child = createScopedMenu(
+      {
+        arrowPadding: () => props.arrowPadding,
+        closeOnSelect: () => props.closeOnSelect ?? parent.closeOnSelect(),
+        collisionBoundary: () => props.collisionBoundary,
+        collisionPadding: () => props.collisionPadding,
+        defaultOpen: props.defaultOpen,
+        fitViewport: () => props.fitViewport,
+        gutter: () => props.gutter,
+        modal: () => false,
+        onOpenChange: props.onOpenChange,
+        onOpenChangeComplete: props.onOpenChangeComplete,
+        open: () => props.open,
+        placement: () => props.placement ?? "right-start",
+        rootBoundary: () => props.rootBoundary,
+        sameWidth: () => props.sameWidth ?? false,
+        scope: factoryOptions.scope,
+        sticky: () => props.sticky,
+        strategy: () => props.strategy,
+      },
+      "menu",
+    );
+    const unregister = parent.registerSubmenu({
+      id: child.contentId,
+      close: () => child.close(undefined, "programmatic"),
+    });
+    onCleanup(unregister);
+
+    return (
+      <SubmenuContext.Provider value={{ child, parent }}>
+        <MenuContext.Provider value={child}>{props.children}</MenuContext.Provider>
+      </SubmenuContext.Provider>
+    );
   }
 
   function SubTrigger(props: MenuTriggerProps) {
-    return <Trigger {...props} />;
+    const submenu = useContext(SubmenuContext);
+
+    if (!submenu) {
+      return <Trigger {...props} />;
+    }
+
+    const [local, others] = splitProps(props, [
+      "as",
+      "children",
+      "disabled",
+      "onClick",
+      "onKeyDown",
+      "onPointerEnter",
+      "onPointerLeave",
+      "onPointerMove",
+      "ref",
+    ]);
+    const value = submenu.child.contentId;
+    const label = () => String(local.children ?? value);
+    let closeTimer: ReturnType<typeof setTimeout> | undefined;
+    const clearCloseTimer = () => {
+      if (closeTimer !== undefined) {
+        clearTimeout(closeTimer);
+        closeTimer = undefined;
+      }
+    };
+    const scheduleClose = () => {
+      clearCloseTimer();
+      closeTimer = setTimeout(() => submenu.child.close(undefined, "programmatic"), 180);
+    };
+    onCleanup(clearCloseTimer);
+
+    const triggerProps = submenu.parent.getItemProps({
+      ...(others as Record<string, unknown>),
+      closeOnSelect: false,
+      disabled: local.disabled,
+      label: label(),
+      onClick: composeEventHandlers<MouseEvent>(local.onClick, (event) => {
+        submenu.parent.closeSubmenus(submenu.child.contentId);
+        submenu.child.setOpen(true, { event, reason: "trigger" });
+      }),
+      onKeyDown: composeEventHandlers<KeyboardEvent>(local.onKeyDown, (event) => {
+        if (event.key === "ArrowRight") {
+          event.preventDefault();
+          submenu.parent.closeSubmenus(submenu.child.contentId);
+          submenu.child.setOpen(true, { event, reason: "keyboard" });
+          queueMicrotask(() => {
+            focusWithoutScrolling(
+              submenu.child.contentElement() ?? submenu.child.triggerElement() ?? document.body,
+            );
+          });
+        }
+      }),
+      onPointerEnter: composeEventHandlers<PointerEvent>(local.onPointerEnter, clearCloseTimer),
+      onPointerLeave: composeEventHandlers<PointerEvent>(local.onPointerLeave, scheduleClose),
+      onPointerMove: composeEventHandlers<PointerEvent>(local.onPointerMove, (event) => {
+        submenu.parent.closeSubmenus(submenu.child.contentId);
+        submenu.child.setOpen(true, { event, reason: "trigger" });
+      }),
+      ref: local.ref as HTMLDivElement | ((element: HTMLDivElement) => void) | undefined,
+      role: "menuitem",
+      value,
+    } as Omit<MenuItemProps, "children" | "label"> & { label: string }) as Record<string, unknown>;
+    const mergedProps = {
+      ...triggerProps,
+      "aria-controls": submenu.child.contentId,
+      get "aria-expanded"() {
+        return submenu.child.open();
+      },
+      "aria-haspopup": "menu" as const,
+      "data-scope": submenu.parent.scope,
+      "data-part": "sub-trigger",
+    };
+
+    if (!local.as) return <div {...mergedProps}>{local.children}</div>;
+    return renderPolymorphic(local.as, "div", { ...mergedProps, children: local.children });
   }
 
   function SubContent(props: MenuContentProps) {
-    return <Content {...props} />;
+    const submenu = useContext(SubmenuContext);
+
+    if (!submenu) {
+      return <Content {...props} />;
+    }
+
+    return (
+      <Content
+        {...props}
+        onKeyDown={composeEventHandlers<KeyboardEvent>(props.onKeyDown, (event) => {
+          if (event.key === "ArrowLeft") {
+            event.preventDefault();
+            submenu.child.close(event, "keyboard");
+            submenu.child.focusTrigger();
+          }
+        })}
+        onPointerEnter={composeEventHandlers<PointerEvent>(props.onPointerEnter, () => {
+          submenu.parent.closeSubmenus(submenu.child.contentId);
+        })}
+      />
+    );
   }
 
   return {
@@ -691,6 +1065,8 @@ function createMenuNamespace(factoryOptions: MenuFactoryOptions) {
     RadioGroup,
     RadioItem,
     ItemIndicator,
+    ItemLabel,
+    ItemDescription,
     SubRoot,
     SubTrigger,
     SubContent,
@@ -705,6 +1081,10 @@ function createControllableBooleanBackedString(options: {
   const [uncontrolled, setUncontrolled] = createSignal(options.defaultValue);
   const value = createMemo(() => options.value?.() ?? uncontrolled());
   const setValue = (next: string, detail: MenuSelectDetail) => {
+    if (Object.is(next, value())) {
+      return;
+    }
+
     if (options.value?.() === undefined) {
       setUncontrolled(next);
     }

--- a/packages/keystone/src/metadata/index.ts
+++ b/packages/keystone/src/metadata/index.ts
@@ -51,6 +51,17 @@ const floatingCssVars = [
   { name: "--keystone-transform-origin" },
 ] as const satisfies readonly PartCssVarMetadata[];
 
+const disclosureStateAttributes = [
+  { name: "data-disabled" },
+  { name: "data-state", values: ["open", "closed"] },
+] as const satisfies readonly PartStateAttributeMetadata[];
+
+const accordionStateAttributes = [
+  { name: "data-disabled" },
+  { name: "data-orientation", values: ["horizontal", "vertical"] },
+  { name: "data-state", values: ["open", "closed"] },
+] as const satisfies readonly PartStateAttributeMetadata[];
+
 const formStateAttributes = [
   { name: "data-dirty" },
   { name: "data-disabled" },
@@ -64,6 +75,17 @@ const formStateAttributes = [
 ] as const satisfies readonly PartStateAttributeMetadata[];
 
 const selectStateAttributes = [
+  { name: "data-disabled" },
+  { name: "data-highlighted" },
+  { name: "data-invalid" },
+  { name: "data-placeholder" },
+  { name: "data-readonly" },
+  { name: "data-required" },
+  { name: "data-selected" },
+  { name: "data-state", values: ["open", "closed"] },
+] as const satisfies readonly PartStateAttributeMetadata[];
+
+const comboboxStateAttributes = [
   { name: "data-disabled" },
   { name: "data-highlighted" },
   { name: "data-invalid" },
@@ -90,7 +112,28 @@ const sideAttributes = [
   { name: "data-side", values: ["top", "right", "bottom", "left"] },
 ] as const satisfies readonly PartStateAttributeMetadata[];
 
+const toastStateAttributes = [
+  { name: "data-status", values: ["open", "closed"] },
+  { name: "data-type", values: ["default", "success", "info", "warning", "error", "loading"] },
+] as const satisfies readonly PartStateAttributeMetadata[];
+
 export const primitiveMetadata = {
+  accordion: definePrimitive("accordion", [
+    part("root", [
+      { name: "data-disabled" },
+      { name: "data-orientation", values: ["horizontal", "vertical"] },
+    ]),
+    part("item", accordionStateAttributes),
+    part("header", disclosureStateAttributes),
+    part("trigger", accordionStateAttributes),
+    part("content", accordionStateAttributes),
+  ]),
+  autocomplete: comboboxPrimitive("autocomplete"),
+  collapsible: definePrimitive("collapsible", [
+    part("trigger", disclosureStateAttributes),
+    part("content", disclosureStateAttributes),
+  ]),
+  combobox: comboboxPrimitive("combobox"),
   dialog: definePrimitive("dialog", [
     part("trigger", overlayStateAttributes),
     part("close", overlayStateAttributes),
@@ -107,6 +150,11 @@ export const primitiveMetadata = {
     part("description", formStateAttributes),
     part("error-message", formStateAttributes),
     part("hidden-input"),
+  ]),
+  "hover-card": definePrimitive("hover-card", [
+    part("trigger", overlayStateAttributes),
+    part("positioner", [...overlayStateAttributes, ...floatingAttributes], floatingCssVars),
+    part("content", [...overlayStateAttributes, ...floatingAttributes], floatingCssVars),
   ]),
   listbox: definePrimitive("listbox", [
     part("listbox"),
@@ -169,6 +217,14 @@ export const primitiveMetadata = {
     part("content", [...overlayStateAttributes, ...sideAttributes]),
     part("title"),
     part("description"),
+  ]),
+  toast: definePrimitive("toast", [
+    part("viewport"),
+    part("root", toastStateAttributes),
+    part("title"),
+    part("description"),
+    part("action"),
+    part("close", [{ name: "data-disabled" }]),
   ]),
   tooltip: definePrimitive("tooltip", [
     part("trigger", overlayStateAttributes),
@@ -241,6 +297,35 @@ function menuPrimitive(scope: string): PrimitiveMetadata {
     part("group-label"),
     part("separator"),
     part("item", menuItemAttributes),
+    part("item-indicator"),
+  ]);
+}
+
+function comboboxPrimitive(scope: string): PrimitiveMetadata {
+  return definePrimitive(scope, [
+    part("input", comboboxStateAttributes),
+    part("trigger", comboboxStateAttributes),
+    part("clear", comboboxStateAttributes),
+    part(
+      "positioner",
+      [...floatingAttributes, { name: "data-state", values: ["open", "closed"] }],
+      floatingCssVars,
+    ),
+    part(
+      "content",
+      [...floatingAttributes, { name: "data-state", values: ["open", "closed"] }],
+      floatingCssVars,
+    ),
+    part("listbox"),
+    part("group", groupAttributes),
+    part("group-label"),
+    part("item", [
+      { name: "data-disabled" },
+      { name: "data-group" },
+      { name: "data-highlighted" },
+      { name: "data-selected" },
+    ]),
+    part("item-text"),
     part("item-indicator"),
   ]);
 }

--- a/packages/keystone/src/metadata/metadata.test.ts
+++ b/packages/keystone/src/metadata/metadata.test.ts
@@ -9,8 +9,37 @@ import {
 } from "./index";
 
 const expectedParts = {
+  accordion: ["root", "item", "header", "trigger", "content"],
+  autocomplete: [
+    "input",
+    "trigger",
+    "clear",
+    "positioner",
+    "content",
+    "listbox",
+    "group",
+    "group-label",
+    "item",
+    "item-text",
+    "item-indicator",
+  ],
+  combobox: [
+    "input",
+    "trigger",
+    "clear",
+    "positioner",
+    "content",
+    "listbox",
+    "group",
+    "group-label",
+    "item",
+    "item-text",
+    "item-indicator",
+  ],
+  collapsible: ["trigger", "content"],
   dialog: ["trigger", "close", "backdrop", "positioner", "content", "title", "description"],
   "form-control": ["root", "control", "label", "description", "error-message", "hidden-input"],
+  "hover-card": ["trigger", "positioner", "content"],
   listbox: ["listbox", "option", "group", "group-label"],
   "context-menu": [
     "trigger",
@@ -67,6 +96,7 @@ const expectedParts = {
     "item-indicator",
   ],
   sheet: ["trigger", "close", "backdrop", "positioner", "content", "title", "description"],
+  toast: ["viewport", "root", "title", "description", "action", "close"],
   tooltip: ["trigger", "positioner", "content"],
 } as const satisfies Record<PrimitiveScope, readonly string[]>;
 

--- a/packages/keystone/src/overlay/controller.ts
+++ b/packages/keystone/src/overlay/controller.ts
@@ -7,6 +7,7 @@ import {
   type FloatingAdapter,
   type FloatingCollisionBoundary,
   type FloatingPlacement,
+  type FloatingReferenceElement,
   type FloatingRootBoundary,
   type FloatingSticky,
   type FloatingStrategy,
@@ -45,6 +46,7 @@ export type OverlayControllerContentEvents = {
 export type OverlayControllerOptions<Reason extends string> = {
   defaultOpen?: boolean;
   floating?: {
+    anchor?: Accessor<FloatingReferenceElement | undefined>;
     arrowPadding?: Accessor<number | undefined>;
     collisionBoundary?: Accessor<FloatingCollisionBoundary | undefined>;
     collisionPadding?: Accessor<number | undefined>;
@@ -128,6 +130,7 @@ export type OverlayController<Reason extends string> = {
   open: Accessor<boolean>;
   presence: OverlayPresenceApi;
   setOpen: (open: boolean, detail: OverlayControllerChangeDetail<Reason>) => void;
+  setVirtualAnchor: (anchor: FloatingReferenceElement | undefined) => void;
   shouldMount: (forceMount?: boolean) => boolean;
   state: Accessor<"closed" | "open">;
   titleId: string;
@@ -145,6 +148,7 @@ export function createOverlayController<Reason extends string>(
   const [triggerElement, setTriggerElement] = createSignal<HTMLElement>();
   const [contentElement, setContentElement] = createSignal<HTMLElement>();
   const [positionerElement, setPositionerElement] = createSignal<HTMLElement>();
+  const [virtualAnchor, setVirtualAnchor] = createSignal<FloatingReferenceElement>();
   let lastDetail: OverlayControllerChangeDetail<Reason> = {
     reason: "programmatic" as Reason,
   };
@@ -161,7 +165,7 @@ export function createOverlayController<Reason extends string>(
   });
   const floating = options.floating
     ? createFloatingAdapter({
-        anchor: triggerElement,
+        anchor: () => virtualAnchor() ?? options.floating?.anchor?.() ?? triggerElement(),
         floating: () => positionerElement() ?? contentElement(),
         enabled: open,
         arrowPadding: options.floating.arrowPadding,
@@ -390,6 +394,7 @@ export function createOverlayController<Reason extends string>(
     open,
     presence,
     setOpen,
+    setVirtualAnchor: (anchor) => setVirtualAnchor(() => anchor),
     shouldMount: (forceMount) => forceMount === true || presence.mounted(),
     state,
     titleId: titleId(),

--- a/packages/keystone/src/overlay/floating.ts
+++ b/packages/keystone/src/overlay/floating.ts
@@ -46,7 +46,7 @@ export type FloatingRootBoundary = RootBoundary;
 export type FloatingSticky = "always" | "partial" | false;
 
 export type CreateFloatingAdapterOptions = {
-  anchor: Accessor<HTMLElement | undefined>;
+  anchor: Accessor<FloatingReferenceElement | undefined>;
   floating: Accessor<HTMLElement | undefined>;
   arrow?: Accessor<HTMLElement | undefined>;
   arrowPadding?: Accessor<number | undefined>;
@@ -61,6 +61,13 @@ export type CreateFloatingAdapterOptions = {
   sticky?: Accessor<FloatingSticky | undefined>;
   strategy?: Accessor<FloatingStrategy | undefined>;
 };
+
+export type FloatingReferenceElement =
+  | HTMLElement
+  | {
+      contextElement?: Element;
+      getBoundingClientRect: () => DOMRect;
+    };
 
 export type FloatingAdapter = {
   align: Accessor<FloatingAlign>;

--- a/packages/keystone/src/toast/index.tsx
+++ b/packages/keystone/src/toast/index.tsx
@@ -1,0 +1,479 @@
+import {
+  For,
+  Show,
+  createContext,
+  createEffect,
+  createMemo,
+  createSignal,
+  onCleanup,
+  splitProps,
+  useContext,
+  type Accessor,
+  type JSX,
+} from "solid-js";
+import { getPartDataAttributes } from "../metadata/index";
+import {
+  composeEventHandlers,
+  createStableId,
+  dataBoolean,
+  renderPolymorphic,
+  type PolymorphicProps,
+} from "../utils/index";
+
+export type ToastType = "default" | "success" | "info" | "warning" | "error" | "loading";
+export type ToastPriority = "polite" | "assertive";
+export type ToastStatus = "open" | "closed";
+
+export type ToastAction = {
+  label: JSX.Element;
+  onClick?: (toast: ToastData) => void;
+};
+
+export type ToastInput = {
+  action?: ToastAction;
+  description?: JSX.Element;
+  dismissible?: boolean;
+  duration?: number;
+  id?: string;
+  priority?: ToastPriority;
+  region?: string;
+  title?: JSX.Element;
+  type?: ToastType;
+};
+
+export type ToastData = Required<
+  Pick<ToastInput, "dismissible" | "duration" | "priority" | "type">
+> &
+  Omit<ToastInput, "dismissible" | "duration" | "priority" | "type"> & {
+    id: string;
+    status: ToastStatus;
+  };
+
+export type ToastManager = {
+  add: (toast: ToastInput | JSX.Element) => string;
+  clear: () => void;
+  dismiss: (id?: string) => void;
+  getToasts: () => readonly ToastData[];
+  subscribe: (listener: ToastManagerListener) => () => void;
+  update: (id: string, toast: Partial<ToastInput>) => void;
+};
+
+export type ToastManagerListener = (toasts: readonly ToastData[]) => void;
+
+export type ToastProviderProps = {
+  children?: JSX.Element;
+  duration?: number;
+  limit?: number;
+  manager?: ToastManager;
+};
+
+export type ToastViewportProps = Omit<JSX.HTMLAttributes<HTMLOListElement>, "children" | "ref"> & {
+  children?: JSX.Element | ((toast: ToastData) => JSX.Element);
+  label?: string;
+  ref?: HTMLOListElement | ((element: HTMLOListElement) => void);
+  region?: string;
+};
+
+export type ToastPartProps<T extends HTMLElement = HTMLElement> = {
+  children?: JSX.Element;
+  class?: string;
+  id?: string;
+  ref?: T | ((element: T) => void);
+  style?: JSX.CSSProperties | string;
+};
+
+export type ToastRootProps = ToastPartProps<HTMLLIElement> &
+  PolymorphicProps<HTMLLIElement> &
+  Omit<JSX.LiHTMLAttributes<HTMLLIElement>, "children" | "ref"> & {
+    toast?: ToastData;
+  };
+export type ToastTitleProps = ToastPartProps<HTMLDivElement> &
+  PolymorphicProps<HTMLDivElement> &
+  Omit<JSX.HTMLAttributes<HTMLDivElement>, "children" | "ref">;
+export type ToastDescriptionProps = ToastPartProps<HTMLDivElement> &
+  PolymorphicProps<HTMLDivElement> &
+  Omit<JSX.HTMLAttributes<HTMLDivElement>, "children" | "ref">;
+export type ToastActionProps = ToastPartProps<HTMLButtonElement> &
+  PolymorphicProps<HTMLButtonElement> &
+  Omit<JSX.ButtonHTMLAttributes<HTMLButtonElement>, "children" | "ref">;
+export type ToastCloseProps = ToastPartProps<HTMLButtonElement> &
+  PolymorphicProps<HTMLButtonElement> &
+  Omit<JSX.ButtonHTMLAttributes<HTMLButtonElement>, "children" | "ref">;
+
+export type CreateToastManagerOptions = {
+  duration?: number;
+};
+
+type ToastProviderContextValue = {
+  dismiss: (id?: string) => void;
+  duration: Accessor<number>;
+  limit: Accessor<number | undefined>;
+  manager: ToastManager;
+  pause: (id?: string) => void;
+  resume: (id?: string) => void;
+  toasts: Accessor<readonly ToastData[]>;
+};
+
+type ToastContextValue = {
+  toast: Accessor<ToastData>;
+};
+
+const defaultDuration = 5000;
+const ToastProviderContext = createContext<ToastProviderContextValue>();
+const ToastContext = createContext<ToastContextValue>();
+const defaultToastManager = createToastManager();
+
+let toastId = 0;
+
+export function createToastManager(options: CreateToastManagerOptions = {}): ToastManager {
+  const listeners = new Set<ToastManagerListener>();
+  let toasts: ToastData[] = [];
+
+  const emit = () => {
+    const snapshot = [...toasts];
+    for (const listener of listeners) {
+      listener(snapshot);
+    }
+  };
+
+  const normalize = (input: ToastInput | JSX.Element): ToastData => {
+    const toast = isToastInput(input) ? input : { title: input };
+    const id = toast.id ?? `toast-${++toastId}`;
+    return {
+      dismissible: toast.dismissible ?? true,
+      duration: toast.duration ?? options.duration ?? defaultDuration,
+      id,
+      priority: toast.priority ?? "polite",
+      status: "open",
+      type: toast.type ?? "default",
+      ...toast,
+    };
+  };
+
+  return {
+    add(input) {
+      const next = normalize(input);
+      const index = toasts.findIndex((toast) => toast.id === next.id);
+      if (index >= 0) {
+        toasts = toasts.map((toast) => (toast.id === next.id ? { ...toast, ...next } : toast));
+      } else {
+        toasts = [...toasts, next];
+      }
+      emit();
+      return next.id;
+    },
+    clear() {
+      toasts = [];
+      emit();
+    },
+    dismiss(id) {
+      toasts = id ? toasts.filter((toast) => toast.id !== id) : [];
+      emit();
+    },
+    getToasts() {
+      return [...toasts];
+    },
+    subscribe(listener) {
+      listeners.add(listener);
+      listener([...toasts]);
+      return () => listeners.delete(listener);
+    },
+    update(id, toast) {
+      toasts = toasts.map((current) =>
+        current.id === id ? { ...current, ...toast, id, status: "open" } : current,
+      );
+      emit();
+    },
+  };
+}
+
+export const toaster = defaultToastManager;
+
+export function ToastProvider(props: ToastProviderProps) {
+  const [toasts, setToasts] = createSignal<readonly ToastData[]>([]);
+  const manager = createMemo(() => props.manager ?? defaultToastManager);
+  const duration = createMemo(() => props.duration ?? defaultDuration);
+  const limit = createMemo(() => props.limit);
+  const timers = new Map<string, ReturnType<typeof setTimeout>>();
+  const scheduledToasts = new Map<string, ToastData>();
+  const paused = new Set<string>();
+
+  const clearTimer = (id: string) => {
+    const timer = timers.get(id);
+    if (timer) {
+      clearTimeout(timer);
+      timers.delete(id);
+    }
+    scheduledToasts.delete(id);
+  };
+
+  const schedule = (toast: ToastData) => {
+    clearTimer(toast.id);
+    const timeout = toast.duration ?? duration();
+    if (timeout <= 0 || !Number.isFinite(timeout) || paused.has(toast.id)) {
+      return;
+    }
+    timers.set(
+      toast.id,
+      setTimeout(() => {
+        manager().dismiss(toast.id);
+      }, timeout),
+    );
+    scheduledToasts.set(toast.id, toast);
+  };
+
+  createEffect(() => {
+    const unsubscribe = manager().subscribe((next) => setToasts(next));
+    onCleanup(unsubscribe);
+  });
+
+  createEffect(() => {
+    const current = toasts();
+    const ids = new Set(current.map((toast) => toast.id));
+    for (const id of timers.keys()) {
+      if (!ids.has(id)) {
+        clearTimer(id);
+      }
+    }
+    for (const toast of current) {
+      if (scheduledToasts.get(toast.id) !== toast) {
+        schedule(toast);
+      }
+    }
+  });
+
+  onCleanup(() => {
+    for (const id of timers.keys()) {
+      clearTimer(id);
+    }
+  });
+
+  const context: ToastProviderContextValue = {
+    dismiss: (id) => manager().dismiss(id),
+    duration,
+    limit,
+    manager: manager(),
+    pause: (id) => {
+      const ids = id ? [id] : toasts().map((toast) => toast.id);
+      for (const toastId of ids) {
+        paused.add(toastId);
+        clearTimer(toastId);
+      }
+    },
+    resume: (id) => {
+      const ids = id ? [id] : toasts().map((toast) => toast.id);
+      for (const toastId of ids) {
+        paused.delete(toastId);
+        const toast = toasts().find((candidate) => candidate.id === toastId);
+        if (toast) {
+          schedule(toast);
+        }
+      }
+    },
+    toasts,
+  };
+
+  return (
+    <ToastProviderContext.Provider value={context}>{props.children}</ToastProviderContext.Provider>
+  );
+}
+
+export function ToastViewport(props: ToastViewportProps) {
+  const context = useToastProviderContext("Toast.Viewport");
+  const [local, rest] = splitProps(props, [
+    "children",
+    "label",
+    "onFocusIn",
+    "onFocusOut",
+    "onMouseEnter",
+    "onMouseLeave",
+    "region",
+  ]);
+  const visibleToasts = createMemo(() => {
+    const filtered = context
+      .toasts()
+      .filter((toast) => (local.region ? toast.region === local.region : true));
+    const limit = context.limit();
+    return limit ? filtered.slice(-limit) : filtered;
+  });
+
+  return (
+    <ol
+      {...rest}
+      {...getPartDataAttributes("toast", "viewport")}
+      aria-label={local.label ?? "Notifications"}
+      role="region"
+      tabindex="-1"
+      onFocusIn={composeEventHandlers(local.onFocusIn, () => context.pause())}
+      onFocusOut={composeEventHandlers(local.onFocusOut, () => context.resume())}
+      onMouseEnter={composeEventHandlers(local.onMouseEnter, () => context.pause())}
+      onMouseLeave={composeEventHandlers(local.onMouseLeave, () => context.resume())}
+    >
+      <For each={visibleToasts()}>
+        {(toast) => (
+          <ToastContext.Provider value={{ toast: () => toast }}>
+            {typeof local.children === "function" ? (
+              local.children(toast)
+            ) : (
+              <ToastRoot>
+                <ToastTitle />
+                <ToastDescription />
+                <ToastAction />
+                <ToastClose>Close</ToastClose>
+              </ToastRoot>
+            )}
+          </ToastContext.Provider>
+        )}
+      </For>
+    </ol>
+  );
+}
+
+export function ToastRoot(props: ToastRootProps) {
+  const contextToast = useContext(ToastContext);
+  const provider = useToastProviderContext("Toast.Root");
+  const [local, rest] = splitProps(props, [
+    "as",
+    "children",
+    "id",
+    "onFocusIn",
+    "onFocusOut",
+    "onMouseEnter",
+    "onMouseLeave",
+    "toast",
+  ]);
+  const toast = createMemo(() => local.toast ?? contextToast?.toast());
+  const titleId = createStableId("toast-title", () => (local.id ? `${local.id}-title` : undefined));
+  const descriptionId = createStableId("toast-description", () =>
+    local.id ? `${local.id}-description` : undefined,
+  );
+
+  return (
+    <ToastContext.Provider value={{ toast: () => requireToast(toast()) }}>
+      {renderPolymorphic(local.as, "li", {
+        ...rest,
+        ...getPartDataAttributes("toast", "root"),
+        "aria-describedby": toast()?.description ? descriptionId() : undefined,
+        "aria-labelledby": toast()?.title ? titleId() : undefined,
+        "data-status": toast()?.status,
+        "data-type": toast()?.type,
+        id: local.id,
+        role: toast()?.priority === "assertive" ? "alert" : "status",
+        onFocusIn: composeEventHandlers(local.onFocusIn, () => provider.pause(toast()?.id)),
+        onFocusOut: composeEventHandlers(local.onFocusOut, () => provider.resume(toast()?.id)),
+        onMouseEnter: composeEventHandlers(local.onMouseEnter, () => provider.pause(toast()?.id)),
+        onMouseLeave: composeEventHandlers(local.onMouseLeave, () => provider.resume(toast()?.id)),
+        children: local.children,
+      })}
+    </ToastContext.Provider>
+  );
+}
+
+export function ToastTitle(props: ToastTitleProps) {
+  const context = useToastContext("Toast.Title");
+  const [local, rest] = splitProps(props, ["as", "children"]);
+  return (
+    <Show when={local.children ?? context.toast().title}>
+      {(children) =>
+        renderPolymorphic(local.as, "div", {
+          ...rest,
+          ...getPartDataAttributes("toast", "title"),
+          children: children(),
+        })
+      }
+    </Show>
+  );
+}
+
+export function ToastDescription(props: ToastDescriptionProps) {
+  const context = useToastContext("Toast.Description");
+  const [local, rest] = splitProps(props, ["as", "children"]);
+  return (
+    <Show when={local.children ?? context.toast().description}>
+      {(children) =>
+        renderPolymorphic(local.as, "div", {
+          ...rest,
+          ...getPartDataAttributes("toast", "description"),
+          children: children(),
+        })
+      }
+    </Show>
+  );
+}
+
+export function ToastAction(props: ToastActionProps) {
+  const context = useToastContext("Toast.Action");
+  const [local, rest] = splitProps(props, ["as", "children", "onClick"]);
+  const action = createMemo(() => context.toast().action);
+  return (
+    <Show when={local.children ?? action()?.label}>
+      {(children) =>
+        renderPolymorphic(local.as, "button", {
+          type: "button",
+          ...rest,
+          ...getPartDataAttributes("toast", "action"),
+          onClick: composeEventHandlers(local.onClick, () => {
+            action()?.onClick?.(context.toast());
+          }),
+          children: children(),
+        })
+      }
+    </Show>
+  );
+}
+
+export function ToastClose(props: ToastCloseProps) {
+  const context = useToastContext("Toast.Close");
+  const provider = useToastProviderContext("Toast.Close");
+  const [local, rest] = splitProps(props, ["as", "children", "onClick"]);
+  return (
+    <Show when={context.toast().dismissible}>
+      {renderPolymorphic(local.as, "button", {
+        type: "button",
+        "aria-label": "Close notification",
+        ...rest,
+        ...getPartDataAttributes("toast", "close"),
+        "data-disabled": dataBoolean(!context.toast().dismissible),
+        onClick: composeEventHandlers(local.onClick, () => provider.dismiss(context.toast().id)),
+        children: local.children,
+      })}
+    </Show>
+  );
+}
+
+export const Toast = {
+  Action: ToastAction,
+  Close: ToastClose,
+  Description: ToastDescription,
+  Provider: ToastProvider,
+  Root: ToastRoot,
+  Title: ToastTitle,
+  Viewport: ToastViewport,
+};
+
+function useToastProviderContext(component: string): ToastProviderContextValue {
+  const context = useContext(ToastProviderContext);
+  if (!context) {
+    throw new Error(`${component} must be used inside Toast.Provider`);
+  }
+  return context;
+}
+
+function useToastContext(component: string): ToastContextValue {
+  const context = useContext(ToastContext);
+  if (!context) {
+    throw new Error(`${component} must be used inside Toast.Root`);
+  }
+  return context;
+}
+
+function requireToast(toast: ToastData | undefined): ToastData {
+  if (!toast) {
+    throw new Error("Toast.Root requires a toast from Toast.Viewport or the toast prop");
+  }
+  return toast;
+}
+
+function isToastInput(value: ToastInput | JSX.Element): value is ToastInput {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/keystone/test/combobox.behavior.test.tsx
+++ b/packages/keystone/test/combobox.behavior.test.tsx
@@ -1,0 +1,141 @@
+import { describe, expect, test } from "vitest";
+import { Autocomplete, Combobox } from "../src/combobox/index";
+import { click, getByPart, keyDown, render, settled } from "./harness";
+
+function inputText(element: HTMLInputElement, value: string) {
+  element.value = value;
+  element.dispatchEvent(new InputEvent("input", { bubbles: true, cancelable: true }));
+}
+
+describe("Combobox behavior harness", () => {
+  test("opens from input, highlights with keyboard, and selects a value", async () => {
+    const values: string[] = [];
+    const inputs: string[] = [];
+
+    render(() => (
+      <Combobox.Root
+        name="project"
+        onInputValueChange={(value) => inputs.push(value)}
+        onValueChange={(value) => values.push(value ?? "")}
+      >
+        <Combobox.Input placeholder="Project" />
+        <Combobox.Content>
+          <Combobox.Listbox>
+            <Combobox.Item value="alpha">Alpha</Combobox.Item>
+            <Combobox.Item value="beta" disabled>
+              Beta
+            </Combobox.Item>
+            <Combobox.Item value="bravo">Bravo</Combobox.Item>
+          </Combobox.Listbox>
+        </Combobox.Content>
+      </Combobox.Root>
+    ));
+
+    const input = getByPart("combobox", "input") as HTMLInputElement;
+    inputText(input, "br");
+    await settled();
+
+    expect(input.getAttribute("aria-expanded")).toBe("true");
+    expect(inputs).toEqual(["br"]);
+
+    keyDown(input, "ArrowDown");
+    keyDown(input, "ArrowDown");
+    expect(
+      document.querySelector('[data-scope="combobox"][data-part="item"][data-highlighted]')
+        ?.textContent,
+    ).toBe("Bravo");
+
+    keyDown(input, "Enter");
+    await settled();
+
+    expect(values).toEqual(["bravo"]);
+    expect(input.value).toBe("Bravo");
+    expect(input.getAttribute("aria-expanded")).toBe("false");
+    expect(
+      new FormData(document.querySelector("form") ?? document.createElement("form")).get("project"),
+    ).toBeNull();
+  });
+
+  test("serializes selected value through a hidden input and resets with its form", async () => {
+    render(() => (
+      <form>
+        <Combobox.Root name="project" defaultValue="alpha" defaultInputValue="Alpha">
+          <Combobox.Input />
+          <Combobox.Content>
+            <Combobox.Listbox>
+              <Combobox.Item value="alpha">Alpha</Combobox.Item>
+              <Combobox.Item value="bravo">Bravo</Combobox.Item>
+            </Combobox.Listbox>
+          </Combobox.Content>
+        </Combobox.Root>
+      </form>
+    ));
+
+    const input = getByPart("combobox", "input") as HTMLInputElement;
+    keyDown(input, "ArrowDown");
+    keyDown(input, "ArrowDown");
+    keyDown(input, "Enter");
+    await settled();
+
+    const form = document.querySelector("form")!;
+    expect(new FormData(form).get("project")).toBe("bravo");
+
+    form.reset();
+    await settled();
+
+    expect(new FormData(form).get("project")).toBe("alpha");
+  });
+
+  test("clear button resets input and selected value", async () => {
+    const values: string[] = [];
+
+    render(() => (
+      <form>
+        <Combobox.Root
+          name="project"
+          defaultValue="alpha"
+          defaultInputValue="Alpha"
+          onValueChange={(value) => values.push(value ?? "")}
+        >
+          <Combobox.Input />
+          <Combobox.Clear>Clear</Combobox.Clear>
+          <Combobox.Content>
+            <Combobox.Listbox>
+              <Combobox.Item value="alpha">Alpha</Combobox.Item>
+            </Combobox.Listbox>
+          </Combobox.Content>
+        </Combobox.Root>
+      </form>
+    ));
+
+    click(getByPart("combobox", "clear"));
+    await settled();
+
+    expect((getByPart("combobox", "input") as HTMLInputElement).value).toBe("");
+    expect(new FormData(document.querySelector("form")!).get("project")).toBe("");
+    expect(values).toEqual([""]);
+  });
+
+  test("autocomplete shares combobox behavior under its own scope", async () => {
+    render(() => (
+      <Autocomplete.Root defaultOpen>
+        <Autocomplete.Input />
+        <Autocomplete.Content>
+          <Autocomplete.Listbox>
+            <Autocomplete.Group value="recent">
+              <Autocomplete.GroupLabel>Recent</Autocomplete.GroupLabel>
+              <Autocomplete.Item value="alpha">Alpha</Autocomplete.Item>
+            </Autocomplete.Group>
+          </Autocomplete.Listbox>
+        </Autocomplete.Content>
+      </Autocomplete.Root>
+    ));
+
+    const input = getByPart("autocomplete", "input");
+    const listbox = getByPart("autocomplete", "listbox");
+
+    expect(input.getAttribute("role")).toBe("combobox");
+    expect(listbox.getAttribute("role")).toBe("listbox");
+    expect(getByPart("autocomplete", "group").getAttribute("role")).toBe("group");
+  });
+});

--- a/packages/keystone/test/disclosure.behavior.test.tsx
+++ b/packages/keystone/test/disclosure.behavior.test.tsx
@@ -1,0 +1,143 @@
+import { createRoot, createSignal } from "solid-js";
+import { describe, expect, test } from "vitest";
+import { Accordion } from "../src/accordion/index";
+import { Collapsible, createCollapsible } from "../src/collapsible/index";
+import { click, getByPart, keyDown, queryByPart, render, settled } from "./harness";
+
+describe("Collapsible behavior", () => {
+  test("toggles open state and exposes the core ARIA and part contract", async () => {
+    const changes: string[] = [];
+
+    render(() => (
+      <Collapsible.Root onOpenChange={(_open, detail) => changes.push(detail.reason)}>
+        <Collapsible.Trigger>Details</Collapsible.Trigger>
+        <Collapsible.Content>Expandable content</Collapsible.Content>
+      </Collapsible.Root>
+    ));
+
+    const trigger = getByPart("collapsible", "trigger");
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+    expect(queryByPart("collapsible", "content")).toBeNull();
+
+    click(trigger);
+    await settled();
+
+    const content = getByPart("collapsible", "content");
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+    expect(trigger.getAttribute("aria-controls")).toBe(content.id);
+    expect(content.getAttribute("data-state")).toBe("open");
+    expect(changes).toEqual(["trigger"]);
+  });
+
+  test("supports controlled state and respects prevented user events", () => {
+    createRoot((dispose) => {
+      const [open, setOpen] = createSignal(false);
+      const changes: boolean[] = [];
+      const collapsible = createCollapsible({
+        open,
+        onOpenChange: (nextOpen) => changes.push(nextOpen),
+      });
+      const prevented = collapsible.getTriggerProps({
+        onClick: (event) => event.preventDefault(),
+      });
+      const trigger = collapsible.getTriggerProps({});
+
+      (prevented.onClick as (event: MouseEvent) => void)(
+        new MouseEvent("click", { cancelable: true }),
+      );
+      expect(changes).toEqual([]);
+      expect(collapsible.open()).toBe(false);
+
+      (trigger.onClick as (event: MouseEvent) => void)(
+        new MouseEvent("click", { cancelable: true }),
+      );
+      expect(changes).toEqual([true]);
+      expect(collapsible.open()).toBe(false);
+
+      setOpen(true);
+      expect(collapsible.open()).toBe(true);
+      dispose();
+    });
+  });
+});
+
+describe("Accordion behavior", () => {
+  test("coordinates single-item disclosure state and ARIA relationships", async () => {
+    const values: string[][] = [];
+
+    render(() => (
+      <Accordion.Root onValueChange={(value) => values.push(value)}>
+        <Accordion.Item value="account">
+          <Accordion.Header>
+            <Accordion.Trigger>Account</Accordion.Trigger>
+          </Accordion.Header>
+          <Accordion.Content>Account settings</Accordion.Content>
+        </Accordion.Item>
+        <Accordion.Item value="billing">
+          <Accordion.Header>
+            <Accordion.Trigger>Billing</Accordion.Trigger>
+          </Accordion.Header>
+          <Accordion.Content>Billing settings</Accordion.Content>
+        </Accordion.Item>
+      </Accordion.Root>
+    ));
+
+    const triggers = Array.from(
+      document.body.querySelectorAll<HTMLButtonElement>(
+        '[data-scope="accordion"][data-part="trigger"]',
+      ),
+    );
+
+    click(triggers[0]);
+    await settled();
+    expect(values).toEqual([["account"]]);
+    expect(triggers[0].getAttribute("aria-expanded")).toBe("true");
+    expect(getByPart("accordion", "content").getAttribute("aria-labelledby")).toBe(triggers[0].id);
+
+    click(triggers[1]);
+    await settled();
+    expect(values).toEqual([["account"], ["billing"]]);
+    expect(triggers[0].getAttribute("aria-expanded")).toBe("false");
+    expect(triggers[1].getAttribute("aria-expanded")).toBe("true");
+  });
+
+  test("supports multiple open items and trigger keyboard navigation", async () => {
+    render(() => (
+      <Accordion.Root multiple defaultValue={["first"]}>
+        <Accordion.Item value="first">
+          <Accordion.Header>
+            <Accordion.Trigger>First</Accordion.Trigger>
+          </Accordion.Header>
+          <Accordion.Content>First content</Accordion.Content>
+        </Accordion.Item>
+        <Accordion.Item value="second" disabled>
+          <Accordion.Header>
+            <Accordion.Trigger>Second</Accordion.Trigger>
+          </Accordion.Header>
+          <Accordion.Content>Second content</Accordion.Content>
+        </Accordion.Item>
+        <Accordion.Item value="third">
+          <Accordion.Header>
+            <Accordion.Trigger>Third</Accordion.Trigger>
+          </Accordion.Header>
+          <Accordion.Content>Third content</Accordion.Content>
+        </Accordion.Item>
+      </Accordion.Root>
+    ));
+
+    const triggers = Array.from(
+      document.body.querySelectorAll<HTMLButtonElement>(
+        '[data-scope="accordion"][data-part="trigger"]',
+      ),
+    );
+
+    triggers[0].focus();
+    keyDown(triggers[0], "ArrowDown");
+    expect(document.activeElement).toBe(triggers[2]);
+
+    click(triggers[2]);
+    await settled();
+    expect(triggers[0].getAttribute("aria-expanded")).toBe("true");
+    expect(triggers[2].getAttribute("aria-expanded")).toBe("true");
+  });
+});

--- a/packages/keystone/test/toast.behavior.test.tsx
+++ b/packages/keystone/test/toast.behavior.test.tsx
@@ -1,0 +1,134 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { Toast, createToastManager } from "../src/toast/index";
+import { click, getByPart, queryByPart, render, settled } from "./harness";
+
+function renderToastHarness(manager = createToastManager(), limit?: number) {
+  render(() => (
+    <Toast.Provider manager={manager} limit={limit}>
+      <Toast.Viewport>
+        {(toast) => (
+          <Toast.Root toast={toast}>
+            <Toast.Title />
+            <Toast.Description />
+            <Toast.Action />
+            <Toast.Close>Dismiss</Toast.Close>
+          </Toast.Root>
+        )}
+      </Toast.Viewport>
+    </Toast.Provider>
+  ));
+
+  return manager;
+}
+
+describe("Toast behavior harness", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("renders manager toasts with stable parts and live-region roles", async () => {
+    const manager = renderToastHarness();
+
+    manager.add({
+      description: "Saved project settings",
+      id: "settings",
+      title: "Saved",
+      type: "success",
+    });
+    await settled();
+
+    const viewport = getByPart("toast", "viewport");
+    const root = getByPart("toast", "root");
+
+    expect(viewport.getAttribute("role")).toBe("region");
+    expect(root.getAttribute("role")).toBe("status");
+    expect(root.getAttribute("data-type")).toBe("success");
+    expect(getByPart("toast", "title").textContent).toBe("Saved");
+    expect(getByPart("toast", "description").textContent).toBe("Saved project settings");
+  });
+
+  test("updates and dismisses a toast by id", async () => {
+    const manager = renderToastHarness();
+
+    manager.add({ id: "sync", title: "Syncing", type: "loading" });
+    await settled();
+
+    expect(getByPart("toast", "title").textContent).toBe("Syncing");
+
+    manager.update("sync", { title: "Synced", type: "success" });
+    await settled();
+
+    expect(getByPart("toast", "title").textContent).toBe("Synced");
+    expect(getByPart("toast", "root").getAttribute("data-type")).toBe("success");
+
+    manager.dismiss("sync");
+    await settled();
+
+    expect(queryByPart("toast", "root")).toBeNull();
+  });
+
+  test("close button runs user handlers before dismissing", async () => {
+    const manager = createToastManager();
+    const clicks: string[] = [];
+
+    render(() => (
+      <Toast.Provider manager={manager}>
+        <Toast.Viewport>
+          {(toast) => (
+            <Toast.Root toast={toast}>
+              <Toast.Title />
+              <Toast.Close onClick={() => clicks.push("user")}>Dismiss</Toast.Close>
+            </Toast.Root>
+          )}
+        </Toast.Viewport>
+      </Toast.Provider>
+    ));
+
+    manager.add({ id: "notice", title: "Notice" });
+    await settled();
+
+    click(getByPart("toast", "close"));
+    await settled();
+
+    expect(clicks).toEqual(["user"]);
+    expect(manager.getToasts()).toHaveLength(0);
+  });
+
+  test("auto dismisses after duration and respects viewport limit", async () => {
+    vi.useFakeTimers();
+    const manager = renderToastHarness(createToastManager(), 2);
+
+    manager.add({ duration: 100, id: "one", title: "One" });
+    manager.add({ duration: 100, id: "two", title: "Two" });
+    manager.add({ duration: 100, id: "three", title: "Three" });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(document.querySelectorAll('[data-scope="toast"][data-part="root"]')).toHaveLength(2);
+    expect(document.body.textContent).not.toContain("One");
+    expect(document.body.textContent).toContain("Three");
+
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(manager.getToasts()).toHaveLength(0);
+  });
+
+  test("action button invokes the toast action callback", async () => {
+    const manager = renderToastHarness();
+    const actionCalls: string[] = [];
+
+    manager.add({
+      action: {
+        label: "Undo",
+        onClick: (toast) => actionCalls.push(toast.id),
+      },
+      id: "undo",
+      title: "Deleted",
+    });
+    await settled();
+
+    click(getByPart("toast", "action"));
+
+    expect(actionCalls).toEqual(["undo"]);
+  });
+});

--- a/packages/mason-registry/src/registry-validation.test.ts
+++ b/packages/mason-registry/src/registry-validation.test.ts
@@ -70,17 +70,22 @@ describe("Mason registry validation tracer", () => {
     }
 
     expect(validatedNames).toEqual([
+      "accordion",
       "account-settings",
+      "autocomplete",
       "badge",
       "button",
       "card",
       "cn",
+      "collapsible",
+      "combobox",
       "context-menu",
       "data-table-tanstack-router",
       "data-table",
       "dialog",
       "dropdown-menu",
       "field",
+      "hover-card",
       "input",
       "label",
       "menu",
@@ -91,6 +96,7 @@ describe("Mason registry validation tracer", () => {
       "sheet",
       "text-field",
       "textarea",
+      "toast",
       "tooltip",
     ]);
   });
@@ -123,6 +129,28 @@ describe("Mason registry validation tracer", () => {
       expect(result.value.meta?.searchParams).toBeString();
       expect(result.value.meta?.stateMapping).toBeString();
       expect(result.value.meta?.limitations).toBeString();
+    }
+  });
+
+  test("captures Toast parity metadata against Kobalte, Base UI, and Sonner", async () => {
+    const item = await import("../../../registry/default/items/toast.json");
+    const result = validateItem(item.default, { registryRoot: defaultRegistryRoot });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.meta?.parts).toEqual([
+        "viewport",
+        "root",
+        "title",
+        "description",
+        "action",
+        "close",
+      ]);
+      expect(result.value.meta?.parity).toMatchObject({
+        baseUi: expect.any(String),
+        kobalte: expect.any(String),
+        sonner: expect.any(String),
+      });
     }
   });
 

--- a/registry/default/items/accordion.json
+++ b/registry/default/items/accordion.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://mason.build/schema/registry-item.json",
+  "name": "accordion",
+  "type": "registry:ui",
+  "title": "Accordion",
+  "description": "Styled Solid accordion component backed by Keystone disclosure coordination.",
+  "version": "0.1.0",
+  "dependencies": ["@keystone-ui/keystone@^0.0.0"],
+  "compatibility": {
+    "mason": ">=0.1.0 <0.2.0",
+    "solid": ">=1.9.0 <2.0.0"
+  },
+  "categories": ["disclosure", "navigation", "layout"],
+  "keywords": ["accordion", "collapsible", "disclosure", "keystone"],
+  "docs": "https://mason.build/docs/components/accordion",
+  "registryDependencies": ["cn"],
+  "meta": {
+    "install": "mason add accordion",
+    "customization": "Style the generated wrappers through mason-accordion classes while Keystone keeps item coordination, trigger ARIA, keyboard navigation, and data attributes.",
+    "sourceFiles": ["registry/default/ui/accordion.tsx"],
+    "dependencies": ["@keystone-ui/keystone", "cn"],
+    "parts": ["root", "item", "header", "trigger", "content"],
+    "parity": "Thin vertical: compares against Kobalte/Base UI with single and multiple value state, disabled items, trigger ARIA, vertical keyboard focus movement, and Mason wrapper metadata. Remaining parity gaps are RTL horizontal key behavior, measured panel CSS variables, hidden-until-found, transition lifecycle states, and broader edge-case tests."
+  },
+  "files": [
+    {
+      "path": "ui/accordion.tsx",
+      "type": "registry:ui"
+    }
+  ]
+}

--- a/registry/default/items/autocomplete.json
+++ b/registry/default/items/autocomplete.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://mason.build/schema/registry-item.json",
+  "name": "autocomplete",
+  "type": "registry:ui",
+  "title": "Autocomplete",
+  "description": "Styled Solid autocomplete component backed by Keystone combobox behavior.",
+  "version": "0.1.0",
+  "dependencies": ["@keystone-ui/keystone@^0.0.0"],
+  "compatibility": {
+    "mason": ">=0.1.0 <0.2.0",
+    "solid": ">=1.9.0 <2.0.0"
+  },
+  "categories": ["form", "listbox", "autocomplete"],
+  "keywords": ["autocomplete", "combobox", "listbox", "keystone"],
+  "docs": "https://mason.build/docs/components/autocomplete",
+  "registryDependencies": ["cn"],
+  "meta": {
+    "install": "mason add autocomplete",
+    "customization": "Style the generated wrappers through mason-autocomplete classes while Keystone owns input/listbox roles, selection, form value, and positioning.",
+    "sourceFiles": ["registry/default/ui/autocomplete.tsx"],
+    "dependencies": ["@keystone-ui/keystone", "cn"]
+  },
+  "files": [
+    {
+      "path": "ui/autocomplete.tsx",
+      "type": "registry:ui"
+    }
+  ]
+}

--- a/registry/default/items/collapsible.json
+++ b/registry/default/items/collapsible.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://mason.build/schema/registry-item.json",
+  "name": "collapsible",
+  "type": "registry:ui",
+  "title": "Collapsible",
+  "description": "Styled Solid collapsible component backed by Keystone disclosure behavior.",
+  "version": "0.1.0",
+  "dependencies": ["@keystone-ui/keystone@^0.0.0"],
+  "compatibility": {
+    "mason": ">=0.1.0 <0.2.0",
+    "solid": ">=1.9.0 <2.0.0"
+  },
+  "categories": ["disclosure", "layout"],
+  "keywords": ["collapsible", "disclosure", "keystone"],
+  "docs": "https://mason.build/docs/components/collapsible",
+  "registryDependencies": ["cn"],
+  "meta": {
+    "install": "mason add collapsible",
+    "customization": "Style the generated wrappers through mason-collapsible classes while Keystone keeps open state, ARIA relationships, and data attributes.",
+    "sourceFiles": ["registry/default/ui/collapsible.tsx"],
+    "dependencies": ["@keystone-ui/keystone", "cn"],
+    "parts": ["trigger", "content"],
+    "parity": "Thin vertical: matches Kobalte/Base UI controlled and uncontrolled disclosure state, trigger ARIA, and data-state hooks. Remaining parity gaps are measured height/width transition CSS variables, hidden-until-found, richer transition status, and edge-case browser find behavior."
+  },
+  "files": [
+    {
+      "path": "ui/collapsible.tsx",
+      "type": "registry:ui"
+    }
+  ]
+}

--- a/registry/default/items/combobox.json
+++ b/registry/default/items/combobox.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://mason.build/schema/registry-item.json",
+  "name": "combobox",
+  "type": "registry:ui",
+  "title": "Combobox",
+  "description": "Styled Solid combobox backed by Keystone input, listbox, selection, and floating behavior.",
+  "version": "0.1.0",
+  "dependencies": ["@keystone-ui/keystone@^0.0.0"],
+  "compatibility": {
+    "mason": ">=0.1.0 <0.2.0",
+    "solid": ">=1.9.0 <2.0.0"
+  },
+  "categories": ["form", "listbox", "autocomplete"],
+  "keywords": ["combobox", "autocomplete", "listbox", "keystone"],
+  "docs": "https://mason.build/docs/components/combobox",
+  "registryDependencies": ["cn"],
+  "meta": {
+    "install": "mason add combobox",
+    "customization": "Style the generated wrappers through mason-combobox classes while Keystone owns input/listbox roles, selection, form value, and positioning.",
+    "sourceFiles": ["registry/default/ui/combobox.tsx"],
+    "dependencies": ["@keystone-ui/keystone", "cn"]
+  },
+  "files": [
+    {
+      "path": "ui/combobox.tsx",
+      "type": "registry:ui"
+    }
+  ]
+}

--- a/registry/default/items/hover-card.json
+++ b/registry/default/items/hover-card.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://mason.build/schema/registry-item.json",
+  "name": "hover-card",
+  "type": "registry:ui",
+  "title": "HoverCard",
+  "description": "Styled Solid hover card component backed by Keystone overlay positioning and pointer/focus preview behavior.",
+  "version": "0.1.0",
+  "dependencies": ["@keystone-ui/keystone@^0.0.0"],
+  "compatibility": {
+    "mason": ">=0.1.0 <0.2.0",
+    "solid": ">=1.9.0 <2.0.0"
+  },
+  "categories": ["overlay", "preview"],
+  "keywords": ["hover-card", "preview", "overlay", "floating", "keystone"],
+  "docs": "https://mason.build/docs/components/hover-card",
+  "registryDependencies": ["cn"],
+  "meta": {
+    "install": "mason add hover-card",
+    "customization": "Style the generated wrappers through mason-hover-card classes while Keystone owns preview timing, positioning, and dismissal.",
+    "sourceFiles": ["registry/default/ui/hover-card.tsx"],
+    "dependencies": ["@keystone-ui/keystone", "cn"],
+    "parts": ["trigger", "positioner", "content"],
+    "parity": {
+      "kobalte": "Matches the core Root/Trigger/Portal/Content shape, custom open/close delays, controlled state, forceMount, and screen-reader-hidden preview intent. Gaps: optional Arrow part and deeper safe-area tuning remain follow-up work.",
+      "baseUi": "Matches the simple PreviewCard Root/Trigger/Portal/Positioner/Popup-style contract through Keystone Content. Gaps: detached triggers, multiple trigger payloads, Backdrop, Viewport, Arrow, and trigger-id coordination remain follow-up work."
+    }
+  },
+  "files": [
+    {
+      "path": "ui/hover-card.tsx",
+      "type": "registry:ui"
+    }
+  ]
+}

--- a/registry/default/items/toast.json
+++ b/registry/default/items/toast.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://mason.build/schema/registry-item.json",
+  "name": "toast",
+  "type": "registry:ui",
+  "title": "Toast",
+  "description": "Styled Solid toast component backed by Keystone notification manager, viewport, timer, and live-region behavior.",
+  "version": "0.1.0",
+  "dependencies": ["@keystone-ui/keystone@^0.0.0"],
+  "compatibility": {
+    "mason": ">=0.1.0 <0.2.0",
+    "solid": ">=1.9.0 <2.0.0"
+  },
+  "categories": ["feedback", "overlay", "notification"],
+  "keywords": ["toast", "notification", "sonner", "keystone"],
+  "docs": "https://mason.build/docs/components/toast",
+  "registryDependencies": ["cn"],
+  "meta": {
+    "install": "mason add toast",
+    "customization": "Style generated mason-toast classes while Keystone owns manager updates, live-region roles, dismissal, timer scheduling, and stable toast part attributes.",
+    "sourceFiles": ["registry/default/ui/toast.tsx"],
+    "dependencies": ["@keystone-ui/keystone", "cn"],
+    "parts": ["viewport", "root", "title", "description", "action", "close"],
+    "parity": {
+      "kobalte": "Matches the core Toaster/Region/Toast Root, Title, Description, Close, action-like composition, Solid store subscription, duration, visible limit, pause-on-interaction, and polite/assertive live-region behavior. Gaps: region hotkey focus, swipe gestures, progress track/fill, persistent lifecycle status, and promise helper parity remain follow-up work.",
+      "baseUi": "Matches the manager/provider/store direction with add, update, dismiss, clear, limit, timer scheduling, viewport rendering, action and close parts, and hover/focus pause behavior. Gaps: loading-to-complete promise transitions, transition status metadata, window blur pausing, viewport geometry, and advanced positioner/portal composition remain follow-up work.",
+      "sonner": "Matches the ergonomic default toaster export, id-based update/dismiss, toast type variants, action callbacks, close button, duration, viewport limit, and generated Toaster wrapper. Gaps: stacked height CSS variables, expand mode, swipe directions, rich color/icon presets, cancel action, custom JSX toast renderer presets, position offsets, and mobile offset props remain follow-up work."
+    }
+  },
+  "files": [
+    {
+      "path": "ui/toast.tsx",
+      "type": "registry:ui"
+    }
+  ]
+}

--- a/registry/default/registry.json
+++ b/registry/default/registry.json
@@ -4,6 +4,12 @@
   "homepage": "https://mason.build",
   "items": [
     {
+      "name": "accordion",
+      "type": "registry:ui",
+      "title": "Accordion",
+      "description": "Styled Solid accordion component backed by Keystone disclosure coordination."
+    },
+    {
       "name": "account-settings",
       "type": "registry:block",
       "title": "AccountSettingsBlock",
@@ -58,6 +64,18 @@
       "description": "TanStack Form select field composed with Keystone Select behavior and Mason styling hooks."
     },
     {
+      "name": "combobox",
+      "type": "registry:ui",
+      "title": "Combobox",
+      "description": "Styled Solid combobox backed by Keystone input, listbox, selection, and floating behavior."
+    },
+    {
+      "name": "autocomplete",
+      "type": "registry:ui",
+      "title": "Autocomplete",
+      "description": "Styled Solid autocomplete component backed by Keystone combobox behavior."
+    },
+    {
       "name": "data-table",
       "type": "registry:ui",
       "title": "DataTable",
@@ -88,6 +106,12 @@
       "description": "Decorative or semantic separator component."
     },
     {
+      "name": "collapsible",
+      "type": "registry:ui",
+      "title": "Collapsible",
+      "description": "Styled Solid collapsible component backed by Keystone disclosure behavior."
+    },
+    {
       "name": "dialog",
       "type": "registry:ui",
       "title": "Dialog",
@@ -98,6 +122,12 @@
       "type": "registry:ui",
       "title": "Popover",
       "description": "Styled Solid popover component backed by Keystone overlay positioning and dismissal."
+    },
+    {
+      "name": "hover-card",
+      "type": "registry:ui",
+      "title": "HoverCard",
+      "description": "Styled Solid hover card component backed by Keystone overlay positioning and pointer/focus preview behavior."
     },
     {
       "name": "menu",
@@ -122,6 +152,12 @@
       "type": "registry:ui",
       "title": "Menubar",
       "description": "Styled Solid menubar backed by Keystone menu navigation, typeahead, and item state behavior."
+    },
+    {
+      "name": "toast",
+      "type": "registry:ui",
+      "title": "Toast",
+      "description": "Styled Solid toast component backed by Keystone notification manager, viewport, timer, and live-region behavior."
     },
     {
       "name": "tooltip",

--- a/registry/default/ui/accordion.tsx
+++ b/registry/default/ui/accordion.tsx
@@ -1,0 +1,63 @@
+import {
+  Accordion as KeystoneAccordion,
+  type AccordionContentProps as KeystoneAccordionContentProps,
+  type AccordionHeaderProps as KeystoneAccordionHeaderProps,
+  type AccordionItemProps as KeystoneAccordionItemProps,
+  type AccordionRootProps as KeystoneAccordionRootProps,
+  type AccordionTriggerProps as KeystoneAccordionTriggerProps,
+} from "@keystone-ui/keystone/accordion";
+import { splitProps, type JSX } from "solid-js";
+import { cn } from "@/lib/cn";
+
+export type AccordionProps = KeystoneAccordionRootProps;
+export type AccordionItemProps = KeystoneAccordionItemProps;
+export type AccordionHeaderProps = KeystoneAccordionHeaderProps;
+export type AccordionTriggerProps = KeystoneAccordionTriggerProps & {
+  indicator?: JSX.Element;
+};
+export type AccordionContentProps = KeystoneAccordionContentProps;
+
+export function Accordion(props: AccordionProps) {
+  return <KeystoneAccordion.Root {...props} />;
+}
+
+export function AccordionItem(props: AccordionItemProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+
+  return <KeystoneAccordion.Item {...rest} class={cn("mason-accordion-item", local.class)} />;
+}
+
+export function AccordionHeader(props: AccordionHeaderProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+
+  return <KeystoneAccordion.Header {...rest} class={cn("mason-accordion-header", local.class)} />;
+}
+
+export function AccordionTrigger(props: AccordionTriggerProps) {
+  const [local, rest] = splitProps(props, ["children", "class", "indicator"]);
+
+  return (
+    <AccordionHeader>
+      <KeystoneAccordion.Trigger {...rest} class={cn("mason-accordion-trigger", local.class)}>
+        <span data-scope="mason-accordion" data-part="trigger-label">
+          {local.children}
+        </span>
+        <span class="mason-accordion-indicator" data-scope="mason-accordion" data-part="indicator">
+          {local.indicator ?? "v"}
+        </span>
+      </KeystoneAccordion.Trigger>
+    </AccordionHeader>
+  );
+}
+
+export function AccordionContent(props: AccordionContentProps) {
+  const [local, rest] = splitProps(props, ["children", "class"]);
+
+  return (
+    <KeystoneAccordion.Content {...rest} class={cn("mason-accordion-content", local.class)}>
+      <div data-scope="mason-accordion" data-part="content-inner">
+        {local.children}
+      </div>
+    </KeystoneAccordion.Content>
+  );
+}

--- a/registry/default/ui/autocomplete.tsx
+++ b/registry/default/ui/autocomplete.tsx
@@ -1,0 +1,139 @@
+import {
+  Autocomplete as KeystoneAutocomplete,
+  type AutocompleteClearProps as KeystoneAutocompleteClearProps,
+  type AutocompleteContentProps as KeystoneAutocompleteContentProps,
+  type AutocompleteGroupLabelProps as KeystoneAutocompleteGroupLabelProps,
+  type AutocompleteGroupProps as KeystoneAutocompleteGroupProps,
+  type AutocompleteInputProps as KeystoneAutocompleteInputProps,
+  type AutocompleteItemIndicatorProps as KeystoneAutocompleteItemIndicatorProps,
+  type AutocompleteItemProps as KeystoneAutocompleteItemProps,
+  type AutocompleteItemTextProps as KeystoneAutocompleteItemTextProps,
+  type AutocompleteListboxProps as KeystoneAutocompleteListboxProps,
+  type AutocompletePortalProps as KeystoneAutocompletePortalProps,
+  type AutocompletePositionerProps as KeystoneAutocompletePositionerProps,
+  type AutocompleteRootProps as KeystoneAutocompleteRootProps,
+  type AutocompleteTriggerProps as KeystoneAutocompleteTriggerProps,
+} from "@keystone-ui/keystone/autocomplete";
+import { splitProps } from "solid-js";
+import { cn } from "@/lib/cn";
+
+export type AutocompleteProps = KeystoneAutocompleteRootProps;
+export type AutocompleteInputProps = KeystoneAutocompleteInputProps;
+export type AutocompleteTriggerProps = KeystoneAutocompleteTriggerProps;
+export type AutocompleteClearProps = KeystoneAutocompleteClearProps;
+export type AutocompletePortalProps = KeystoneAutocompletePortalProps;
+export type AutocompletePositionerProps = KeystoneAutocompletePositionerProps;
+export type AutocompleteContentProps = KeystoneAutocompleteContentProps & {
+  portal?: AutocompletePortalProps;
+  positionerClass?: string;
+};
+export type AutocompleteListboxProps = KeystoneAutocompleteListboxProps;
+export type AutocompleteGroupProps = KeystoneAutocompleteGroupProps;
+export type AutocompleteGroupLabelProps = KeystoneAutocompleteGroupLabelProps;
+export type AutocompleteItemProps = KeystoneAutocompleteItemProps;
+export type AutocompleteItemTextProps = KeystoneAutocompleteItemTextProps;
+export type AutocompleteItemIndicatorProps = KeystoneAutocompleteItemIndicatorProps;
+
+export function Autocomplete(props: AutocompleteProps) {
+  return <KeystoneAutocomplete.Root {...props} />;
+}
+
+export function AutocompleteInput(props: AutocompleteInputProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return (
+    <KeystoneAutocomplete.Input {...rest} class={cn("mason-autocomplete-input", local.class)} />
+  );
+}
+
+export function AutocompleteTrigger(props: AutocompleteTriggerProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return (
+    <KeystoneAutocomplete.Trigger {...rest} class={cn("mason-autocomplete-trigger", local.class)} />
+  );
+}
+
+export function AutocompleteClear(props: AutocompleteClearProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return (
+    <KeystoneAutocomplete.Clear {...rest} class={cn("mason-autocomplete-clear", local.class)} />
+  );
+}
+
+export function AutocompletePortal(props: AutocompletePortalProps) {
+  return <KeystoneAutocomplete.Portal {...props} />;
+}
+
+export function AutocompletePositioner(props: AutocompletePositionerProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return (
+    <KeystoneAutocomplete.Positioner
+      {...rest}
+      class={cn("mason-autocomplete-positioner", local.class)}
+    />
+  );
+}
+
+export function AutocompleteContent(props: AutocompleteContentProps) {
+  const [local, rest] = splitProps(props, ["children", "class", "portal", "positionerClass"]);
+  return (
+    <AutocompletePortal {...local.portal}>
+      <AutocompletePositioner class={local.positionerClass}>
+        <KeystoneAutocomplete.Content
+          {...rest}
+          class={cn("mason-autocomplete-content", local.class)}
+        >
+          {local.children}
+        </KeystoneAutocomplete.Content>
+      </AutocompletePositioner>
+    </AutocompletePortal>
+  );
+}
+
+export function AutocompleteListbox(props: AutocompleteListboxProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return (
+    <KeystoneAutocomplete.Listbox {...rest} class={cn("mason-autocomplete-listbox", local.class)} />
+  );
+}
+
+export function AutocompleteGroup(props: AutocompleteGroupProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return (
+    <KeystoneAutocomplete.Group {...rest} class={cn("mason-autocomplete-group", local.class)} />
+  );
+}
+
+export function AutocompleteGroupLabel(props: AutocompleteGroupLabelProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return (
+    <KeystoneAutocomplete.GroupLabel
+      {...rest}
+      class={cn("mason-autocomplete-group-label", local.class)}
+    />
+  );
+}
+
+export function AutocompleteItem(props: AutocompleteItemProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return <KeystoneAutocomplete.Item {...rest} class={cn("mason-autocomplete-item", local.class)} />;
+}
+
+export function AutocompleteItemText(props: AutocompleteItemTextProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return (
+    <KeystoneAutocomplete.ItemText
+      {...rest}
+      class={cn("mason-autocomplete-item-text", local.class)}
+    />
+  );
+}
+
+export function AutocompleteItemIndicator(props: AutocompleteItemIndicatorProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return (
+    <KeystoneAutocomplete.ItemIndicator
+      {...rest}
+      class={cn("mason-autocomplete-item-indicator", local.class)}
+    />
+  );
+}

--- a/registry/default/ui/collapsible.tsx
+++ b/registry/default/ui/collapsible.tsx
@@ -1,0 +1,32 @@
+import {
+  Collapsible as KeystoneCollapsible,
+  type CollapsibleContentProps as KeystoneCollapsibleContentProps,
+  type CollapsibleRootProps as KeystoneCollapsibleRootProps,
+  type CollapsibleTriggerProps as KeystoneCollapsibleTriggerProps,
+} from "@keystone-ui/keystone/collapsible";
+import { splitProps } from "solid-js";
+import { cn } from "@/lib/cn";
+
+export type CollapsibleProps = KeystoneCollapsibleRootProps;
+export type CollapsibleTriggerProps = KeystoneCollapsibleTriggerProps;
+export type CollapsibleContentProps = KeystoneCollapsibleContentProps;
+
+export function Collapsible(props: CollapsibleProps) {
+  return <KeystoneCollapsible.Root {...props} />;
+}
+
+export function CollapsibleTrigger(props: CollapsibleTriggerProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+
+  return (
+    <KeystoneCollapsible.Trigger {...rest} class={cn("mason-collapsible-trigger", local.class)} />
+  );
+}
+
+export function CollapsibleContent(props: CollapsibleContentProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+
+  return (
+    <KeystoneCollapsible.Content {...rest} class={cn("mason-collapsible-content", local.class)} />
+  );
+}

--- a/registry/default/ui/combobox.tsx
+++ b/registry/default/ui/combobox.tsx
@@ -1,0 +1,117 @@
+import {
+  Combobox as KeystoneCombobox,
+  type ComboboxClearProps as KeystoneComboboxClearProps,
+  type ComboboxContentProps as KeystoneComboboxContentProps,
+  type ComboboxGroupLabelProps as KeystoneComboboxGroupLabelProps,
+  type ComboboxGroupProps as KeystoneComboboxGroupProps,
+  type ComboboxInputProps as KeystoneComboboxInputProps,
+  type ComboboxItemIndicatorProps as KeystoneComboboxItemIndicatorProps,
+  type ComboboxItemProps as KeystoneComboboxItemProps,
+  type ComboboxItemTextProps as KeystoneComboboxItemTextProps,
+  type ComboboxListboxProps as KeystoneComboboxListboxProps,
+  type ComboboxPortalProps as KeystoneComboboxPortalProps,
+  type ComboboxPositionerProps as KeystoneComboboxPositionerProps,
+  type ComboboxRootProps as KeystoneComboboxRootProps,
+  type ComboboxTriggerProps as KeystoneComboboxTriggerProps,
+} from "@keystone-ui/keystone/combobox";
+import { splitProps } from "solid-js";
+import { cn } from "@/lib/cn";
+
+export type ComboboxProps = KeystoneComboboxRootProps;
+export type ComboboxInputProps = KeystoneComboboxInputProps;
+export type ComboboxTriggerProps = KeystoneComboboxTriggerProps;
+export type ComboboxClearProps = KeystoneComboboxClearProps;
+export type ComboboxPortalProps = KeystoneComboboxPortalProps;
+export type ComboboxPositionerProps = KeystoneComboboxPositionerProps;
+export type ComboboxContentProps = KeystoneComboboxContentProps & {
+  portal?: ComboboxPortalProps;
+  positionerClass?: string;
+};
+export type ComboboxListboxProps = KeystoneComboboxListboxProps;
+export type ComboboxGroupProps = KeystoneComboboxGroupProps;
+export type ComboboxGroupLabelProps = KeystoneComboboxGroupLabelProps;
+export type ComboboxItemProps = KeystoneComboboxItemProps;
+export type ComboboxItemTextProps = KeystoneComboboxItemTextProps;
+export type ComboboxItemIndicatorProps = KeystoneComboboxItemIndicatorProps;
+
+export function Combobox(props: ComboboxProps) {
+  return <KeystoneCombobox.Root {...props} />;
+}
+
+export function ComboboxInput(props: ComboboxInputProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return <KeystoneCombobox.Input {...rest} class={cn("mason-combobox-input", local.class)} />;
+}
+
+export function ComboboxTrigger(props: ComboboxTriggerProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return <KeystoneCombobox.Trigger {...rest} class={cn("mason-combobox-trigger", local.class)} />;
+}
+
+export function ComboboxClear(props: ComboboxClearProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return <KeystoneCombobox.Clear {...rest} class={cn("mason-combobox-clear", local.class)} />;
+}
+
+export function ComboboxPortal(props: ComboboxPortalProps) {
+  return <KeystoneCombobox.Portal {...props} />;
+}
+
+export function ComboboxPositioner(props: ComboboxPositionerProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return (
+    <KeystoneCombobox.Positioner {...rest} class={cn("mason-combobox-positioner", local.class)} />
+  );
+}
+
+export function ComboboxContent(props: ComboboxContentProps) {
+  const [local, rest] = splitProps(props, ["children", "class", "portal", "positionerClass"]);
+  return (
+    <ComboboxPortal {...local.portal}>
+      <ComboboxPositioner class={local.positionerClass}>
+        <KeystoneCombobox.Content {...rest} class={cn("mason-combobox-content", local.class)}>
+          {local.children}
+        </KeystoneCombobox.Content>
+      </ComboboxPositioner>
+    </ComboboxPortal>
+  );
+}
+
+export function ComboboxListbox(props: ComboboxListboxProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return <KeystoneCombobox.Listbox {...rest} class={cn("mason-combobox-listbox", local.class)} />;
+}
+
+export function ComboboxGroup(props: ComboboxGroupProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return <KeystoneCombobox.Group {...rest} class={cn("mason-combobox-group", local.class)} />;
+}
+
+export function ComboboxGroupLabel(props: ComboboxGroupLabelProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return (
+    <KeystoneCombobox.GroupLabel {...rest} class={cn("mason-combobox-group-label", local.class)} />
+  );
+}
+
+export function ComboboxItem(props: ComboboxItemProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return <KeystoneCombobox.Item {...rest} class={cn("mason-combobox-item", local.class)} />;
+}
+
+export function ComboboxItemText(props: ComboboxItemTextProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return (
+    <KeystoneCombobox.ItemText {...rest} class={cn("mason-combobox-item-text", local.class)} />
+  );
+}
+
+export function ComboboxItemIndicator(props: ComboboxItemIndicatorProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return (
+    <KeystoneCombobox.ItemIndicator
+      {...rest}
+      class={cn("mason-combobox-item-indicator", local.class)}
+    />
+  );
+}

--- a/registry/default/ui/hover-card.tsx
+++ b/registry/default/ui/hover-card.tsx
@@ -1,0 +1,58 @@
+import {
+  HoverCard as KeystoneHoverCard,
+  type HoverCardContentProps as KeystoneHoverCardContentProps,
+  type HoverCardPortalProps as KeystoneHoverCardPortalProps,
+  type HoverCardPositionerProps as KeystoneHoverCardPositionerProps,
+  type HoverCardRootProps as KeystoneHoverCardRootProps,
+  type HoverCardTriggerProps as KeystoneHoverCardTriggerProps,
+} from "@keystone-ui/keystone/hover-card";
+import { splitProps } from "solid-js";
+import { cn } from "@/lib/cn";
+
+export type HoverCardProps = KeystoneHoverCardRootProps;
+export type HoverCardTriggerProps = KeystoneHoverCardTriggerProps;
+export type HoverCardPortalProps = KeystoneHoverCardPortalProps;
+export type HoverCardPositionerProps = KeystoneHoverCardPositionerProps;
+export type HoverCardContentProps = KeystoneHoverCardContentProps & {
+  portal?: HoverCardPortalProps;
+  positionerClass?: string;
+};
+
+export function HoverCard(props: HoverCardProps) {
+  return <KeystoneHoverCard.Root {...props} />;
+}
+
+export function HoverCardTrigger(props: HoverCardTriggerProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return (
+    <KeystoneHoverCard.Trigger {...rest} class={cn("mason-hover-card-trigger", local.class)} />
+  );
+}
+
+export function HoverCardPortal(props: HoverCardPortalProps) {
+  return <KeystoneHoverCard.Portal {...props} />;
+}
+
+export function HoverCardPositioner(props: HoverCardPositionerProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return (
+    <KeystoneHoverCard.Positioner
+      {...rest}
+      class={cn("mason-hover-card-positioner", local.class)}
+    />
+  );
+}
+
+export function HoverCardContent(props: HoverCardContentProps) {
+  const [local, rest] = splitProps(props, ["children", "class", "portal", "positionerClass"]);
+
+  return (
+    <HoverCardPortal {...local.portal}>
+      <HoverCardPositioner class={local.positionerClass}>
+        <KeystoneHoverCard.Content {...rest} class={cn("mason-hover-card-content", local.class)}>
+          {local.children}
+        </KeystoneHoverCard.Content>
+      </HoverCardPositioner>
+    </HoverCardPortal>
+  );
+}

--- a/registry/default/ui/toast.tsx
+++ b/registry/default/ui/toast.tsx
@@ -1,0 +1,79 @@
+import {
+  Toast as KeystoneToast,
+  toaster,
+  type ToastActionProps as KeystoneToastActionProps,
+  type ToastCloseProps as KeystoneToastCloseProps,
+  type ToastData,
+  type ToastDescriptionProps as KeystoneToastDescriptionProps,
+  type ToastInput,
+  type ToastManager,
+  type ToastProviderProps as KeystoneToastProviderProps,
+  type ToastRootProps as KeystoneToastRootProps,
+  type ToastTitleProps as KeystoneToastTitleProps,
+  type ToastViewportProps as KeystoneToastViewportProps,
+} from "@keystone-ui/keystone/toast";
+import { splitProps } from "solid-js";
+import { cn } from "@/lib/cn";
+
+export type ToastProviderProps = KeystoneToastProviderProps;
+export type ToastViewportProps = KeystoneToastViewportProps;
+export type ToastProps = KeystoneToastRootProps;
+export type ToastTitleProps = KeystoneToastTitleProps;
+export type ToastDescriptionProps = KeystoneToastDescriptionProps;
+export type ToastActionProps = KeystoneToastActionProps;
+export type ToastCloseProps = KeystoneToastCloseProps;
+export type { ToastData, ToastInput, ToastManager };
+
+export { toaster };
+
+export function ToastProvider(props: ToastProviderProps) {
+  return <KeystoneToast.Provider {...props} />;
+}
+
+export function ToastViewport(props: ToastViewportProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return <KeystoneToast.Viewport {...rest} class={cn("mason-toast-viewport", local.class)} />;
+}
+
+export function Toast(props: ToastProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return <KeystoneToast.Root {...rest} class={cn("mason-toast", local.class)} />;
+}
+
+export function ToastTitle(props: ToastTitleProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return <KeystoneToast.Title {...rest} class={cn("mason-toast-title", local.class)} />;
+}
+
+export function ToastDescription(props: ToastDescriptionProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return <KeystoneToast.Description {...rest} class={cn("mason-toast-description", local.class)} />;
+}
+
+export function ToastAction(props: ToastActionProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return <KeystoneToast.Action {...rest} class={cn("mason-toast-action", local.class)} />;
+}
+
+export function ToastClose(props: ToastCloseProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return <KeystoneToast.Close {...rest} class={cn("mason-toast-close", local.class)} />;
+}
+
+export function Toaster(props: ToastProviderProps & { viewport?: ToastViewportProps }) {
+  const [local, providerProps] = splitProps(props, ["viewport"]);
+  return (
+    <ToastProvider {...providerProps}>
+      <ToastViewport {...local.viewport}>
+        {(toast: ToastData) => (
+          <Toast toast={toast}>
+            <ToastTitle />
+            <ToastDescription />
+            <ToastAction />
+            <ToastClose>Close</ToastClose>
+          </Toast>
+        )}
+      </ToastViewport>
+    </ToastProvider>
+  );
+}


### PR DESCRIPTION
## Summary

Adds the next Keystone primitive set and corresponding Mason registry entries, covering disclosure, accordion, collapsible, combobox/autocomplete, hover-card, and toast work.

## Core changes

- Exports new Keystone primitives and metadata for accordion, autocomplete, collapsible, combobox, hover-card, and toast.
- Adds shared disclosure behavior, overlay virtual anchors, menu submenu/context-menu refinements, and focused behavior tests for disclosure, combobox, and toast.
- Registers styled Mason UI entries and item manifests for the new primitives, plus registry validation coverage and docs index updates.
- Includes formatter output for the generated TanStack route tree produced by `bun run check`.

## Validation

- `bun run check`
- `bun run check-types`
