### PR TITLE
[codex] expand primitive and registry contracts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ coverage
 tmp
 temp
 inspo/
+.playwright-mcp/

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ Every first-party registry item carries docs-ready metadata:
 
 Base UI is the first reference for runtime depth. Kobalte is the first reference for Solid-native primitive shape. Some components use more specific references, such as TanStack Table, TanStack Form, TanStack Router, Sonner, or shadcn-style registry conventions.
 
+The registry metadata contract is documented in [Mason Registry RFC](docs/rfcs/mason-registry.md).
+
 ## Development
 
 Install dependencies:

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -7,7 +7,7 @@
     "build": "vite build",
     "serve": "vite preview",
     "start": "node .output/server/index.mjs",
-    "test": "vitest run",
+    "test": "bun test",
     "dev:bare": "vite dev"
   },
   "dependencies": {

--- a/apps/docs/src/components/header.tsx
+++ b/apps/docs/src/components/header.tsx
@@ -1,13 +1,13 @@
 import { Link } from "@tanstack/solid-router";
-import { Box, Code2, FileText, Layers } from "lucide-solid";
+import { Code2, FileText, Layers } from "lucide-solid";
 import { For } from "solid-js";
 
 export default function Header() {
   const links = [
     { to: "/", label: "Overview" },
-    { to: "/docs/keystone/dialog", label: "Keystone Dialog" },
-    { to: "/docs/mason/dialog", label: "Mason Dialog" },
-    { to: "/#release", label: "0.1.0" },
+    { to: "/#keystone", label: "Keystone" },
+    { to: "/#mason", label: "Mason" },
+    { to: "/#reference", label: "Reference" },
   ];
 
   return (
@@ -34,10 +34,7 @@ export default function Header() {
         </nav>
 
         <div class="icon-links" aria-label="Project links">
-          <a class="icon-link" href="#release" aria-label="Release status">
-            <Box size={17} />
-          </a>
-          <a class="icon-link" href="#docs" aria-label="Documentation map">
+          <a class="icon-link" href="#shape" aria-label="Documentation shape">
             <FileText size={17} />
           </a>
           <a

--- a/apps/docs/src/lib/docs-contracts.test.ts
+++ b/apps/docs/src/lib/docs-contracts.test.ts
@@ -1,0 +1,59 @@
+import { readdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, test } from "bun:test";
+import { primitiveMetadata } from "@keystone-ui/keystone";
+import { primitiveContracts, primitiveScopes } from "./primitive-contracts";
+import { registryItemContracts } from "./registry-contracts";
+
+describe("docs metadata contracts", () => {
+  test("covers every Keystone primitive metadata scope", () => {
+    expect(primitiveContracts.map((contract) => contract.scope).sort()).toEqual(
+      Object.keys(primitiveMetadata).sort(),
+    );
+
+    for (const contract of primitiveContracts) {
+      expect(contract.title).toBeString();
+      expect(contract.importPath).toBeString();
+      expect(contract.roleNotes.length).toBeGreaterThan(0);
+      expect(contract.keyboardNotes.length).toBeGreaterThan(0);
+      expect(contract.ariaNotes.length).toBeGreaterThan(0);
+      expect(contract.ssrNotes.length).toBeGreaterThan(0);
+      expect(contract.example).toBeString();
+
+      const metadata = primitiveMetadata[contract.scope];
+      expect(metadata.parts.length).toBeGreaterThan(0);
+      for (const part of metadata.parts) {
+        expect(part.dataAttributes.map((attribute) => attribute.name)).toContain("data-scope");
+        expect(part.dataAttributes.map((attribute) => attribute.name)).toContain("data-part");
+      }
+    }
+  });
+
+  test("covers every default Mason registry item", () => {
+    const registryItemsDir = resolve(import.meta.dir, "../../../../registry/default/items");
+    const itemNames = readdirSync(registryItemsDir)
+      .filter((file) => file.endsWith(".json"))
+      .map((file) => file.replace(/\.json$/, ""))
+      .sort();
+
+    expect(registryItemContracts.map((item) => item.name).sort()).toEqual(itemNames);
+
+    for (const item of registryItemContracts) {
+      expect(item.install).toStartWith("mason add ");
+      expect(item.files.length).toBeGreaterThan(0);
+      expect(item.customization).toBeString();
+      expect(item.caveats).toBeString();
+      expect(Object.keys(item.parity).length).toBeGreaterThan(0);
+      expect(Object.values(item.parity).every((note) => note.length > 0)).toBe(true);
+    }
+  });
+
+  test("includes the required preview docs surfaces", () => {
+    expect(primitiveScopes).toEqual(
+      expect.arrayContaining(["dialog", "popover", "tooltip", "sheet", "select"]),
+    );
+    expect(registryItemContracts.map((item) => item.name)).toEqual(
+      expect.arrayContaining(["text-field", "select-field", "account-settings"]),
+    );
+  });
+});

--- a/apps/docs/src/lib/primitive-contracts.ts
+++ b/apps/docs/src/lib/primitive-contracts.ts
@@ -1,0 +1,413 @@
+import { getDocsMetadata, primitiveMetadata, type PrimitiveScope } from "@keystone-ui/keystone";
+
+export type PrimitiveContract = {
+  scope: PrimitiveScope;
+  title: string;
+  importPath: string;
+  roleNotes: readonly string[];
+  keyboardNotes: readonly string[];
+  ariaNotes: readonly string[];
+  ssrNotes: readonly string[];
+  example: string;
+};
+
+const overlayNotes = {
+  keyboardNotes: [
+    "Escape dismisses the topmost dismissable layer when dismissal is enabled.",
+    "Focus entry, trap, and restore are owned by Keystone overlay internals where the primitive is modal.",
+  ],
+  ssrNotes: [
+    "Portal and layer behavior runs behind Solid lifecycle guards so server rendering does not touch document APIs.",
+    "Force-mounted content should keep stable data attributes for animation and hydration checks.",
+  ],
+};
+
+const collectionNotes = {
+  keyboardNotes: [
+    "Arrow keys move through enabled items.",
+    "Home and End target collection boundaries where the primitive exposes roving or active-descendant focus.",
+    "Typeahead is shared by listbox, select, combobox, and menu-derived primitives where applicable.",
+  ],
+  ssrNotes: [
+    "Collection registration is DOM-backed after mount and should not require browser globals during SSR.",
+  ],
+};
+
+export const primitiveContracts = [
+  {
+    scope: "accordion",
+    title: "Accordion",
+    importPath: "@keystone-ui/keystone/accordion",
+    roleNotes: ["Headers wrap button triggers; content panels expose disclosure state."],
+    keyboardNotes: [
+      "Arrow keys move between triggers for the configured orientation.",
+      "Home and End move to the first and last enabled trigger.",
+    ],
+    ariaNotes: ["Triggers expose expanded state and control relationships to content panels."],
+    ssrNotes: ["Disclosure state is serializable through stable data attributes."],
+    example: `<Accordion.Root defaultValue="details"><Accordion.Item value="details"><Accordion.Trigger>Details</Accordion.Trigger><Accordion.Content>Content</Accordion.Content></Accordion.Item></Accordion.Root>`,
+  },
+  {
+    scope: "autocomplete",
+    title: "Autocomplete",
+    importPath: "@keystone-ui/keystone/autocomplete",
+    roleNotes: ["Input, listbox, option, group, and popup parts follow the combobox contract."],
+    keyboardNotes: collectionNotes.keyboardNotes,
+    ariaNotes: ["Input and popup relationships are owned by Keystone combobox behavior."],
+    ssrNotes: collectionNotes.ssrNotes,
+    example: `<Autocomplete.Root items={items}><Autocomplete.Input /><Autocomplete.Content><Autocomplete.Listbox /></Autocomplete.Content></Autocomplete.Root>`,
+  },
+  {
+    scope: "calendar",
+    title: "Calendar",
+    importPath: "@keystone-ui/keystone/date-picker",
+    roleNotes: ["Grid, row, column header, cell, and cell trigger parts model a date grid."],
+    keyboardNotes: [
+      "Arrow keys move by day or week; month navigation triggers move visible range.",
+    ],
+    ariaNotes: [
+      "Selected, today, outside-month, disabled, and value state are exposed on date cells.",
+    ],
+    ssrNotes: [
+      "Calendar grid generation is deterministic from value, month, min, max, and locale options.",
+    ],
+    example: `<Calendar.Root><Calendar.Header /><Calendar.Grid /></Calendar.Root>`,
+  },
+  {
+    scope: "checkbox",
+    title: "Checkbox",
+    importPath: "@keystone-ui/keystone/checkbox",
+    roleNotes: [
+      "Root/control parts expose checkbox state and a hidden native input participates in forms.",
+    ],
+    keyboardNotes: ["Space toggles checked state unless the interaction is disabled or prevented."],
+    ariaNotes: [
+      "Checked, indeterminate, required, invalid, readonly, and disabled state are reflected in data and ARIA contracts.",
+    ],
+    ssrNotes: ["Hidden input output is stable for SSR and native form submission."],
+    example: `<Checkbox.Root name="terms"><Checkbox.Control><Checkbox.Indicator /></Checkbox.Control><Checkbox.HiddenInput /></Checkbox.Root>`,
+  },
+  {
+    scope: "collapsible",
+    title: "Collapsible",
+    importPath: "@keystone-ui/keystone/collapsible",
+    roleNotes: ["Trigger and content parts expose disclosure state."],
+    keyboardNotes: ["Button activation toggles open state unless disabled or prevented."],
+    ariaNotes: ["Trigger expanded state and content visibility stay coordinated."],
+    ssrNotes: [
+      "Hidden-until-found and open state are represented through stable content attributes.",
+    ],
+    example: `<Collapsible.Root><Collapsible.Trigger>Toggle</Collapsible.Trigger><Collapsible.Content>Panel</Collapsible.Content></Collapsible.Root>`,
+  },
+  {
+    scope: "combobox",
+    title: "Combobox",
+    importPath: "@keystone-ui/keystone/combobox",
+    roleNotes: [
+      "Input owns text entry while listbox and item parts own option navigation and selection.",
+    ],
+    keyboardNotes: collectionNotes.keyboardNotes,
+    ariaNotes: [
+      "Highlighted, selected, required, invalid, readonly, placeholder, and disabled state are exposed for wrappers.",
+    ],
+    ssrNotes: collectionNotes.ssrNotes,
+    example: `<Combobox.Root items={items}><Combobox.Input /><Combobox.Content><Combobox.Listbox /></Combobox.Content></Combobox.Root>`,
+  },
+  {
+    scope: "context-menu",
+    title: "ContextMenu",
+    importPath: "@keystone-ui/keystone/context-menu",
+    roleNotes: ["Menu, group, separator, item, and indicator parts use the shared menu kernel."],
+    keyboardNotes: collectionNotes.keyboardNotes,
+    ariaNotes: ["Disabled, highlighted, checked, and value metadata are exposed on menu items."],
+    ssrNotes: overlayNotes.ssrNotes,
+    example: `<ContextMenu.Root><ContextMenu.Trigger>Open</ContextMenu.Trigger><ContextMenu.Content><ContextMenu.Item value="copy">Copy</ContextMenu.Item></ContextMenu.Content></ContextMenu.Root>`,
+  },
+  {
+    scope: "date-picker",
+    title: "DatePicker",
+    importPath: "@keystone-ui/keystone/date-picker",
+    roleNotes: [
+      "Root, trigger, content, and nested calendar parts compose date selection with popup behavior.",
+    ],
+    keyboardNotes: [
+      "Trigger opens the calendar popup; calendar keys handle date movement and selection.",
+    ],
+    ariaNotes: [
+      "Open, placeholder, selected value, and disabled state are exposed on public parts.",
+    ],
+    ssrNotes: [
+      "Popup behavior is lifecycle guarded and calendar output is deterministic from date options.",
+    ],
+    example: `<DatePicker.Root><DatePicker.Trigger>Choose date</DatePicker.Trigger><DatePicker.Content><DatePicker.Calendar /></DatePicker.Content></DatePicker.Root>`,
+  },
+  {
+    scope: "dialog",
+    title: "Dialog",
+    importPath: "@keystone-ui/keystone/dialog",
+    roleNotes: [
+      "Content owns dialog semantics while title and description provide accessible naming hooks.",
+    ],
+    keyboardNotes: overlayNotes.keyboardNotes,
+    ariaNotes: [
+      "Title and description IDs are coordinated with content; open state is exposed on overlay parts.",
+    ],
+    ssrNotes: overlayNotes.ssrNotes,
+    example: `<Dialog.Root><Dialog.Trigger>Open</Dialog.Trigger><Dialog.Content><Dialog.Title>Title</Dialog.Title></Dialog.Content></Dialog.Root>`,
+  },
+  {
+    scope: "dropdown-menu",
+    title: "DropdownMenu",
+    importPath: "@keystone-ui/keystone/dropdown-menu",
+    roleNotes: [
+      "Trigger, content, group, separator, item, and indicator parts use menu semantics.",
+    ],
+    keyboardNotes: collectionNotes.keyboardNotes,
+    ariaNotes: ["Open, highlighted, disabled, checked, and value state are exposed to wrappers."],
+    ssrNotes: overlayNotes.ssrNotes,
+    example: `<DropdownMenu.Root><DropdownMenu.Trigger>Actions</DropdownMenu.Trigger><DropdownMenu.Content><DropdownMenu.Item value="edit">Edit</DropdownMenu.Item></DropdownMenu.Content></DropdownMenu.Root>`,
+  },
+  {
+    scope: "form-control",
+    title: "FormControl",
+    importPath: "@keystone-ui/keystone/form",
+    roleNotes: [
+      "Root, label, control, description, error, and hidden input parts describe form-control relationships.",
+    ],
+    keyboardNotes: ["Keyboard behavior remains native to the rendered control."],
+    ariaNotes: [
+      "Required, invalid, readonly, disabled, dirty, touched, filled, focused, and validating state are exposed.",
+    ],
+    ssrNotes: [
+      "Generated IDs and hidden input props should remain stable across server and client renders.",
+    ],
+    example: `const field = createFormControl({ id: "email" });`,
+  },
+  {
+    scope: "hover-card",
+    title: "HoverCard",
+    importPath: "@keystone-ui/keystone/hover-card",
+    roleNotes: ["Trigger, positioner, and content parts expose non-modal preview behavior."],
+    keyboardNotes: overlayNotes.keyboardNotes,
+    ariaNotes: ["Open state, side, align, and geometry variables are exposed for preview content."],
+    ssrNotes: overlayNotes.ssrNotes,
+    example: `<HoverCard.Root><HoverCard.Trigger>Preview</HoverCard.Trigger><HoverCard.Content>Details</HoverCard.Content></HoverCard.Root>`,
+  },
+  {
+    scope: "listbox",
+    title: "Listbox",
+    importPath: "@keystone-ui/keystone/select",
+    roleNotes: ["Listbox, option, group, and group-label parts expose collection state."],
+    keyboardNotes: collectionNotes.keyboardNotes,
+    ariaNotes: ["Options expose selected, highlighted, disabled, and group metadata."],
+    ssrNotes: collectionNotes.ssrNotes,
+    example: `<Select.Listbox><Select.Item value="team">Team</Select.Item></Select.Listbox>`,
+  },
+  {
+    scope: "menu",
+    title: "Menu",
+    importPath: "@keystone-ui/keystone/menu",
+    roleNotes: [
+      "Menu item, group, separator, checkbox/radio item, and indicator behavior share one kernel.",
+    ],
+    keyboardNotes: collectionNotes.keyboardNotes,
+    ariaNotes: ["Checked, highlighted, disabled, and value states are reflected on item parts."],
+    ssrNotes: overlayNotes.ssrNotes,
+    example: `<Menu.Root><Menu.Trigger>Open</Menu.Trigger><Menu.Content><Menu.Item value="copy">Copy</Menu.Item></Menu.Content></Menu.Root>`,
+  },
+  {
+    scope: "menubar",
+    title: "Menubar",
+    importPath: "@keystone-ui/keystone/menubar",
+    roleNotes: ["Menubar composes menu parts with horizontal top-level navigation behavior."],
+    keyboardNotes: collectionNotes.keyboardNotes,
+    ariaNotes: [
+      "Open, highlighted, disabled, checked, and value metadata follow the shared menu contract.",
+    ],
+    ssrNotes: overlayNotes.ssrNotes,
+    example: `<Menubar.Root><Menubar.Trigger>File</Menubar.Trigger><Menubar.Content><Menubar.Item value="new">New</Menubar.Item></Menubar.Content></Menubar.Root>`,
+  },
+  {
+    scope: "navigation-menu",
+    title: "NavigationMenu",
+    importPath: "@keystone-ui/keystone/navigation-menu",
+    roleNotes: [
+      "Navigation menu uses menu-derived trigger, content, group, separator, and item parts.",
+    ],
+    keyboardNotes: collectionNotes.keyboardNotes,
+    ariaNotes: [
+      "Open, highlighted, disabled, checked, and value state are exposed through navigation-menu scope.",
+    ],
+    ssrNotes: overlayNotes.ssrNotes,
+    example: `<NavigationMenu.Root><NavigationMenu.Trigger>Docs</NavigationMenu.Trigger><NavigationMenu.Content><NavigationMenu.Item value="guide">Guide</NavigationMenu.Item></NavigationMenu.Content></NavigationMenu.Root>`,
+  },
+  {
+    scope: "overlay",
+    title: "Overlay",
+    importPath: "@keystone-ui/keystone/overlay",
+    roleNotes: ["Layer parts expose modal and top-layer metadata for overlay coordination."],
+    keyboardNotes: overlayNotes.keyboardNotes,
+    ariaNotes: [
+      "Layer id, index, modal, and top-layer data expose stack state for tests and wrappers.",
+    ],
+    ssrNotes: overlayNotes.ssrNotes,
+    example: `createOverlayLayerStack();`,
+  },
+  {
+    scope: "popover",
+    title: "Popover",
+    importPath: "@keystone-ui/keystone/popover",
+    roleNotes: [
+      "Trigger, positioner, and content parts expose non-modal floating disclosure behavior.",
+    ],
+    keyboardNotes: overlayNotes.keyboardNotes,
+    ariaNotes: ["Open state, side, align, and geometry variables are exposed on floating parts."],
+    ssrNotes: overlayNotes.ssrNotes,
+    example: `<Popover.Root><Popover.Trigger>Open</Popover.Trigger><Popover.Content>Panel</Popover.Content></Popover.Root>`,
+  },
+  {
+    scope: "radio-group",
+    title: "RadioGroup",
+    importPath: "@keystone-ui/keystone/radio-group",
+    roleNotes: ["Root, item, indicator, and hidden input parts expose one selected value."],
+    keyboardNotes: [
+      "Arrow keys move and select enabled radio items; Home and End target collection boundaries.",
+    ],
+    ariaNotes: [
+      "Required, invalid, readonly, disabled, orientation, checked, and state metadata are exposed.",
+    ],
+    ssrNotes: ["Hidden input output is stable for native form submission."],
+    example: `<RadioGroup.Root name="plan"><RadioGroup.Item value="team"><RadioGroup.ItemIndicator /></RadioGroup.Item></RadioGroup.Root>`,
+  },
+  {
+    scope: "select",
+    title: "Select",
+    importPath: "@keystone-ui/keystone/select",
+    roleNotes: [
+      "Trigger, value, popup, listbox, group, item, item text, and indicator parts expose single selection.",
+    ],
+    keyboardNotes: collectionNotes.keyboardNotes,
+    ariaNotes: [
+      "Placeholder, required, invalid, readonly, selected, highlighted, and disabled state are exposed.",
+    ],
+    ssrNotes: collectionNotes.ssrNotes,
+    example: `<Select.Root items={items}><Select.Trigger><Select.Value /></Select.Trigger><Select.Content><Select.Listbox /></Select.Content></Select.Root>`,
+  },
+  {
+    scope: "sheet",
+    title: "Sheet",
+    importPath: "@keystone-ui/keystone/sheet",
+    roleNotes: ["Sheet composes dialog-grade content semantics with side-aware overlay parts."],
+    keyboardNotes: overlayNotes.keyboardNotes,
+    ariaNotes: ["Title, description, open state, and side metadata are exposed for wrappers."],
+    ssrNotes: overlayNotes.ssrNotes,
+    example: `<Sheet.Root side="right"><Sheet.Trigger>Open</Sheet.Trigger><Sheet.Content><Sheet.Title>Panel</Sheet.Title></Sheet.Content></Sheet.Root>`,
+  },
+  {
+    scope: "slider",
+    title: "Slider",
+    importPath: "@keystone-ui/keystone/slider",
+    roleNotes: ["Root, track, range, and thumb parts expose range input behavior."],
+    keyboardNotes: [
+      "Arrow keys step values; Page, Home, and End keys adjust larger increments and bounds.",
+    ],
+    ariaNotes: [
+      "Thumb ARIA value metadata is paired with orientation, disabled, and range CSS variables.",
+    ],
+    ssrNotes: [
+      "Value-derived CSS variables are deterministic from current value, min, max, and orientation.",
+    ],
+    example: `<Slider.Root defaultValue={[40]}><Slider.Track><Slider.Range /><Slider.Thumb index={0} /></Slider.Track></Slider.Root>`,
+  },
+  {
+    scope: "switch",
+    title: "Switch",
+    importPath: "@keystone-ui/keystone/switch",
+    roleNotes: ["Root, control, thumb, and hidden input parts expose switch state."],
+    keyboardNotes: ["Space toggles checked state unless disabled, readonly, or prevented."],
+    ariaNotes: ["Checked, required, invalid, readonly, disabled, and state metadata are exposed."],
+    ssrNotes: ["Hidden input output is stable for native form submission."],
+    example: `<Switch.Root name="notifications"><Switch.Control><Switch.Thumb /></Switch.Control><Switch.HiddenInput /></Switch.Root>`,
+  },
+  {
+    scope: "tabs",
+    title: "Tabs",
+    importPath: "@keystone-ui/keystone/tabs",
+    roleNotes: [
+      "Root, list, trigger, indicator, and content parts expose tablist and tabpanel relationships.",
+    ],
+    keyboardNotes: ["Arrow keys move between triggers; activation may be automatic or manual."],
+    ariaNotes: ["Selected, highlighted, disabled, and orientation state are exposed on tab parts."],
+    ssrNotes: ["Selected content state is deterministic from controlled or default value."],
+    example: `<Tabs.Root defaultValue="overview"><Tabs.List><Tabs.Trigger value="overview">Overview</Tabs.Trigger></Tabs.List><Tabs.Content value="overview">Panel</Tabs.Content></Tabs.Root>`,
+  },
+  {
+    scope: "toast",
+    title: "Toast",
+    importPath: "@keystone-ui/keystone/toast",
+    roleNotes: [
+      "Viewport, root, title, description, action, and close parts expose live notification behavior.",
+    ],
+    keyboardNotes: [
+      "Close and action controls use native button behavior; timers pause on hover/focus where configured.",
+    ],
+    ariaNotes: [
+      "Priority maps to live-region behavior while type and status are exposed as data attributes.",
+    ],
+    ssrNotes: ["Toast manager state is client-owned; rendered parts keep stable data attributes."],
+    example: `toaster.success("Saved");`,
+  },
+  {
+    scope: "toolbar",
+    title: "Toolbar",
+    importPath: "@keystone-ui/keystone/toolbar",
+    roleNotes: [
+      "Root, button, link, and separator parts expose toolbar orientation and item state.",
+    ],
+    keyboardNotes: [
+      "Arrow keys move through enabled toolbar items for the configured orientation.",
+    ],
+    ariaNotes: ["Orientation, pressed, disabled, and separator metadata are exposed."],
+    ssrNotes: [
+      "Roving focus setup is lifecycle-bound and data attributes are stable for SSR output.",
+    ],
+    example: `<Toolbar.Root><Toolbar.Button>Bold</Toolbar.Button><Toolbar.Separator /><Toolbar.Link href="/docs">Docs</Toolbar.Link></Toolbar.Root>`,
+  },
+  {
+    scope: "tooltip",
+    title: "Tooltip",
+    importPath: "@keystone-ui/keystone/tooltip",
+    roleNotes: ["Trigger, positioner, and content parts expose descriptive overlay behavior."],
+    keyboardNotes: overlayNotes.keyboardNotes,
+    ariaNotes: [
+      "Trigger and content IDs support description relationships; floating parts expose geometry data.",
+    ],
+    ssrNotes: overlayNotes.ssrNotes,
+    example: `<Tooltip.Root><Tooltip.Trigger>Help</Tooltip.Trigger><Tooltip.Content>More detail</Tooltip.Content></Tooltip.Root>`,
+  },
+] as const satisfies readonly PrimitiveContract[];
+
+export function getPrimitiveContract(scope: PrimitiveScope): PrimitiveContract {
+  const contract = primitiveContracts.find((candidate) => candidate.scope === scope);
+
+  if (!contract) {
+    throw new Error(`Missing primitive docs contract for ${scope}`);
+  }
+
+  return contract;
+}
+
+export function getPrimitiveDocs(scope: PrimitiveScope) {
+  const metadata = getDocsMetadata(scope);
+
+  if (!metadata) {
+    throw new Error(`Missing primitive metadata for ${scope}`);
+  }
+
+  return {
+    contract: getPrimitiveContract(scope),
+    metadata,
+  };
+}
+
+export const primitiveScopes = Object.keys(primitiveMetadata).sort() as PrimitiveScope[];

--- a/apps/docs/src/lib/registry-contracts.ts
+++ b/apps/docs/src/lib/registry-contracts.ts
@@ -1,0 +1,146 @@
+import accordion from "../../../../registry/default/items/accordion.json";
+import accountSettings from "../../../../registry/default/items/account-settings.json";
+import autocomplete from "../../../../registry/default/items/autocomplete.json";
+import badge from "../../../../registry/default/items/badge.json";
+import button from "../../../../registry/default/items/button.json";
+import card from "../../../../registry/default/items/card.json";
+import checkbox from "../../../../registry/default/items/checkbox.json";
+import cn from "../../../../registry/default/items/cn.json";
+import collapsible from "../../../../registry/default/items/collapsible.json";
+import combobox from "../../../../registry/default/items/combobox.json";
+import contextMenu from "../../../../registry/default/items/context-menu.json";
+import dataTableTanstackRouter from "../../../../registry/default/items/data-table-tanstack-router.json";
+import dataTable from "../../../../registry/default/items/data-table.json";
+import datePicker from "../../../../registry/default/items/date-picker.json";
+import dialog from "../../../../registry/default/items/dialog.json";
+import dropdownMenu from "../../../../registry/default/items/dropdown-menu.json";
+import field from "../../../../registry/default/items/field.json";
+import hoverCard from "../../../../registry/default/items/hover-card.json";
+import input from "../../../../registry/default/items/input.json";
+import label from "../../../../registry/default/items/label.json";
+import menu from "../../../../registry/default/items/menu.json";
+import menubar from "../../../../registry/default/items/menubar.json";
+import navigationMenu from "../../../../registry/default/items/navigation-menu.json";
+import popover from "../../../../registry/default/items/popover.json";
+import radioGroup from "../../../../registry/default/items/radio-group.json";
+import selectField from "../../../../registry/default/items/select-field.json";
+import separator from "../../../../registry/default/items/separator.json";
+import sheet from "../../../../registry/default/items/sheet.json";
+import slider from "../../../../registry/default/items/slider.json";
+import switchItem from "../../../../registry/default/items/switch.json";
+import tabs from "../../../../registry/default/items/tabs.json";
+import textField from "../../../../registry/default/items/text-field.json";
+import textarea from "../../../../registry/default/items/textarea.json";
+import toast from "../../../../registry/default/items/toast.json";
+import toolbar from "../../../../registry/default/items/toolbar.json";
+import tooltip from "../../../../registry/default/items/tooltip.json";
+
+export type RegistryFileContract = {
+  path: string;
+  type: string;
+  target: string;
+};
+
+export type RegistryItemContract = {
+  name: string;
+  title: string;
+  description: string;
+  type: string;
+  install: string;
+  dependencies: readonly string[];
+  registryDependencies: readonly string[];
+  customization: string;
+  caveats: string;
+  files: readonly RegistryFileContract[];
+  parity: Readonly<Record<string, string>>;
+};
+
+const rawItems = [
+  accordion,
+  accountSettings,
+  autocomplete,
+  badge,
+  button,
+  card,
+  checkbox,
+  cn,
+  collapsible,
+  combobox,
+  contextMenu,
+  dataTableTanstackRouter,
+  dataTable,
+  datePicker,
+  dialog,
+  dropdownMenu,
+  field,
+  hoverCard,
+  input,
+  label,
+  menu,
+  menubar,
+  navigationMenu,
+  popover,
+  radioGroup,
+  selectField,
+  separator,
+  sheet,
+  slider,
+  switchItem,
+  tabs,
+  textField,
+  textarea,
+  toast,
+  toolbar,
+  tooltip,
+] as const;
+
+export const registryItemContracts = rawItems
+  .map((item) => ({
+    name: item.name,
+    title: item.title,
+    description: item.description,
+    type: item.type,
+    install: String(item.meta.install),
+    dependencies: item.dependencies ?? [],
+    registryDependencies: item.registryDependencies ?? [],
+    customization: String(item.meta.customization ?? item.meta.limitations ?? ""),
+    caveats: String(
+      item.meta.limitations ??
+        "Generated output is user-owned source. Mason may plan future diffs and updates, but app teams can edit the installed files.",
+    ),
+    files: item.files.map((file) => ({
+      path: file.path,
+      type: file.type,
+      target: file.target ?? deriveTarget(file.path, file.type),
+    })),
+    parity: item.meta.parity as Readonly<Record<string, string>>,
+  }))
+  .sort((left, right) =>
+    left.name.localeCompare(right.name),
+  ) satisfies readonly RegistryItemContract[];
+
+export function getRegistryItemContract(name: string): RegistryItemContract {
+  const item = registryItemContracts.find((candidate) => candidate.name === name);
+
+  if (!item) {
+    throw new Error(`Missing registry docs contract for ${name}`);
+  }
+
+  return item;
+}
+
+function deriveTarget(sourcePath: string, type: string): string {
+  if (type === "registry:block") {
+    return sourcePath.replace(/^blocks\//, "src/components/blocks/");
+  }
+
+  if (type === "registry:lib") {
+    return sourcePath.replace(/^lib\//, "src/lib/");
+  }
+
+  if (sourcePath.startsWith("components/")) {
+    return `src/${sourcePath}`;
+  }
+
+  return sourcePath.replace(/^ui\//, "src/components/ui/");
+}

--- a/apps/docs/src/routeTree.gen.ts
+++ b/apps/docs/src/routeTree.gen.ts
@@ -13,9 +13,11 @@ import { Route as IndexRouteImport } from './routes/index'
 import { Route as DocsOverlayPopoverTooltipSheetRouteImport } from './routes/docs.overlay.popover-tooltip-sheet'
 import { Route as DocsMasonTextFieldRouteImport } from './routes/docs.mason.text-field'
 import { Route as DocsMasonSelectFieldRouteImport } from './routes/docs.mason.select-field'
+import { Route as DocsMasonRegistryRouteImport } from './routes/docs.mason.registry'
 import { Route as DocsMasonDialogRouteImport } from './routes/docs.mason.dialog'
 import { Route as DocsMasonDataTableRouteImport } from './routes/docs.mason.data-table'
 import { Route as DocsKeystoneDialogRouteImport } from './routes/docs.keystone.dialog'
+import { Route as DocsKeystoneContractsRouteImport } from './routes/docs.keystone.contracts'
 
 const IndexRoute = IndexRouteImport.update({
   id: '/',
@@ -38,6 +40,11 @@ const DocsMasonSelectFieldRoute = DocsMasonSelectFieldRouteImport.update({
   path: '/docs/mason/select-field',
   getParentRoute: () => rootRouteImport,
 } as any)
+const DocsMasonRegistryRoute = DocsMasonRegistryRouteImport.update({
+  id: '/docs/mason/registry',
+  path: '/docs/mason/registry',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const DocsMasonDialogRoute = DocsMasonDialogRouteImport.update({
   id: '/docs/mason/dialog',
   path: '/docs/mason/dialog',
@@ -53,21 +60,30 @@ const DocsKeystoneDialogRoute = DocsKeystoneDialogRouteImport.update({
   path: '/docs/keystone/dialog',
   getParentRoute: () => rootRouteImport,
 } as any)
+const DocsKeystoneContractsRoute = DocsKeystoneContractsRouteImport.update({
+  id: '/docs/keystone/contracts',
+  path: '/docs/keystone/contracts',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/docs/keystone/contracts': typeof DocsKeystoneContractsRoute
   '/docs/keystone/dialog': typeof DocsKeystoneDialogRoute
   '/docs/mason/data-table': typeof DocsMasonDataTableRoute
   '/docs/mason/dialog': typeof DocsMasonDialogRoute
+  '/docs/mason/registry': typeof DocsMasonRegistryRoute
   '/docs/mason/select-field': typeof DocsMasonSelectFieldRoute
   '/docs/mason/text-field': typeof DocsMasonTextFieldRoute
   '/docs/overlay/popover-tooltip-sheet': typeof DocsOverlayPopoverTooltipSheetRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/docs/keystone/contracts': typeof DocsKeystoneContractsRoute
   '/docs/keystone/dialog': typeof DocsKeystoneDialogRoute
   '/docs/mason/data-table': typeof DocsMasonDataTableRoute
   '/docs/mason/dialog': typeof DocsMasonDialogRoute
+  '/docs/mason/registry': typeof DocsMasonRegistryRoute
   '/docs/mason/select-field': typeof DocsMasonSelectFieldRoute
   '/docs/mason/text-field': typeof DocsMasonTextFieldRoute
   '/docs/overlay/popover-tooltip-sheet': typeof DocsOverlayPopoverTooltipSheetRoute
@@ -75,9 +91,11 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/docs/keystone/contracts': typeof DocsKeystoneContractsRoute
   '/docs/keystone/dialog': typeof DocsKeystoneDialogRoute
   '/docs/mason/data-table': typeof DocsMasonDataTableRoute
   '/docs/mason/dialog': typeof DocsMasonDialogRoute
+  '/docs/mason/registry': typeof DocsMasonRegistryRoute
   '/docs/mason/select-field': typeof DocsMasonSelectFieldRoute
   '/docs/mason/text-field': typeof DocsMasonTextFieldRoute
   '/docs/overlay/popover-tooltip-sheet': typeof DocsOverlayPopoverTooltipSheetRoute
@@ -86,27 +104,33 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/docs/keystone/contracts'
     | '/docs/keystone/dialog'
     | '/docs/mason/data-table'
     | '/docs/mason/dialog'
+    | '/docs/mason/registry'
     | '/docs/mason/select-field'
     | '/docs/mason/text-field'
     | '/docs/overlay/popover-tooltip-sheet'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/docs/keystone/contracts'
     | '/docs/keystone/dialog'
     | '/docs/mason/data-table'
     | '/docs/mason/dialog'
+    | '/docs/mason/registry'
     | '/docs/mason/select-field'
     | '/docs/mason/text-field'
     | '/docs/overlay/popover-tooltip-sheet'
   id:
     | '__root__'
     | '/'
+    | '/docs/keystone/contracts'
     | '/docs/keystone/dialog'
     | '/docs/mason/data-table'
     | '/docs/mason/dialog'
+    | '/docs/mason/registry'
     | '/docs/mason/select-field'
     | '/docs/mason/text-field'
     | '/docs/overlay/popover-tooltip-sheet'
@@ -114,9 +138,11 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  DocsKeystoneContractsRoute: typeof DocsKeystoneContractsRoute
   DocsKeystoneDialogRoute: typeof DocsKeystoneDialogRoute
   DocsMasonDataTableRoute: typeof DocsMasonDataTableRoute
   DocsMasonDialogRoute: typeof DocsMasonDialogRoute
+  DocsMasonRegistryRoute: typeof DocsMasonRegistryRoute
   DocsMasonSelectFieldRoute: typeof DocsMasonSelectFieldRoute
   DocsMasonTextFieldRoute: typeof DocsMasonTextFieldRoute
   DocsOverlayPopoverTooltipSheetRoute: typeof DocsOverlayPopoverTooltipSheetRoute
@@ -152,6 +178,13 @@ declare module '@tanstack/solid-router' {
       preLoaderRoute: typeof DocsMasonSelectFieldRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/docs/mason/registry': {
+      id: '/docs/mason/registry'
+      path: '/docs/mason/registry'
+      fullPath: '/docs/mason/registry'
+      preLoaderRoute: typeof DocsMasonRegistryRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/docs/mason/dialog': {
       id: '/docs/mason/dialog'
       path: '/docs/mason/dialog'
@@ -173,14 +206,23 @@ declare module '@tanstack/solid-router' {
       preLoaderRoute: typeof DocsKeystoneDialogRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/docs/keystone/contracts': {
+      id: '/docs/keystone/contracts'
+      path: '/docs/keystone/contracts'
+      fullPath: '/docs/keystone/contracts'
+      preLoaderRoute: typeof DocsKeystoneContractsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  DocsKeystoneContractsRoute: DocsKeystoneContractsRoute,
   DocsKeystoneDialogRoute: DocsKeystoneDialogRoute,
   DocsMasonDataTableRoute: DocsMasonDataTableRoute,
   DocsMasonDialogRoute: DocsMasonDialogRoute,
+  DocsMasonRegistryRoute: DocsMasonRegistryRoute,
   DocsMasonSelectFieldRoute: DocsMasonSelectFieldRoute,
   DocsMasonTextFieldRoute: DocsMasonTextFieldRoute,
   DocsOverlayPopoverTooltipSheetRoute: DocsOverlayPopoverTooltipSheetRoute,

--- a/apps/docs/src/routes/__root.tsx
+++ b/apps/docs/src/routes/__root.tsx
@@ -1,7 +1,6 @@
 /// <reference types="vite/client" />
 
 import { HeadContent, Outlet, Scripts, createRootRouteWithContext } from "@tanstack/solid-router";
-import { TanStackRouterDevtools } from "@tanstack/solid-router-devtools";
 import type { JSX } from "solid-js";
 import { Suspense } from "solid-js";
 import { HydrationScript } from "solid-js/web";
@@ -30,7 +29,6 @@ function RootComponent() {
         <Header />
         <Outlet />
       </div>
-      <TanStackRouterDevtools />
     </RootDocument>
   );
 }

--- a/apps/docs/src/routes/docs.keystone.contracts.tsx
+++ b/apps/docs/src/routes/docs.keystone.contracts.tsx
@@ -1,0 +1,148 @@
+import { createFileRoute, Link } from "@tanstack/solid-router";
+import { ArrowLeft, BookOpen, Code2, Keyboard, ShieldCheck } from "lucide-solid";
+import { For, createSignal } from "solid-js";
+
+import { getPrimitiveDocs, primitiveScopes } from "@/lib/primitive-contracts";
+
+export const Route = createFileRoute("/docs/keystone/contracts")({
+  component: KeystoneContractsDocs,
+});
+
+const initialScope = "dialog";
+
+function KeystoneContractsDocs() {
+  const [selectedScope, setSelectedScope] = createSignal(initialScope);
+  const selected = () => getPrimitiveDocs(selectedScope() as (typeof primitiveScopes)[number]);
+
+  return (
+    <main class="doc-page">
+      <div class="doc-shell">
+        <Link to="/" class="back-link">
+          <ArrowLeft size={17} />
+          Overview
+        </Link>
+
+        <section class="doc-hero">
+          <div>
+            <p class="eyebrow">Keystone contracts</p>
+            <h1>Primitive metadata</h1>
+            <p class="doc-lede">
+              Public primitive contracts are rendered from Keystone part metadata plus docs notes
+              for roles, keyboard behavior, ARIA, SSR, and examples. This page is the broad contract
+              index; individual deep pages can build on the same source.
+            </p>
+          </div>
+
+          <div class="doc-fact-panel" aria-label="Primitive metadata facts">
+            <span>Primitive scopes</span>
+            <strong>{primitiveScopes.length}</strong>
+            <span>Contract source</span>
+            <strong>@keystone-ui/keystone metadata</strong>
+            <span>Coverage check</span>
+            <strong>docs contract test</strong>
+          </div>
+        </section>
+
+        <section class="contract-layout">
+          <nav class="contract-nav" aria-label="Primitive contracts">
+            <For each={primitiveScopes}>
+              {(scope) => {
+                const docs = getPrimitiveDocs(scope);
+                return (
+                  <button
+                    class="contract-nav-item"
+                    classList={{ "is-active": selectedScope() === scope }}
+                    type="button"
+                    onClick={() => setSelectedScope(scope)}
+                  >
+                    <span>{docs.contract.title}</span>
+                    <small>{docs.metadata.parts.length} parts</small>
+                  </button>
+                );
+              }}
+            </For>
+          </nav>
+
+          <article class="contract-detail">
+            <div class="contract-detail-header">
+              <div>
+                <p class="eyebrow">{selected().metadata.scope}</p>
+                <h2>{selected().contract.title}</h2>
+              </div>
+              <code>{selected().contract.importPath}</code>
+            </div>
+
+            <section class="doc-panel-grid compact">
+              <ContractNote icon={<ShieldCheck size={18} />} title="Roles">
+                <For each={selected().contract.roleNotes}>{(note) => <li>{note}</li>}</For>
+              </ContractNote>
+              <ContractNote icon={<Keyboard size={18} />} title="Keyboard">
+                <For each={selected().contract.keyboardNotes}>{(note) => <li>{note}</li>}</For>
+              </ContractNote>
+              <ContractNote icon={<BookOpen size={18} />} title="ARIA">
+                <For each={selected().contract.ariaNotes}>{(note) => <li>{note}</li>}</For>
+              </ContractNote>
+              <ContractNote icon={<Code2 size={18} />} title="SSR">
+                <For each={selected().contract.ssrNotes}>{(note) => <li>{note}</li>}</For>
+              </ContractNote>
+            </section>
+
+            <section class="doc-panel">
+              <h2>Parts</h2>
+              <div class="metadata-table" role="table" aria-label="Primitive parts">
+                <div class="metadata-row metadata-head" role="row">
+                  <span role="columnheader">Selector</span>
+                  <span role="columnheader">Data attributes</span>
+                  <span role="columnheader">CSS variables</span>
+                </div>
+                <For each={selected().metadata.parts}>
+                  {(part) => (
+                    <div class="metadata-row" role="row">
+                      <code role="cell">{part.selector}</code>
+                      <span role="cell">
+                        {part.dataAttributes
+                          .map((attribute) =>
+                            attribute.values
+                              ? `${attribute.name}=${attribute.values.join("|")}`
+                              : attribute.name,
+                          )
+                          .join(", ")}
+                      </span>
+                      <span role="cell">
+                        {part.cssVars.length > 0
+                          ? part.cssVars.map((cssVar) => cssVar.name).join(", ")
+                          : "None"}
+                      </span>
+                    </div>
+                  )}
+                </For>
+              </div>
+            </section>
+
+            <section class="doc-section">
+              <div class="doc-section-title">
+                <Code2 size={19} />
+                <h2>Example</h2>
+              </div>
+              <pre>
+                <code>{selected().contract.example}</code>
+              </pre>
+            </section>
+          </article>
+        </section>
+      </div>
+    </main>
+  );
+}
+
+function ContractNote(props: { icon: Element; title: string; children: Element }) {
+  return (
+    <article class="doc-panel">
+      <div class="doc-section-title">
+        {props.icon}
+        <h2>{props.title}</h2>
+      </div>
+      <ul class="doc-list">{props.children}</ul>
+    </article>
+  );
+}

--- a/apps/docs/src/routes/docs.mason.registry.tsx
+++ b/apps/docs/src/routes/docs.mason.registry.tsx
@@ -1,0 +1,153 @@
+import { createFileRoute, Link } from "@tanstack/solid-router";
+import { ArrowLeft, FileJson2, PackageCheck, Paintbrush } from "lucide-solid";
+import { For, createMemo, createSignal } from "solid-js";
+
+import { getRegistryItemContract, registryItemContracts } from "@/lib/registry-contracts";
+
+export const Route = createFileRoute("/docs/mason/registry")({
+  component: MasonRegistryDocs,
+});
+
+const initialItem = "dialog";
+
+function MasonRegistryDocs() {
+  const [selectedName, setSelectedName] = createSignal(initialItem);
+  const selected = createMemo(() => getRegistryItemContract(selectedName()));
+  const blockItems = registryItemContracts.filter((item) => item.type === "registry:block");
+  const templateItems = registryItemContracts.filter((item) => item.type === "registry:template");
+
+  return (
+    <main class="doc-page mason-doc-page">
+      <div class="doc-shell">
+        <Link to="/" class="back-link">
+          <ArrowLeft size={17} />
+          Overview
+        </Link>
+
+        <section class="doc-hero">
+          <div>
+            <p class="eyebrow">Mason registry</p>
+            <h1>Item contracts</h1>
+            <p class="doc-lede">
+              Every first-party registry item exposes install, file, dependency, customization,
+              caveat, and parity metadata. This page reads the same item JSON that the CLI
+              validates.
+            </p>
+          </div>
+
+          <div class="doc-fact-panel" aria-label="Registry metadata facts">
+            <span>Registry items</span>
+            <strong>{registryItemContracts.length}</strong>
+            <span>First block</span>
+            <strong>{blockItems[0]?.name ?? "Not shipped"}</strong>
+            <span>Templates</span>
+            <strong>{templateItems.length > 0 ? templateItems.length : "Not shipped yet"}</strong>
+          </div>
+        </section>
+
+        <section class="contract-layout">
+          <nav class="contract-nav" aria-label="Registry items">
+            <For each={registryItemContracts}>
+              {(item) => (
+                <button
+                  class="contract-nav-item"
+                  classList={{ "is-active": selectedName() === item.name }}
+                  type="button"
+                  onClick={() => setSelectedName(item.name)}
+                >
+                  <span>{item.name}</span>
+                  <small>{item.type}</small>
+                </button>
+              )}
+            </For>
+          </nav>
+
+          <article class="contract-detail">
+            <div class="contract-detail-header">
+              <div>
+                <p class="eyebrow">{selected().type}</p>
+                <h2>{selected().title}</h2>
+                <p>{selected().description}</p>
+              </div>
+              <code>{selected().install}</code>
+            </div>
+
+            <section class="doc-panel-grid compact">
+              <article class="doc-panel">
+                <div class="doc-section-title">
+                  <PackageCheck size={18} />
+                  <h2>Dependencies</h2>
+                </div>
+                <ul class="doc-list">
+                  <li>
+                    Packages:{" "}
+                    {selected().dependencies.length > 0
+                      ? selected().dependencies.join(", ")
+                      : "None"}
+                  </li>
+                  <li>
+                    Registry items:{" "}
+                    {selected().registryDependencies.length > 0
+                      ? selected().registryDependencies.join(", ")
+                      : "None"}
+                  </li>
+                </ul>
+              </article>
+
+              <article class="doc-panel">
+                <div class="doc-section-title">
+                  <Paintbrush size={18} />
+                  <h2>Customization</h2>
+                </div>
+                <p>{selected().customization}</p>
+              </article>
+            </section>
+
+            <section class="doc-panel">
+              <h2>File Tree</h2>
+              <div class="metadata-table" role="table" aria-label="Registry files">
+                <div class="metadata-row metadata-head" role="row">
+                  <span role="columnheader">Source</span>
+                  <span role="columnheader">Target</span>
+                  <span role="columnheader">Type</span>
+                </div>
+                <For each={selected().files}>
+                  {(file) => (
+                    <div class="metadata-row" role="row">
+                      <code role="cell">{file.path}</code>
+                      <code role="cell">{file.target}</code>
+                      <span role="cell">{file.type}</span>
+                    </div>
+                  )}
+                </For>
+              </div>
+            </section>
+
+            <section class="doc-panel-grid compact">
+              <article class="doc-panel">
+                <div class="doc-section-title">
+                  <FileJson2 size={18} />
+                  <h2>Parity Notes</h2>
+                </div>
+                <ul class="doc-list">
+                  <For each={Object.entries(selected().parity)}>
+                    {([reference, note]) => (
+                      <li>
+                        <strong>{reference}</strong>: {note}
+                      </li>
+                    )}
+                  </For>
+                </ul>
+              </article>
+
+              <article class="doc-panel">
+                <h2>Generated Output Caveat</h2>
+                <p>{selected().caveats}</p>
+              </article>
+            </section>
+          </article>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/apps/docs/src/routes/index.tsx
+++ b/apps/docs/src/routes/index.tsx
@@ -1,16 +1,16 @@
-import { createFileRoute } from "@tanstack/solid-router";
 import { Dialog } from "@keystone-ui/keystone/dialog";
 import { Select } from "@keystone-ui/keystone/select";
+import { createFileRoute } from "@tanstack/solid-router";
 import {
   ArrowRight,
   BookOpen,
-  CheckCircle2,
+  Boxes,
   Code2,
   FileJson2,
   Layers,
   PackageCheck,
+  RouteIcon,
   Sparkles,
-  Terminal,
 } from "lucide-solid";
 import { For } from "solid-js";
 
@@ -18,50 +18,104 @@ export const Route = createFileRoute("/")({
   component: App,
 });
 
-const releaseChecks = [
-  "Keystone kernel tests",
-  "Dialog and Select behavior tests",
-  "Mason CLI generated app build",
-  "Registry validation and path safety",
-  "Example app SSR/build smoke",
-  "Web SSR build",
-];
-
-const primitives = [
+const entryPoints = [
   {
-    name: "Dialog",
-    status: "Dogfooded",
-    copy: "Focus entry, focus trap, restore, top-layer dismissal, preventable outside interaction.",
+    icon: <Layers size={19} />,
+    title: "Use Keystone",
+    body: "Start with unstyled Solid primitives. Learn anatomy, behavior, accessibility, data attributes, CSS variables, and SSR constraints.",
+    href: "/docs/keystone/contracts",
+    action: "Read primitive contracts",
   },
   {
-    name: "Select",
-    status: "Dogfooded",
-    copy: "Collection registration, typeahead, list navigation, form reset, floating geometry.",
+    icon: <FileJson2 size={19} />,
+    title: "Use Mason",
+    body: "Install editable source for app UI. Inspect generated files, registry dependencies, target paths, caveats, and parity notes.",
+    href: "/docs/mason/registry",
+    action: "Browse registry contracts",
   },
   {
-    name: "Form control",
-    status: "Kernel",
-    copy: "ARIA relationships, state attributes, hidden input props, reset hooks.",
-  },
-  {
-    name: "Overlay",
-    status: "Kernel",
-    copy: "Dismissable layer, focus scope, layer stack, pointer-event isolation.",
+    icon: <BookOpen size={19} />,
+    title: "Read a primitive page",
+    body: "Dialog is the model page for Keystone docs: import, anatomy, controlled state, focus, dismissal, styling, and deeper references.",
+    href: "/docs/keystone/dialog",
+    action: "Open Dialog docs",
   },
 ];
 
-const masonFlow = [
-  "Detect Solid app shape",
-  "Resolve registry dependencies",
-  "Plan target writes",
-  "Dry-run or apply source files",
-  "Typecheck and build generated output",
+const keystoneDocs = [
+  {
+    title: "Primitive contracts",
+    body: "Metadata-backed parts, ARIA notes, keyboard behavior, data attributes, CSS variables, SSR notes, and examples.",
+    href: "/docs/keystone/contracts",
+  },
+  {
+    title: "Dialog",
+    body: "Modal overlay behavior: focus entry, trap, restore, outside interaction, escape dismissal, ARIA relationships, and styling hooks.",
+    href: "/docs/keystone/dialog",
+  },
+  {
+    title: "Overlay vertical",
+    body: "Popover, Tooltip, and Sheet share the Keystone overlay layer model, geometry contracts, and modal/non-modal boundaries.",
+    href: "/docs/overlay/popover-tooltip-sheet",
+  },
 ];
 
-const nextWork = [
-  { issue: "#14", title: "Example app verification tracer", tone: "amber" },
-  { issue: "#13", title: "Docs product tracer", tone: "blue" },
-  { issue: "#12", title: "First Mason block tracer", tone: "green" },
+const masonDocs = [
+  {
+    title: "Registry contracts",
+    body: "Install commands, file trees, dependencies, generated-output caveats, customization notes, and parity references.",
+    href: "/docs/mason/registry",
+  },
+  {
+    title: "TanStack Form field",
+    body: "TextField shows how Mason owns app form integration while Keystone keeps form-control behavior generic.",
+    href: "/docs/mason/text-field",
+  },
+  {
+    title: "TanStack DataTable",
+    body: "DataTable documents the editable source layer around TanStack Table: toolbar, filters, pagination, row actions, and router state.",
+    href: "/docs/mason/data-table",
+  },
+];
+
+const primitiveTemplate = [
+  "Import",
+  "When to use",
+  "Anatomy",
+  "Basic example",
+  "Behavior",
+  "Accessibility",
+  "Styling contract",
+  "SSR notes",
+  "API reference",
+];
+
+const registryTemplate = [
+  "Install",
+  "What gets added",
+  "Usage",
+  "Generated source contract",
+  "Customization",
+  "Parity notes",
+  "Limitations",
+];
+
+const statusNotes = [
+  {
+    label: "Keystone",
+    value: "behavior first",
+    body: "Depth comes before catalog breadth. Dialog, Select, overlay, collection, and form-control contracts lead the docs.",
+  },
+  {
+    label: "Mason",
+    value: "source owned",
+    body: "Generated files are readable Solid source. Mason should explain writes, dependencies, and escape hatches before showing volume.",
+  },
+  {
+    label: "Reference",
+    value: "metadata backed",
+    body: "Contract pages can stay generated, but they should sit behind learning pages instead of replacing them.",
+  },
 ];
 
 function App() {
@@ -70,35 +124,40 @@ function App() {
       <section class="hero-section">
         <div class="hero-grid">
           <div class="hero-copy">
-            <p class="eyebrow">0.1.0 preparation surface</p>
-            <h1>Accessible Solid primitives. Editable app source.</h1>
+            <p class="eyebrow">Keystone UI docs</p>
+            <h1>Solid primitives and editable app source.</h1>
             <p class="hero-lede">
-              Keystone is the behavior layer. Mason is the source registry that installs UI into the
-              user project. This docs app is now the docs product surface and uses the local
-              Keystone package directly.
+              Keystone documents accessible, unstyled primitive behavior. Mason documents the source
+              registry that installs styled Solid components, blocks, and app integrations into user
+              projects.
             </p>
             <div class="hero-actions">
-              <a class="command-button primary" href="#keystone">
-                <Layers size={18} />
-                Inspect primitives
+              <a class="command-button primary" href="#start">
+                <RouteIcon size={18} />
+                Start here
               </a>
-              <a class="command-button secondary" href="#release">
-                <PackageCheck size={18} />
-                Release gate
+              <a class="command-button secondary" href="#shape">
+                <BookOpen size={18} />
+                Docs shape
               </a>
             </div>
           </div>
 
-          <div class="status-console" aria-label="Current verification state">
+          <div class="status-console" aria-label="Documentation model">
             <div class="console-topline">
-              <span>release/readiness</span>
-              <span>passing</span>
+              <span>docs/model</span>
+              <span>two tracks</span>
             </div>
-            <For each={releaseChecks}>
+            <For each={statusNotes}>
               {(item) => (
-                <div class="console-row">
-                  <CheckCircle2 size={17} />
-                  <span>{item}</span>
+                <div class="console-row doc-model-row">
+                  <PackageCheck size={17} />
+                  <span>
+                    <strong>{item.label}</strong>
+                    <small>
+                      {item.value}. {item.body}
+                    </small>
+                  </span>
                 </div>
               )}
             </For>
@@ -106,27 +165,54 @@ function App() {
         </div>
       </section>
 
-      <section id="keystone" class="surface-band">
+      <section id="start" class="surface-band">
         <div class="section-heading">
-          <p class="eyebrow">Keystone</p>
-          <h2>Primitive behavior is the product.</h2>
+          <p class="eyebrow">Start here</p>
+          <h2>Choose the layer you are working in.</h2>
           <p>
-            The first kernel pass is centered on Dialog and Select because overlays and item
-            collections prove most of the hard behavior.
+            The first decision in these docs should be whether you need primitive behavior or
+            editable application source. That split keeps Keystone independent and Mason practical.
           </p>
         </div>
 
-        <div class="primitive-layout">
-          <div class="primitive-list">
-            <For each={primitives}>
-              {(primitive) => (
-                <article class="primitive-item">
-                  <div>
-                    <h3>{primitive.name}</h3>
-                    <p>{primitive.copy}</p>
-                  </div>
-                  <span>{primitive.status}</span>
-                </article>
+        <div class="entry-grid">
+          <For each={entryPoints}>
+            {(item) => (
+              <a class="entry-card" href={item.href}>
+                <div class="entry-icon">{item.icon}</div>
+                <h3>{item.title}</h3>
+                <p>{item.body}</p>
+                <span>
+                  {item.action}
+                  <ArrowRight size={16} />
+                </span>
+              </a>
+            )}
+          </For>
+        </div>
+      </section>
+
+      <section id="keystone" class="surface-band">
+        <div class="section-heading">
+          <p class="eyebrow">Keystone</p>
+          <h2>Primitive pages should teach behavior before props.</h2>
+          <p>
+            Base UI is the runtime-depth reference and Kobalte is the Solid-shape reference.
+            Keystone docs should explain when to use a primitive, how its parts compose, and what
+            behavior it guarantees.
+          </p>
+        </div>
+
+        <div class="docs-track-grid">
+          <div class="doc-lanes">
+            <For each={keystoneDocs}>
+              {(item) => (
+                <DocLane
+                  icon={<BookOpen size={20} />}
+                  title={item.title}
+                  body={item.body}
+                  href={item.href}
+                />
               )}
             </For>
           </div>
@@ -134,7 +220,7 @@ function App() {
           <div class="live-lab">
             <div class="lab-header">
               <Code2 size={18} />
-              <span>Live Keystone parts</span>
+              <span>Primitive proof</span>
             </div>
             <DialogDemo />
             <SelectDemo />
@@ -145,94 +231,97 @@ function App() {
       <section id="mason" class="mason-section">
         <div class="section-heading narrow">
           <p class="eyebrow">Mason</p>
-          <h2>The registry installs source, not mystery runtime.</h2>
+          <h2>Registry pages should explain the write plan.</h2>
           <p>
-            Mason maps shadcn-style registry concepts onto Solid and Keystone. Generated files are
-            ordinary source files owned by the app.
+            Mason is closer to shadcn than to a runtime component package. The docs should show the
+            command, the files, the dependencies, the owned source contract, and the limits.
           </p>
         </div>
 
-        <div class="mason-flow" aria-label="Mason install flow">
-          <For each={masonFlow}>
-            {(step, index) => (
-              <div class="flow-step">
-                <span>{String(index() + 1).padStart(2, "0")}</span>
-                <p>{step}</p>
-              </div>
-            )}
-          </For>
-        </div>
-      </section>
-
-      <section id="docs" class="docs-band">
-        <div class="docs-grid">
-          <div>
-            <p class="eyebrow">Docs map</p>
-            <h2>What this app should grow into next.</h2>
+        <div class="docs-track-grid">
+          <div class="mason-flow" aria-label="Mason install flow">
+            <FlowStep index="01" title="Detect app" />
+            <FlowStep index="02" title="Resolve registry dependencies" />
+            <FlowStep index="03" title="Plan target writes" />
+            <FlowStep index="04" title="Dry-run or apply source" />
+            <FlowStep index="05" title="Verify generated output" />
           </div>
+
           <div class="doc-lanes">
-            <DocLane
-              icon={<BookOpen size={20} />}
-              title="Primitive docs"
-              body="Anatomy, keyboard behavior, ARIA, data attributes, examples, known limits."
-              href="/docs/keystone/dialog"
-            />
-            <DocLane
-              icon={<FileJson2 size={20} />}
-              title="Registry docs"
-              body="Item schema, dependency resolution, path safety, source ownership, install plans."
-              href="/docs/mason/dialog"
-            />
-            <DocLane
-              icon={<FileJson2 size={20} />}
-              title="TanStack Form field"
-              body="Mason TextField proves the app form layer without pulling TanStack into Keystone."
-              href="/docs/mason/text-field"
-            />
-            <DocLane
-              icon={<FileJson2 size={20} />}
-              title="TanStack Select field"
-              body="Mason SelectField composes TanStack Form state with Keystone Select behavior."
-              href="/docs/mason/select-field"
-            />
-            <DocLane
-              icon={<FileJson2 size={20} />}
-              title="TanStack DataTable"
-              body="Mason DataTable wraps TanStack Table for sorting, filtering, pagination, and row actions."
-              href="/docs/mason/data-table"
-            />
-            <DocLane
-              icon={<Terminal size={20} />}
-              title="CLI docs"
-              body="Init, add, dry-run, generated-output verification, and framework detection."
-            />
-          </div>
-        </div>
-      </section>
-
-      <section id="release" class="release-section">
-        <div class="release-panel">
-          <div class="release-title">
-            <p class="eyebrow">Remaining before 0.1.0</p>
-            <h2>Keep the release small and legible.</h2>
-          </div>
-          <div class="release-issues">
-            <For each={nextWork}>
+            <For each={masonDocs}>
               {(item) => (
-                <a
-                  class={`issue-link issue-${item.tone}`}
-                  href={`https://github.com/erik-kroon/keystone-ui/issues/${item.issue.slice(1)}`}
-                >
-                  <span>{item.issue}</span>
-                  <strong>{item.title}</strong>
-                  <ArrowRight size={17} />
-                </a>
+                <DocLane
+                  icon={<FileJson2 size={20} />}
+                  title={item.title}
+                  body={item.body}
+                  href={item.href}
+                />
               )}
             </For>
           </div>
         </div>
       </section>
+
+      <section id="shape" class="docs-band">
+        <div class="docs-grid">
+          <div>
+            <p class="eyebrow">Docs shape</p>
+            <h2>The map each page should follow.</h2>
+            <p class="section-note">
+              The content system should be predictable enough that maintainers, users, and agents
+              know where a detail belongs.
+            </p>
+          </div>
+          <div class="template-grid">
+            <TemplateList
+              icon={<Layers size={20} />}
+              title="Keystone primitive page"
+              items={primitiveTemplate}
+            />
+            <TemplateList
+              icon={<Boxes size={20} />}
+              title="Mason registry item page"
+              items={registryTemplate}
+            />
+          </div>
+        </div>
+      </section>
+
+      <section id="reference" class="release-section">
+        <div class="release-panel">
+          <div class="release-title">
+            <p class="eyebrow">Reference</p>
+            <h2>Generated contracts stay useful, but move behind the learning path.</h2>
+          </div>
+          <div class="release-issues">
+            <a class="issue-link issue-green" href="/docs/keystone/contracts">
+              <span>Keystone</span>
+              <strong>Primitive metadata reference</strong>
+              <ArrowRight size={17} />
+            </a>
+            <a class="issue-link issue-blue" href="/docs/mason/registry">
+              <span>Mason</span>
+              <strong>Registry metadata reference</strong>
+              <ArrowRight size={17} />
+            </a>
+            <a class="issue-link issue-amber" href="/docs/overlay/popover-tooltip-sheet">
+              <span>Overlay</span>
+              <strong>Shared overlay vertical</strong>
+              <ArrowRight size={17} />
+            </a>
+          </div>
+        </div>
+      </section>
     </main>
+  );
+}
+
+function FlowStep(props: { index: string; title: string }) {
+  return (
+    <div class="flow-step">
+      <span>{props.index}</span>
+      <p>{props.title}</p>
+    </div>
   );
 }
 
@@ -289,24 +378,28 @@ function SelectDemo() {
   );
 }
 
-function DocLane(props: { icon: Element; title: string; body: string; href?: string }) {
-  const content = (
-    <>
+function DocLane(props: { icon: Element; title: string; body: string; href: string }) {
+  return (
+    <a class="doc-lane" href={props.href}>
       <div class="doc-icon">{props.icon}</div>
       <div>
         <h3>{props.title}</h3>
         <p>{props.body}</p>
       </div>
-    </>
+    </a>
   );
+}
 
-  if (props.href) {
-    return (
-      <a class="doc-lane" href={props.href}>
-        {content}
-      </a>
-    );
-  }
-
-  return <article class="doc-lane">{content}</article>;
+function TemplateList(props: { icon: Element; title: string; items: readonly string[] }) {
+  return (
+    <article class="template-list">
+      <div class="doc-section-title">
+        {props.icon}
+        <h3>{props.title}</h3>
+      </div>
+      <ol>
+        <For each={props.items}>{(item) => <li>{item}</li>}</For>
+      </ol>
+    </article>
+  );
 }

--- a/apps/docs/src/styles.css
+++ b/apps/docs/src/styles.css
@@ -1,16 +1,18 @@
 @import "tailwindcss";
 
 @theme {
-  --font-sans: "Avenir Next", "Segoe UI", sans-serif;
+  --font-sans: system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
   --font-mono: "SFMono-Regular", "SF Mono", Consolas, monospace;
 }
 
 :root {
-  color: #17201c;
-  background: #f3efe4;
+  color: #202722;
+  background: #f7f4ec;
   font-family: var(--font-sans);
   font-synthesis: none;
-  text-rendering: geometricprecision;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 * {
@@ -24,11 +26,8 @@ html {
 body {
   margin: 0;
   min-width: 320px;
-  background:
-    linear-gradient(90deg, rgba(23, 32, 28, 0.055) 1px, transparent 1px),
-    linear-gradient(180deg, rgba(23, 32, 28, 0.045) 1px, transparent 1px), #f3efe4;
-  background-size: 26px 26px;
-  color: #17201c;
+  background: #f7f4ec;
+  color: #202722;
 }
 
 button,
@@ -45,9 +44,9 @@ a {
   position: sticky;
   top: 0;
   z-index: 30;
-  border-bottom: 1px solid rgba(23, 32, 28, 0.18);
-  background: rgba(243, 239, 228, 0.92);
-  backdrop-filter: blur(14px);
+  border-bottom: 1px solid rgba(32, 39, 34, 0.12);
+  background: rgba(247, 244, 236, 0.96);
+  backdrop-filter: blur(10px);
 }
 
 .brand-mark,
@@ -74,7 +73,7 @@ a {
 }
 
 .site-header {
-  min-height: 72px;
+  min-height: 64px;
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -83,7 +82,7 @@ a {
 
 .brand-mark {
   gap: 0.75rem;
-  min-width: 14rem;
+  min-width: 12rem;
 }
 
 .brand-symbol,
@@ -91,13 +90,13 @@ a {
 .doc-icon {
   display: grid;
   place-items: center;
-  border: 1px solid rgba(23, 32, 28, 0.2);
-  background: #fff8e9;
+  border: 1px solid rgba(32, 39, 34, 0.14);
+  background: #fbfaf6;
 }
 
 .brand-symbol {
-  width: 2.25rem;
-  height: 2.25rem;
+  width: 2rem;
+  height: 2rem;
 }
 
 .brand-name,
@@ -107,13 +106,13 @@ a {
 }
 
 .brand-name {
-  font-weight: 780;
+  font-weight: 700;
   letter-spacing: 0;
 }
 
 .brand-subtitle {
   margin-top: 0.2rem;
-  color: #58635c;
+  color: #66716a;
   font-size: 0.78rem;
 }
 
@@ -123,7 +122,7 @@ a {
 
 .header-nav {
   gap: clamp(0.75rem, 2vw, 1.5rem);
-  color: #3d4841;
+  color: #4b5650;
   font-size: 0.92rem;
 }
 
@@ -133,7 +132,7 @@ a {
 
 .nav-link:hover,
 .nav-link:focus-visible {
-  color: #b2382f;
+  color: #8f4b42;
 }
 
 .icon-links {
@@ -141,33 +140,33 @@ a {
 }
 
 .icon-link {
-  width: 2.1rem;
-  height: 2.1rem;
+  width: 2rem;
+  height: 2rem;
 }
 
 .hero-section {
-  min-height: calc(100svh - 72px);
+  min-height: auto;
   display: flex;
-  align-items: center;
-  padding-block: clamp(2rem, 5vw, 5rem);
+  align-items: flex-start;
+  padding-block: clamp(2.5rem, 5vw, 4.5rem);
 }
 
 .hero-grid {
   width: min(1180px, 100%);
   margin-inline: auto;
   display: grid;
-  grid-template-columns: minmax(0, 1.08fr) minmax(20rem, 0.72fr);
-  gap: clamp(2rem, 6vw, 6rem);
-  align-items: end;
+  grid-template-columns: minmax(0, 0.92fr) minmax(18rem, 0.58fr);
+  gap: clamp(2rem, 5vw, 4.5rem);
+  align-items: start;
 }
 
 .eyebrow {
   margin: 0 0 0.85rem;
-  color: #9b332c;
+  color: #8f4b42;
   font-family: var(--font-mono);
-  font-size: 0.78rem;
-  font-weight: 760;
-  letter-spacing: 0.08em;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
 }
 
@@ -179,30 +178,32 @@ p {
 }
 
 h1 {
-  max-width: 13ch;
-  margin-bottom: 1.4rem;
-  font-size: clamp(3.7rem, 10vw, 8.8rem);
-  font-weight: 840;
+  max-width: 18ch;
+  margin-bottom: 1.1rem;
+  font-size: clamp(2.1rem, 4vw, 4.25rem);
+  font-weight: 600;
   letter-spacing: 0;
-  line-height: 0.88;
+  line-height: 1;
 }
 
 h2 {
   margin-bottom: 0.85rem;
-  font-size: clamp(2rem, 4.4vw, 4.75rem);
-  font-weight: 820;
+  font-size: clamp(1.45rem, 2.35vw, 2.55rem);
+  font-weight: 600;
   letter-spacing: 0;
-  line-height: 0.95;
+  line-height: 1.08;
 }
 
 h3 {
   margin-bottom: 0.35rem;
   font-size: 1rem;
-  font-weight: 780;
+  font-weight: 600;
 }
 
 .hero-lede,
 .section-heading p,
+.section-note,
+.entry-card p,
 .doc-lane p,
 .primitive-item p {
   color: #4e5a53;
@@ -210,14 +211,33 @@ h3 {
 }
 
 .hero-lede {
-  max-width: 42rem;
-  font-size: clamp(1.08rem, 2vw, 1.3rem);
+  max-width: 39rem;
+  font-size: clamp(1rem, 1.4vw, 1.15rem);
 }
 
 .hero-actions {
   flex-wrap: wrap;
   gap: 0.75rem;
-  margin-top: 2rem;
+  margin-top: 1.5rem;
+}
+
+.doc-model-row {
+  align-items: flex-start;
+}
+
+.doc-model-row span {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.doc-model-row strong {
+  font-weight: 600;
+}
+
+.doc-model-row small {
+  color: #66716a;
+  font-size: 0.9rem;
+  line-height: 1.45;
 }
 
 .command-button,
@@ -228,38 +248,37 @@ h3 {
   align-items: center;
   justify-content: center;
   gap: 0.55rem;
-  border: 1px solid #17201c;
-  padding: 0.75rem 1rem;
-  font-weight: 760;
+  border: 1px solid rgba(32, 39, 34, 0.24);
+  padding: 0.68rem 0.9rem;
+  font-weight: 600;
   line-height: 1;
 }
 
 .command-button.primary,
 .demo-trigger {
-  background: #17201c;
-  color: #fff8e9;
+  background: #202722;
+  color: #fbfaf6;
 }
 
 .command-button.secondary,
 .select-trigger {
-  background: #fff8e9;
-  color: #17201c;
+  background: #fbfaf6;
+  color: #202722;
 }
 
 .status-console {
-  border: 1px solid #17201c;
-  background: #17201c;
-  color: #f7f0df;
-  box-shadow: 10px 10px 0 #c94638;
+  border: 1px solid rgba(32, 39, 34, 0.14);
+  background: #fbfaf6;
+  color: #202722;
 }
 
 .console-topline {
   display: flex;
   justify-content: space-between;
   gap: 1rem;
-  border-bottom: 1px solid rgba(247, 240, 223, 0.22);
-  padding: 0.9rem 1rem;
-  color: #d7ddc6;
+  border-bottom: 1px solid rgba(32, 39, 34, 0.1);
+  padding: 0.8rem 0.95rem;
+  color: #66716a;
   font-family: var(--font-mono);
   font-size: 0.76rem;
   text-transform: uppercase;
@@ -267,8 +286,8 @@ h3 {
 
 .console-row {
   gap: 0.75rem;
-  border-bottom: 1px solid rgba(247, 240, 223, 0.12);
-  padding: 1rem;
+  border-bottom: 1px solid rgba(32, 39, 34, 0.08);
+  padding: 0.85rem 0.95rem;
 }
 
 .console-row:last-child {
@@ -276,7 +295,7 @@ h3 {
 }
 
 .console-row svg {
-  color: #83a86f;
+  color: #6f8d61;
   flex: 0 0 auto;
 }
 
@@ -284,12 +303,55 @@ h3 {
 .mason-section,
 .docs-band,
 .release-section {
-  padding-block: clamp(3.5rem, 8vw, 7rem);
+  padding-block: clamp(3rem, 6vw, 5rem);
+}
+
+.entry-grid {
+  width: min(1180px, 100%);
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: clamp(1rem, 2vw, 1.25rem);
+}
+
+.entry-card {
+  min-width: 0;
+  display: grid;
+  align-content: start;
+  gap: 0.75rem;
+  border-top: 1px solid rgba(32, 39, 34, 0.16);
+  padding-top: 1rem;
+}
+
+.entry-card:hover,
+.entry-card:focus-visible {
+  color: #8f4b42;
+}
+
+.entry-icon {
+  width: 2.25rem;
+  height: 2.25rem;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(32, 39, 34, 0.14);
+  background: #fbfaf6;
+}
+
+.entry-card h3,
+.entry-card p {
+  margin-bottom: 0;
+}
+
+.entry-card span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-top: 0.25rem;
+  font-weight: 600;
 }
 
 .section-heading {
-  width: min(840px, 100%);
-  margin-bottom: clamp(2rem, 5vw, 4rem);
+  width: min(760px, 100%);
+  margin-bottom: clamp(1.5rem, 4vw, 3rem);
 }
 
 .section-heading.narrow {
@@ -299,13 +361,21 @@ h3 {
 .primitive-layout {
   width: min(1180px, 100%);
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(20rem, 0.78fr);
-  gap: clamp(1.5rem, 4vw, 4rem);
+  grid-template-columns: minmax(0, 1fr) minmax(18rem, 0.7fr);
+  gap: clamp(1.5rem, 4vw, 3rem);
+}
+
+.docs-track-grid {
+  width: min(1180px, 100%);
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(18rem, 0.72fr);
+  gap: clamp(1.5rem, 4vw, 3rem);
+  align-items: start;
 }
 
 .primitive-list {
   display: grid;
-  border-top: 1px solid rgba(23, 32, 28, 0.2);
+  border-top: 1px solid rgba(32, 39, 34, 0.14);
 }
 
 .primitive-item {
@@ -313,13 +383,13 @@ h3 {
   grid-template-columns: minmax(0, 1fr) auto;
   gap: 1rem;
   align-items: start;
-  border-bottom: 1px solid rgba(23, 32, 28, 0.2);
-  padding: 1.35rem 0;
+  border-bottom: 1px solid rgba(32, 39, 34, 0.12);
+  padding: 1rem 0;
 }
 
 .primitive-item span {
-  border: 1px solid rgba(23, 32, 28, 0.2);
-  background: #e6efda;
+  border: 1px solid rgba(32, 39, 34, 0.12);
+  background: #edf3e6;
   padding: 0.32rem 0.5rem;
   color: #28462e;
   font-family: var(--font-mono);
@@ -328,8 +398,8 @@ h3 {
 
 .live-lab {
   align-self: start;
-  border: 1px solid rgba(23, 32, 28, 0.24);
-  background: #fff8e9;
+  border: 1px solid rgba(32, 39, 34, 0.14);
+  background: #fbfaf6;
   padding: clamp(1rem, 3vw, 1.5rem);
 }
 
@@ -370,10 +440,10 @@ h3 {
 
 .dialog-content {
   width: min(28rem, 100%);
-  border: 1px solid #17201c;
-  background: #fff8e9;
+  border: 1px solid rgba(32, 39, 34, 0.24);
+  background: #fbfaf6;
   padding: 1.35rem;
-  box-shadow: 8px 8px 0 #5b73a7;
+  box-shadow: 0 18px 44px rgba(32, 39, 34, 0.16);
 }
 
 .dialog-title {
@@ -399,9 +469,9 @@ h3 {
 }
 
 .select-content {
-  border: 1px solid #17201c;
-  background: #fff8e9;
-  box-shadow: 6px 6px 0 #83a86f;
+  border: 1px solid rgba(32, 39, 34, 0.24);
+  background: #fbfaf6;
+  box-shadow: 0 14px 36px rgba(32, 39, 34, 0.14);
 }
 
 .select-listbox {
@@ -415,32 +485,32 @@ h3 {
 
 .select-item[data-highlighted],
 .select-item:hover {
-  background: #17201c;
-  color: #fff8e9;
+  background: #202722;
+  color: #fbfaf6;
 }
 
 .mason-section {
-  background: #17201c;
-  color: #f7f0df;
+  background: #ebe6d8;
+  color: #202722;
 }
 
 .mason-section .section-heading p {
-  color: #d4dccd;
+  color: #4e5a53;
 }
 
 .mason-section .eyebrow {
-  color: #f0c15c;
+  color: #766036;
 }
 
 .mason-flow {
   display: grid;
   grid-template-columns: repeat(5, minmax(0, 1fr));
-  border-block: 1px solid rgba(247, 240, 223, 0.18);
+  border-block: 1px solid rgba(32, 39, 34, 0.12);
 }
 
 .flow-step {
-  min-height: 11rem;
-  border-right: 1px solid rgba(247, 240, 223, 0.18);
+  min-height: 8rem;
+  border-right: 1px solid rgba(32, 39, 34, 0.1);
   padding: 1rem;
 }
 
@@ -449,23 +519,43 @@ h3 {
 }
 
 .flow-step span {
-  color: #f0c15c;
+  color: #766036;
   font-family: var(--font-mono);
   font-size: 0.78rem;
 }
 
 .flow-step p {
-  margin-top: 2.2rem;
-  font-size: clamp(1.05rem, 1.6vw, 1.35rem);
-  font-weight: 740;
-  line-height: 1.16;
+  margin-top: 1.35rem;
+  font-size: clamp(0.98rem, 1.2vw, 1.12rem);
+  font-weight: 600;
+  line-height: 1.28;
 }
 
 .docs-grid {
   width: min(1180px, 100%);
   display: grid;
-  grid-template-columns: minmax(0, 0.85fr) minmax(20rem, 1.15fr);
-  gap: clamp(2rem, 5vw, 5rem);
+  grid-template-columns: minmax(0, 0.7fr) minmax(20rem, 1.3fr);
+  gap: clamp(2rem, 5vw, 4rem);
+}
+
+.template-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: clamp(1rem, 3vw, 1.5rem);
+}
+
+.template-list {
+  border-top: 1px solid rgba(32, 39, 34, 0.14);
+  padding-top: 1rem;
+}
+
+.template-list ol {
+  display: grid;
+  gap: 0.45rem;
+  margin: 0;
+  padding-left: 1.25rem;
+  color: #4e5a53;
+  line-height: 1.5;
 }
 
 .doc-lanes {
@@ -476,7 +566,7 @@ h3 {
 .doc-lane {
   align-items: flex-start;
   gap: 1rem;
-  border-top: 1px solid rgba(23, 32, 28, 0.18);
+  border-top: 1px solid rgba(32, 39, 34, 0.12);
   padding-top: 1rem;
 }
 
@@ -488,27 +578,27 @@ a.doc-lane {
 
 a.doc-lane:hover,
 a.doc-lane:focus-visible {
-  color: #9b332c;
-  transform: translateX(0.25rem);
+  color: #8f4b42;
+  transform: translateX(0.12rem);
 }
 
 .doc-icon {
-  width: 2.7rem;
-  height: 2.7rem;
+  width: 2.4rem;
+  height: 2.4rem;
   flex: 0 0 auto;
 }
 
 .release-section {
-  padding-bottom: clamp(4rem, 10vw, 9rem);
+  padding-bottom: clamp(4rem, 8vw, 7rem);
 }
 
 .release-panel {
   width: min(1180px, 100%);
   display: grid;
   grid-template-columns: minmax(0, 0.8fr) minmax(18rem, 1fr);
-  gap: clamp(2rem, 5vw, 5rem);
-  border-top: 2px solid #17201c;
-  padding-top: clamp(1.5rem, 4vw, 3rem);
+  gap: clamp(2rem, 5vw, 4rem);
+  border-top: 1px solid rgba(32, 39, 34, 0.18);
+  padding-top: clamp(1.5rem, 4vw, 2.5rem);
 }
 
 .release-issues {
@@ -519,9 +609,9 @@ a.doc-lane:focus-visible {
 .issue-link {
   justify-content: space-between;
   gap: 1rem;
-  border: 1px solid rgba(23, 32, 28, 0.2);
-  background: #fff8e9;
-  padding: 1rem;
+  border: 1px solid rgba(32, 39, 34, 0.12);
+  background: #fbfaf6;
+  padding: 0.85rem 0.95rem;
 }
 
 .issue-link span {
@@ -534,28 +624,29 @@ a.doc-lane:focus-visible {
 }
 
 .issue-amber {
-  border-left: 0.5rem solid #f0c15c;
+  border-left: 0.25rem solid #d0a94a;
 }
 
 .issue-blue {
-  border-left: 0.5rem solid #5b73a7;
+  border-left: 0.25rem solid #6f7fa4;
 }
 
 .issue-green {
-  border-left: 0.5rem solid #83a86f;
+  border-left: 0.25rem solid #7c966d;
 }
 
 .doc-page {
-  padding-block: clamp(2rem, 5vw, 4.5rem) clamp(4rem, 8vw, 7rem);
+  padding-block: clamp(1.5rem, 4vw, 3.5rem) clamp(4rem, 7vw, 6rem);
 }
 
 .mason-doc-page {
-  background: #17201c;
-  color: #f7f0df;
+  background: #ebe6d8;
+  color: #202722;
 }
 
 .doc-shell {
   width: min(1120px, 100%);
+  min-width: 0;
   margin-inline: auto;
 }
 
@@ -564,64 +655,64 @@ a.doc-lane:focus-visible {
   display: inline-flex;
   align-items: center;
   gap: 0.45rem;
-  margin-bottom: clamp(2rem, 5vw, 4rem);
-  color: #58635c;
-  font-weight: 740;
+  margin-bottom: clamp(1.4rem, 4vw, 2.6rem);
+  color: #66716a;
+  font-weight: 600;
 }
 
 .mason-doc-page .back-link {
-  color: #d4dccd;
+  color: #5d665f;
 }
 
 .back-link:hover,
 .back-link:focus-visible,
 .doc-link-list a:hover,
 .doc-link-list a:focus-visible {
-  color: #b2382f;
+  color: #8f4b42;
 }
 
 .doc-hero {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(18rem, 0.42fr);
-  gap: clamp(2rem, 5vw, 5rem);
-  align-items: end;
-  border-bottom: 2px solid currentcolor;
-  padding-bottom: clamp(2rem, 5vw, 4rem);
+  gap: clamp(1.5rem, 4vw, 3rem);
+  align-items: start;
+  border-bottom: 1px solid rgba(32, 39, 34, 0.18);
+  padding-bottom: clamp(1.5rem, 4vw, 2.6rem);
 }
 
 .doc-hero h1 {
-  max-width: none;
-  margin-bottom: 1rem;
-  font-size: clamp(4rem, 13vw, 10rem);
+  max-width: 18ch;
+  margin-bottom: 0.8rem;
+  font-size: clamp(2rem, 3.8vw, 4rem);
 }
 
 .doc-lede {
-  max-width: 50rem;
+  max-width: 46rem;
   color: #4e5a53;
-  font-size: clamp(1.08rem, 2vw, 1.32rem);
-  line-height: 1.62;
+  font-size: clamp(1rem, 1.3vw, 1.12rem);
+  line-height: 1.65;
 }
 
 .mason-doc-page .doc-lede,
 .mason-doc-page .doc-section p,
 .mason-doc-page .doc-list {
-  color: #d4dccd;
+  color: #4e5a53;
 }
 
 .mason-doc-page .eyebrow {
-  color: #f0c15c;
+  color: #766036;
 }
 
 .doc-fact-panel {
   display: grid;
   grid-template-columns: 1fr;
-  border: 1px solid currentcolor;
-  background: #fff8e9;
-  color: #17201c;
+  border: 1px solid rgba(32, 39, 34, 0.14);
+  background: #fbfaf6;
+  color: #202722;
 }
 
 .mason-doc-page .doc-fact-panel {
-  background: #f7f0df;
+  background: #f7f4ec;
 }
 
 .doc-fact-panel span,
@@ -630,8 +721,8 @@ a.doc-lane:focus-visible {
 }
 
 .doc-fact-panel span {
-  border-top: 1px solid rgba(23, 32, 28, 0.2);
-  color: #58635c;
+  border-top: 1px solid rgba(32, 39, 34, 0.1);
+  color: #66716a;
   font-family: var(--font-mono);
   font-size: 0.74rem;
   text-transform: uppercase;
@@ -650,18 +741,159 @@ a.doc-lane:focus-visible {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: clamp(1rem, 3vw, 1.5rem);
-  margin-top: clamp(1.5rem, 4vw, 3rem);
+  margin-top: clamp(1.25rem, 3vw, 2.25rem);
+}
+
+.doc-panel-grid.compact {
+  margin-top: 1.5rem;
+}
+
+.contract-layout {
+  display: grid;
+  grid-template-columns: minmax(13rem, 0.32fr) minmax(0, 1fr);
+  gap: clamp(1.2rem, 4vw, 2.4rem);
+  margin-top: clamp(1.25rem, 3vw, 2.25rem);
+}
+
+.contract-detail,
+.doc-panel,
+.doc-section {
+  min-width: 0;
+}
+
+.contract-nav {
+  position: sticky;
+  top: 96px;
+  align-self: start;
+  max-height: calc(100svh - 120px);
+  overflow: auto;
+  border-top: 1px solid rgba(32, 39, 34, 0.14);
+}
+
+.mason-doc-page .contract-nav {
+  border-top-color: rgba(32, 39, 34, 0.14);
+}
+
+.contract-nav-item {
+  width: 100%;
+  display: grid;
+  gap: 0.25rem;
+  border: 0;
+  border-bottom: 1px solid rgba(32, 39, 34, 0.1);
+  background: transparent;
+  padding: 0.85rem 0.15rem;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+}
+
+.mason-doc-page .contract-nav-item {
+  border-bottom-color: rgba(32, 39, 34, 0.1);
+}
+
+.contract-nav-item span {
+  font-weight: 600;
+}
+
+.contract-nav-item small {
+  color: #66716a;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+}
+
+.mason-doc-page .contract-nav-item small {
+  color: #66716a;
+}
+
+.contract-nav-item:hover,
+.contract-nav-item:focus-visible,
+.contract-nav-item.is-active {
+  color: #8f4b42;
+}
+
+.contract-detail-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: start;
+  border-top: 1px solid rgba(32, 39, 34, 0.18);
+  padding-top: 1rem;
+}
+
+.contract-detail-header h2 {
+  font-size: clamp(1.45rem, 2.6vw, 2.6rem);
+}
+
+.contract-detail-header p {
+  max-width: 44rem;
+  color: #4e5a53;
+  line-height: 1.6;
+}
+
+.mason-doc-page .contract-detail-header p {
+  color: #4e5a53;
+}
+
+.contract-detail-header code {
+  max-width: min(24rem, 42vw);
+  overflow-wrap: anywhere;
+  border: 1px solid rgba(32, 39, 34, 0.18);
+  background: #fbfaf6;
+  padding: 0.65rem 0.75rem;
+  color: #202722;
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+}
+
+.metadata-table {
+  display: grid;
+  max-width: 100%;
+  overflow-x: auto;
+  border-top: 1px solid rgba(32, 39, 34, 0.12);
+}
+
+.mason-doc-page .metadata-table {
+  border-top-color: rgba(32, 39, 34, 0.12);
+}
+
+.metadata-row {
+  min-width: 46rem;
+  display: grid;
+  grid-template-columns: minmax(12rem, 0.8fr) minmax(14rem, 1.2fr) minmax(10rem, 0.8fr);
+  gap: 1rem;
+  border-bottom: 1px solid rgba(32, 39, 34, 0.1);
+  padding: 0.8rem 0;
+}
+
+.mason-doc-page .metadata-row {
+  border-bottom-color: rgba(32, 39, 34, 0.1);
+}
+
+.metadata-head {
+  color: #66716a;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+}
+
+.mason-doc-page .metadata-head {
+  color: #66716a;
+}
+
+.metadata-row code,
+.metadata-row span {
+  overflow-wrap: anywhere;
 }
 
 .doc-section,
 .doc-panel {
-  border-top: 1px solid rgba(23, 32, 28, 0.22);
+  border-top: 1px solid rgba(32, 39, 34, 0.14);
   padding-top: 1rem;
 }
 
 .mason-doc-page .doc-section,
 .mason-doc-page .doc-panel {
-  border-top-color: rgba(247, 240, 223, 0.24);
+  border-top-color: rgba(32, 39, 34, 0.14);
 }
 
 .doc-section-title {
@@ -674,8 +906,8 @@ a.doc-lane:focus-visible {
 .doc-section-title h2,
 .doc-panel h2 {
   margin-bottom: 0;
-  font-size: clamp(1.35rem, 2.5vw, 2rem);
-  line-height: 1.05;
+  font-size: clamp(1.15rem, 1.8vw, 1.55rem);
+  line-height: 1.15;
 }
 
 .doc-section p,
@@ -692,10 +924,10 @@ a.doc-lane:focus-visible {
 .doc-section pre,
 .doc-panel pre {
   overflow-x: auto;
-  border: 1px solid #17201c;
-  background: #fff8e9;
+  border: 1px solid rgba(32, 39, 34, 0.14);
+  background: #fbfaf6;
   padding: 1rem;
-  color: #17201c;
+  color: #202722;
   font-family: var(--font-mono);
   font-size: 0.82rem;
   line-height: 1.55;
@@ -708,10 +940,10 @@ a.doc-lane:focus-visible {
 }
 
 .part-grid span {
-  border: 1px solid rgba(23, 32, 28, 0.24);
-  background: #fff8e9;
-  padding: 0.5rem 0.65rem;
-  color: #17201c;
+  border: 1px solid rgba(32, 39, 34, 0.14);
+  background: #fbfaf6;
+  padding: 0.45rem 0.6rem;
+  color: #202722;
   font-family: var(--font-mono);
   font-size: 0.78rem;
 }
@@ -733,7 +965,7 @@ a.doc-lane:focus-visible {
 .doc-link-list a {
   border-bottom: 1px solid currentcolor;
   padding-bottom: 0.35rem;
-  font-weight: 760;
+  font-weight: 700;
 }
 
 @media (max-width: 920px) {
@@ -742,13 +974,30 @@ a.doc-lane:focus-visible {
   }
 
   .hero-grid,
+  .entry-grid,
   .primitive-layout,
+  .docs-track-grid,
   .docs-grid,
+  .template-grid,
   .release-panel,
   .doc-hero,
   .doc-two-column,
-  .doc-panel-grid {
+  .doc-panel-grid,
+  .contract-layout {
     grid-template-columns: 1fr;
+  }
+
+  .contract-nav {
+    position: static;
+    max-height: none;
+  }
+
+  .contract-detail-header {
+    display: grid;
+  }
+
+  .contract-detail-header code {
+    max-width: none;
   }
 
   .hero-section {
@@ -762,7 +1011,7 @@ a.doc-lane:focus-visible {
   .flow-step {
     min-height: auto;
     border-right: 0;
-    border-bottom: 1px solid rgba(247, 240, 223, 0.18);
+    border-bottom: 1px solid rgba(32, 39, 34, 0.1);
   }
 
   .flow-step p {
@@ -781,7 +1030,8 @@ a.doc-lane:focus-visible {
   }
 
   h1 {
-    font-size: clamp(3rem, 18vw, 4.6rem);
+    font-size: clamp(2.15rem, 11.5vw, 3rem);
+    line-height: 1.03;
   }
 
   .primitive-item {

--- a/docs/accessibility/testing-plan.md
+++ b/docs/accessibility/testing-plan.md
@@ -134,10 +134,12 @@ Keystone primitive tests should use `packages/keystone/test/accessibility.ts` fo
 The harness provides:
 
 - `runKeyboardTable` for keyboard interaction tables, including controller prop handlers and rendered DOM targets.
-- `expectRole`, `expectPart`, `expectAriaState`, `expectAriaRelationship`, and `expectNoAriaRelationship` for public DOM and prop getter contracts.
-- `expectFocus` and `expectFocusWithin` for focus entry, containment, restore, and active-descendant models.
-- `expectFormValues` for native submission and hidden input serialization.
-- `withDirection` and `withReducedMotion` for RTL and reduced-motion test hooks.
+- `expectRole`, `expectPart`, `expectStablePartAttributes`, `expectAriaState`, `expectAriaRelationship`, and `expectNoAriaRelationship` for public DOM and prop getter contracts.
+- `expectFocus`, `expectFocusWithin`, `expectFocusTrap`, and `expectFocusRestore` for focus entry, containment, restore, and active-descendant models.
+- `expectOutsideDismissal` for preventable outside pointer/focus dismissal checks.
+- `expectFormValues` and `expectFormReset` for native submission, reset, and hidden input serialization.
+- `expectSsrSmoke` and `expectHydrationSmoke` for server-render and hydration smoke checks.
+- `withDirection`, `withReducedMotion`, and `withForcedColors` for RTL, reduced-motion, and forced-color test hooks.
 
 Primitive accessibility specs should include a short "Automated Coverage" section that maps each required behavior to one of these harness interfaces. Example:
 
@@ -148,6 +150,8 @@ Primitive accessibility specs should include a short "Automated Coverage" sectio
 | Popup exposes listbox semantics   | `expectRole(listbox, "listbox")`                         |
 | Selection serializes to form data | `expectFormValues(form, { project: "alpha" })`           |
 | RTL navigation is direction-aware | `withDirection("rtl", () => ...)`                        |
+| Forced-colors branch stays stable | `withForcedColors(() => ...)`                            |
+| Hydration-sensitive IDs are safe  | `expectHydrationSmoke({ html })`                         |
 
 Controller tests should use the same harness against prop getter return objects when rendering is unnecessary. Browser tests should use it against rendered elements when focus, form ownership, portals, or native DOM behavior are part of the requirement.
 
@@ -224,6 +228,28 @@ Manual testing should record:
 - Follow-up issue or doc note.
 
 Manual evidence can live in `.context/` during active work, but release-blocking results should be summarized in durable docs or release notes.
+
+### Manual Checklist Output
+
+Use this shape for release-blocking manual evidence:
+
+```md
+## Manual Accessibility Check
+
+- Primitive:
+- Version or commit:
+- Tester:
+- Date:
+- Environment:
+- Assistive technology:
+- Scenario:
+- Expected:
+- Actual:
+- Result: Pass | Fail | Blocked
+- Follow-up:
+```
+
+Each stable primitive should have at least one checklist entry for keyboard-only use and one for the relevant screen-reader path before release. Failed or blocked checks need a linked issue or an explicit known-limitation note.
 
 ## First Primitive Coverage
 

--- a/docs/agents/date-picker-calendar-vertical.md
+++ b/docs/agents/date-picker-calendar-vertical.md
@@ -12,12 +12,14 @@ This vertical applies the primitive delivery standard to DatePicker and Calendar
 
 ## Current Keystone Contract
 
-- `Calendar.Root` supports controlled and uncontrolled `value`, `month`, `defaultValue`, `defaultMonth`, `minValue`, `maxValue`, `disabled`, `locale`, `weekStartsOn`, `onValueChange`, and `onMonthChange`.
+- `Calendar.Root` supports controlled and uncontrolled single-date `value`, range `rangeValue`, `month`, `defaultValue`, `defaultRangeValue`, `defaultMonth`, `selectionMode`, `minValue`, `maxValue`, `unavailable`, `disabled`, `locale`, `weekStartsOn`, `onValueChange`, `onRangeValueChange`, and `onMonthChange`.
 - `Calendar.Grid` renders a `role="grid"` month table with column headers, rows, grid cells, and day buttons.
-- Day buttons expose selected, outside-month, today, disabled, and value data attributes.
+- Day buttons expose selected, range start/end/in-range, outside-month, today, unavailable, disabled, and value data attributes.
+- Range selection normalizes reverse selection, keeps partial ranges open, and restarts instead of completing across unavailable dates.
+- Calendar week starts infer from `Intl.Locale.weekInfo` when `weekStartsOn` is omitted, with an explicit `weekStartsOn` override and Sunday fallback.
 - Calendar keyboard support covers arrow movement, Home/End, PageUp/PageDown, Enter, and Space.
 - `DatePicker.Root` adds controlled and uncontrolled `open` state around the same calendar state.
-- `DatePicker.Trigger` exposes `aria-haspopup="dialog"`, `aria-expanded`, `aria-controls`, placeholder state, and selected value text.
+- `DatePicker.Trigger` exposes `aria-haspopup="dialog"`, `aria-expanded`, `aria-controls`, placeholder state, selection mode, selected single-date text, and range label text.
 - User click and keydown handlers run first; internal behavior skips when the event is default-prevented.
 
 ## Mason Surface
@@ -27,4 +29,4 @@ This vertical applies the primitive delivery standard to DatePicker and Calendar
 
 ## Parity Notes
 
-Kobalte and Base UI go deeper on date fields, segment editing, validation and form semantics, richer unavailable date policies, multi-month and range calendars, cursor/touch behavior, nested overlay coordination, focus restoration, and edge-case accessibility tests. The next parity pass should deepen those areas without moving TanStack app-layer form concerns into Keystone.
+Kobalte and Base UI still go deeper on date fields, segment editing, validation and form semantics, multi-month rendering, alternate calendar systems beyond localized `Intl` formatting and locale week starts, cursor/touch behavior, nested overlay coordination, focus restoration, and edge-case accessibility tests. The next parity pass should deepen those areas without moving TanStack app-layer form concerns into Keystone.

--- a/docs/agents/navigation-menu-vertical.md
+++ b/docs/agents/navigation-menu-vertical.md
@@ -4,8 +4,8 @@
 
 - Keystone primitive: `@keystone-ui/keystone/navigation-menu`
 - Mason registry item: `navigation-menu`
-- Parts: `trigger`, `positioner`, `content`, `group`, `group-label`, `separator`, `item`, `item-indicator`
-- Core behavior: menubar role semantics, trigger ARIA, overlay positioning, keyboard navigation, typeahead, disabled item skipping, groups, separators, item state metadata, and stable `data-scope`/`data-part` contracts.
+- Parts: `trigger`, `positioner`, `content`, `group`, `group-label`, `separator`, `item`, `link`, `item-indicator`
+- Core behavior: menubar role semantics, trigger ARIA, overlay positioning, keyboard navigation, typeahead, disabled item skipping, routed anchor links, groups, separators, item state metadata, and stable `data-scope`/`data-part` contracts.
 
 ## Parity Baseline
 
@@ -13,10 +13,10 @@ The current vertical is the thin Keystone/Mason pass against Kobalte and Base UI
 
 ## Remaining Parity Gaps
 
-- Explicit `Root` DOM, `List`, `Viewport`, and routed link helper parts.
+- Explicit `Root` DOM, `List`, and `Viewport` parts.
 - Hover intent tuning and cursor safety between trigger/content regions.
 - Touch pointer behavior and coarse-pointer open/close timing.
 - Nested menu coordination beyond the shared menu kernel baseline.
-- Focus restoration across routed links, dynamic route transitions, and nested overlays.
+- Focus restoration across dynamic route transitions and nested overlays.
 - Controlled active item state and richer layout animation metadata.
 - More edge-case tests for RTL navigation, dynamic item mounting, viewport sizing, and mixed link/menu item content.

--- a/docs/agents/selection-controls-vertical.md
+++ b/docs/agents/selection-controls-vertical.md
@@ -14,21 +14,24 @@ This vertical applies the current primitive delivery standard to Switch, Checkbo
 
 Switch:
 
-- `Switch.Root` supports controlled and uncontrolled `checked`, `defaultChecked`, `disabled`, `readOnly`, `invalid`, `required`, `name`, `value`, and `onCheckedChange`.
+- `Switch.Root` supports controlled and uncontrolled `checked`, `defaultChecked`, `disabled`, `readOnly`, `invalid`, `required`, `name`, `form`, `value`, and `onCheckedChange`.
 - `Switch.Control` exposes `role="switch"`, `aria-checked`, state data attributes, keyboard Space toggling, and user-handler-first click behavior.
 - `Switch.HiddenInput` mirrors checked state for form submission.
+- `Switch.HiddenInput` participates in native form reset and can sync checked state from input change events.
 
 Checkbox:
 
-- `Checkbox.Root` supports controlled and uncontrolled `checked`, `defaultChecked`, indeterminate state, disabled/read-only/invalid/required flags, `name`, `value`, and `onCheckedChange`.
+- `Checkbox.Root` supports controlled and uncontrolled `checked`, `defaultChecked`, indeterminate state, disabled/read-only/invalid/required flags, `name`, `form`, `value`, and `onCheckedChange`.
 - `Checkbox.Control` exposes `role="checkbox"`, `aria-checked="mixed"` for indeterminate state, state data attributes, keyboard Space toggling, and preventable click behavior.
 - `Checkbox.HiddenInput` mirrors checked and `indeterminate` input state.
+- `Checkbox.HiddenInput` participates in native form reset and can sync checked state from input change events.
 
 RadioGroup:
 
-- `RadioGroup.Root` supports controlled and uncontrolled `value`, `defaultValue`, `disabled`, `readOnly`, `invalid`, `required`, `orientation`, `loopFocus`, `name`, and `onValueChange`.
+- `RadioGroup.Root` supports controlled and uncontrolled `value`, `defaultValue`, `disabled`, `readOnly`, `invalid`, `required`, `orientation`, `loopFocus`, `name`, `form`, and `onValueChange`.
 - `RadioGroup.Item` exposes `role="radio"`, roving `tabIndex`, checked data attributes, click selection, and arrow/Home/End keyboard selection.
 - `RadioGroup.HiddenInput` mirrors item selection as native radio inputs.
+- `RadioGroup.HiddenInput` participates in native form reset, including external form ownership through the root `form` prop.
 
 ## Mason Surface
 

--- a/docs/agents/slider-vertical.md
+++ b/docs/agents/slider-vertical.md
@@ -12,17 +12,18 @@ This vertical applies the primitive delivery standard to Slider:
 
 ## Current Keystone Contract
 
-- `Slider.Root` supports `value`, `defaultValue`, `min`, `max`, `step`, `orientation`, `disabled`, `onValueChange`, and `onValueCommit`.
+- `Slider.Root` supports `value`, `defaultValue`, `min`, `max`, `step`, `orientation`, `disabled`, `readOnly`, `invalid`, `required`, `name`, `form`, `onValueChange`, and `onValueCommit`.
 - `Slider.Track` owns pointer track selection and drag movement.
 - `Slider.Range` exposes range CSS variables for generated Mason styling.
 - `Slider.Thumb` exposes `role="slider"`, value ARIA, orientation ARIA, `data-scope`, `data-part`, `data-index`, `data-disabled`, and keyboard stepping.
+- `Slider.HiddenInput` serializes slider values for native forms, supports external form ownership, syncs input events back to slider state, and resets to `defaultValue`.
 - User keyboard and pointer handlers run first; internal behavior skips when the event is default-prevented.
 
 ## Mason Surface
 
-- `registry/default/ui/slider.tsx` wraps Keystone Slider with `mason-slider-*` styling hooks.
+- `registry/default/ui/slider.tsx` wraps Keystone Slider with `mason-slider-*` styling hooks and exposes the hidden input part.
 - Registry metadata records dependencies, parts, CSS variables, install command, source files, customization notes, and parity gaps.
 
 ## Parity Notes
 
-Kobalte and Base UI go deeper on field integration, disabled/read-only policy, validation semantics, and advanced pointer behavior. TanStack Ranger goes deeper on range-engine ergonomics, active handle lifecycle, tick helpers, interpolation, and commit timing. The next parity pass should add cursor/touch behavior, nested coordination, focus restoration, minimum thumb distance, form hidden inputs, metadata docs examples, and edge-case tests.
+Kobalte and Base UI go deeper on field integration, validation semantics, and advanced pointer behavior. TanStack Ranger goes deeper on range-engine ergonomics, active handle lifecycle, tick helpers, interpolation, and commit timing. The next parity pass should add cursor/touch behavior, nested coordination, focus restoration, minimum thumb distance, metadata docs examples, and edge-case tests.

--- a/docs/agents/tabs-vertical.md
+++ b/docs/agents/tabs-vertical.md
@@ -29,6 +29,7 @@ This vertical applies the primitive delivery standard to Tabs:
 - Kobalte Tabs documents the same anatomy: root, list, trigger, indicator, and content. It also calls out controlled/uncontrolled value, disabled tabs, horizontal/vertical orientation, automatic/manual activation, RTL keyboard navigation, focus management for panels, and `forceMount`.
 - Base UI Tabs exposes root, list, tab, indicator, and panel, with controlled/uncontrolled value, orientation, disabled tabs, `keepMounted`, and measured indicator CSS variables.
 - Keystone now covers the shared core contract: value state, orientation, disabled triggers, activation mode, roving focus, trigger/panel ARIA, `forceMount`, data parts, and Mason metadata.
+- The #51 parity pass adds explicit `dir="rtl"` handling for horizontal arrow keys so `ArrowLeft` moves forward and `ArrowRight` moves backward in RTL tablists.
 
 References checked on 2026-05-03:
 
@@ -37,4 +38,4 @@ References checked on 2026-05-03:
 
 ## Parity Notes
 
-The next Tabs parity pass should add RTL-aware horizontal key behavior, measured indicator positioning and CSS variables, dynamic removal focus restoration, closable/deleteable tab coordination, activation latency policy, panel focus heuristics that omit `tabIndex` when content already has focusable children, and broader touch/cursor edge-case tests.
+The next Tabs parity pass should add measured indicator positioning and CSS variables, dynamic removal focus restoration, closable/deleteable tab coordination, activation latency policy, panel focus heuristics that omit `tabIndex` when content already has focusable children, and broader touch/cursor edge-case tests.

--- a/docs/agents/toolbar-vertical.md
+++ b/docs/agents/toolbar-vertical.md
@@ -5,7 +5,7 @@
 - Keystone primitive: `@keystone-ui/keystone/toolbar`
 - Mason registry item: `toolbar`
 - Parts: `root`, `button`, `link`, `separator`
-- Core behavior: `role="toolbar"`, `aria-orientation`, horizontal and vertical roving focus, disabled item skipping, non-looping focus boundaries, pressed button metadata, separator semantics, and stable `data-scope`/`data-part` contracts.
+- Core behavior: `role="toolbar"`, `aria-orientation`, horizontal and vertical roving focus, RTL-aware horizontal arrow keys, disabled item skipping, non-looping focus boundaries, pressed button metadata, separator semantics, and stable `data-scope`/`data-part` contracts.
 
 ## Parity Baseline
 
@@ -14,7 +14,6 @@ The current vertical is the thin Keystone/Mason pass against Kobalte and Base UI
 ## Remaining Parity Gaps
 
 - Toggle group and radio group coordination inside toolbar.
-- RTL horizontal arrow behavior.
 - Cursor and touch behavior for non-button controls.
 - Nested coordination with menus, popovers, and command controls.
 - Focus restoration after nested overlay tools close.

--- a/docs/rfcs/mason-registry.md
+++ b/docs/rfcs/mason-registry.md
@@ -125,6 +125,34 @@ Optional metadata:
 - `changelog`: human-readable item changes.
 - `integrity`: hash metadata for remote item payloads when available.
 
+## Parity Metadata
+
+First-party Mason registry items should include `meta.parity` so docs and maintainers can see what each item currently matches, which references were used, and which gaps are intentionally left for later work.
+
+`meta.parity` is an object whose keys name reference systems and whose values are concise notes:
+
+```json
+{
+  "meta": {
+    "parity": {
+      "baseUi": "Matches the core runtime contract. Gaps: advanced transition metadata remains follow-up work.",
+      "kobalte": "Matches the Solid composition shape. Gaps: deeper form-control integration remains follow-up work."
+    }
+  }
+}
+```
+
+Reference selection:
+
+- Use `baseUi` first for Keystone-backed primitive and overlay runtime depth.
+- Use `kobalte` second for Solid-native primitive API shape and composition.
+- Use a more specific first-class reference when Base UI or Kobalte is not the right comparison.
+- TanStack-backed Mason app components may use keys such as `tanstackForm`, `tanstackTable`, or `tanstackRouter`.
+- Toast behavior may include `sonner`.
+- Mason utilities, blocks, and source-registry conventions may use keys such as `mason` or `shadcn`.
+
+Parity notes are not a claim of complete compatibility. They should state what the current item covers and name important gaps. For the default first-party registry, tests should fail when parity notes are missing, empty, or not string-valued. Third-party registries may adopt the same convention, but this RFC does not make parity metadata a public compatibility guarantee for all external registries yet.
+
 ## File Descriptors
 
 Each file descriptor must include:

--- a/package.json
+++ b/package.json
@@ -17,10 +17,11 @@
     "build": "turbo build",
     "check-types": "turbo check-types",
     "test:keystone": "turbo -F @keystone-ui/keystone test",
+    "test:docs": "bun --filter docs test",
     "test:mason-cli": "bun --filter @keystone-ui/mason-cli test",
     "test:mason-registry": "bun --filter @keystone-ui/mason-registry test",
     "verify:example-app": "bun scripts/verify-example-app.ts",
-    "verify:release": "bun run check && bun run check-types && bun run test:keystone && bun run test:mason-cli && bun run test:mason-registry && bun run verify:example-app && bun run build",
+    "verify:release": "bun run check && bun run check-types && bun run test:keystone && bun run test:docs && bun run test:mason-cli && bun run test:mason-registry && bun run verify:example-app && bun run build",
     "dev:docs": "turbo -F docs dev",
     "check": "oxlint && oxfmt --write"
   },

--- a/packages/keystone/package.json
+++ b/packages/keystone/package.json
@@ -31,6 +31,7 @@
     "./toast": "./src/toast/index.tsx"
   },
   "scripts": {
+    "bench:listbox": "bun scripts/bench-listbox.ts",
     "check-types": "tsc --noEmit",
     "test": "vitest run"
   },

--- a/packages/keystone/scripts/bench-listbox.ts
+++ b/packages/keystone/scripts/bench-listbox.ts
@@ -1,0 +1,85 @@
+import { performance } from "node:perf_hooks";
+import { createRoot } from "solid-js";
+import { createListboxInteraction } from "../src/listbox/index";
+
+type BenchmarkResult = {
+  itemCount: number;
+  navigationMs: number;
+  registrationMs: number;
+  typeaheadMs: number;
+};
+
+function keyEvent(key: string): KeyboardEvent {
+  return {
+    altKey: false,
+    ctrlKey: false,
+    key,
+    metaKey: false,
+    preventDefault() {},
+    stopPropagation() {},
+  } as KeyboardEvent;
+}
+
+function benchmarkListbox(itemCount: number): BenchmarkResult {
+  return createRoot((dispose) => {
+    const listbox = createListboxInteraction<
+      { disabled?: boolean; label: string; value: string },
+      { reason: string }
+    >({
+      id: () => "bench-listbox",
+      labelledBy: () => "bench-trigger",
+      optionId: (value) => `bench-option-${value}`,
+      optionSelectDetail: () => ({ reason: "item" }),
+      programmaticDetail: { reason: "programmatic" },
+      scope: "bench-listbox",
+    });
+
+    const registrationStart = performance.now();
+    for (let index = 0; index < itemCount; index += 1) {
+      listbox.registerOption({
+        disabled: index % 17 === 0,
+        label: `Item ${String(index).padStart(5, "0")}`,
+        value: `item-${index}`,
+      });
+    }
+    const registrationMs = performance.now() - registrationStart;
+
+    const navigationStart = performance.now();
+    for (let index = 0; index < 1000; index += 1) {
+      listbox.keyboard.highlight("next");
+    }
+    const navigationMs = performance.now() - navigationStart;
+
+    const typeaheadStart = performance.now();
+    for (const key of ["I", "t", "e", "m", " ", "0", "9"]) {
+      listbox.typeahead.handleKeyDown(keyEvent(key));
+    }
+    const typeaheadMs = performance.now() - typeaheadStart;
+
+    dispose();
+
+    return {
+      itemCount,
+      navigationMs,
+      registrationMs,
+      typeaheadMs,
+    };
+  });
+}
+
+const counts = process.argv
+  .slice(2)
+  .map((value) => Number.parseInt(value, 10))
+  .filter(Number.isFinite);
+const itemCounts = counts.length > 0 ? counts : [100, 1000, 5000, 10000, 20000];
+
+for (const result of itemCounts.map(benchmarkListbox)) {
+  console.info(
+    [
+      `[listbox-bench] items=${result.itemCount}`,
+      `registration=${result.registrationMs.toFixed(2)}ms`,
+      `navigation1000=${result.navigationMs.toFixed(2)}ms`,
+      `typeahead7=${result.typeaheadMs.toFixed(2)}ms`,
+    ].join(" "),
+  );
+}

--- a/packages/keystone/src/checkbox/index.tsx
+++ b/packages/keystone/src/checkbox/index.tsx
@@ -1,4 +1,12 @@
-import { createContext, createEffect, splitProps, useContext, type JSX } from "solid-js";
+import {
+  createContext,
+  createEffect,
+  onCleanup,
+  onMount,
+  splitProps,
+  useContext,
+  type JSX,
+} from "solid-js";
 import {
   createSelectionControl,
   getSelectionControlProps,
@@ -6,7 +14,7 @@ import {
   type SelectionControlChangeDetail,
   type SelectionControlCheckedState,
 } from "../selection-control/controller";
-import { dataBoolean, partDataAttributes } from "../utils/index";
+import { callEventHandler, dataBoolean, partDataAttributes } from "../utils/index";
 
 export type CheckboxCheckedState = SelectionControlCheckedState;
 export type CheckboxCheckedChangeDetail = SelectionControlChangeDetail;
@@ -16,6 +24,7 @@ export type CheckboxRootProps = CheckboxPartProps<HTMLSpanElement> &
     checked?: CheckboxCheckedState;
     defaultChecked?: CheckboxCheckedState;
     disabled?: boolean;
+    form?: string;
     invalid?: boolean;
     name?: string;
     onCheckedChange?: (checked: CheckboxCheckedState, detail: CheckboxCheckedChangeDetail) => void;
@@ -50,6 +59,7 @@ export function createCheckbox(
     checked?: () => CheckboxCheckedState | undefined;
     defaultChecked?: CheckboxCheckedState;
     disabled?: () => boolean | undefined;
+    form?: () => string | undefined;
     invalid?: () => boolean | undefined;
     name?: () => string | undefined;
     onCheckedChange?: (checked: CheckboxCheckedState, detail: CheckboxCheckedChangeDetail) => void;
@@ -62,6 +72,7 @@ export function createCheckbox(
     checked: options.checked,
     defaultChecked: options.defaultChecked,
     disabled: options.disabled,
+    form: options.form,
     invalid: options.invalid,
     name: options.name,
     onCheckedChange: options.onCheckedChange,
@@ -84,6 +95,7 @@ function Root(props: CheckboxRootProps) {
     "children",
     "defaultChecked",
     "disabled",
+    "form",
     "invalid",
     "name",
     "onCheckedChange",
@@ -95,6 +107,7 @@ function Root(props: CheckboxRootProps) {
     checked: () => local.checked,
     defaultChecked: local.defaultChecked,
     disabled: () => local.disabled,
+    form: () => local.form,
     invalid: () => local.invalid,
     name: () => local.name,
     onCheckedChange: local.onCheckedChange,
@@ -157,15 +170,30 @@ function HiddenInput(props: CheckboxHiddenInputProps) {
     if (input) input.indeterminate = control.checked() === "indeterminate";
   });
 
+  onMount(() => {
+    const form = input?.form;
+    if (!form) return;
+
+    const onReset = () => control.reset();
+    form.addEventListener("reset", onReset);
+    onCleanup(() => form.removeEventListener("reset", onReset));
+  });
+
   return (
     <input
       {...props}
+      onChange={(event) => {
+        callEventHandler(props.onChange, event);
+        if (event.defaultPrevented || control.disabled() || control.readOnly()) return;
+        control.setChecked(event.currentTarget.checked, { reason: "control" });
+      }}
       ref={(element) => {
         input = element;
         if (typeof props.ref === "function") props.ref(element);
       }}
       checked={control.checked() === true}
       disabled={control.disabled()}
+      form={props.form ?? control.form()}
       id={control.inputId}
       name={control.name()}
       required={control.required()}

--- a/packages/keystone/src/context-menu/index.ts
+++ b/packages/keystone/src/context-menu/index.ts
@@ -7,6 +7,7 @@ export type {
   MenuGroupLabelProps as ContextMenuGroupLabelProps,
   MenuGroupProps as ContextMenuGroupProps,
   MenuItemProps as ContextMenuItemProps,
+  MenuLinkProps as ContextMenuLinkProps,
   MenuOpenChangeDetail as ContextMenuOpenChangeDetail,
   MenuPartProps as ContextMenuPartProps,
   MenuPortalProps as ContextMenuPortalProps,

--- a/packages/keystone/src/date-picker/index.tsx
+++ b/packages/keystone/src/date-picker/index.tsx
@@ -18,10 +18,18 @@ import {
 
 export type CalendarValue = string;
 export type CalendarMonth = string;
+export type CalendarRangeValue = {
+  end?: CalendarValue;
+  start?: CalendarValue;
+};
+export type CalendarSelectionMode = "single" | "range";
 export type CalendarValueChangeReason = "cell" | "keyboard" | "programmatic";
 export type CalendarValueChangeDetail = {
   event?: Event;
   reason: CalendarValueChangeReason;
+};
+export type CalendarRangeValueChangeDetail = CalendarValueChangeDetail & {
+  complete: boolean;
 };
 export type CalendarMonthChangeDetail = {
   event?: Event;
@@ -43,6 +51,7 @@ export type CalendarPartProps<T extends HTMLElement = HTMLElement> = {
 export type CalendarRootProps = CalendarPartProps<HTMLDivElement> &
   Omit<JSX.HTMLAttributes<HTMLDivElement>, "children" | "ref"> & {
     defaultMonth?: CalendarMonth;
+    defaultRangeValue?: CalendarRangeValue;
     defaultValue?: CalendarValue;
     disabled?: boolean;
     locale?: string;
@@ -50,7 +59,14 @@ export type CalendarRootProps = CalendarPartProps<HTMLDivElement> &
     minValue?: CalendarValue;
     month?: CalendarMonth;
     onMonthChange?: (month: CalendarMonth, detail: CalendarMonthChangeDetail) => void;
+    onRangeValueChange?: (
+      rangeValue: CalendarRangeValue,
+      detail: CalendarRangeValueChangeDetail,
+    ) => void;
     onValueChange?: (value: CalendarValue, detail: CalendarValueChangeDetail) => void;
+    rangeValue?: CalendarRangeValue;
+    selectionMode?: CalendarSelectionMode;
+    unavailable?: (value: CalendarValue) => boolean;
     value?: CalendarValue;
     weekStartsOn?: number;
   };
@@ -83,6 +99,7 @@ export type DatePickerCalendarProps = Omit<
 
 export type CreateCalendarOptions = {
   defaultMonth?: CalendarMonth;
+  defaultRangeValue?: CalendarRangeValue;
   defaultValue?: CalendarValue;
   disabled?: () => boolean | undefined;
   locale?: () => string | undefined;
@@ -90,7 +107,14 @@ export type CreateCalendarOptions = {
   minValue?: () => CalendarValue | undefined;
   month?: () => CalendarMonth | undefined;
   onMonthChange?: (month: CalendarMonth, detail: CalendarMonthChangeDetail) => void;
+  onRangeValueChange?: (
+    rangeValue: CalendarRangeValue,
+    detail: CalendarRangeValueChangeDetail,
+  ) => void;
   onValueChange?: (value: CalendarValue, detail: CalendarValueChangeDetail) => void;
+  rangeValue?: () => CalendarRangeValue | undefined;
+  selectionMode?: () => CalendarSelectionMode | undefined;
+  unavailable?: (value: CalendarValue) => boolean;
   value?: () => CalendarValue | undefined;
   weekStartsOn?: () => number | undefined;
 };
@@ -105,9 +129,13 @@ export type CalendarDay = {
   date: CalendarValue;
   day: number;
   disabled: boolean;
+  inRange: boolean;
   outsideMonth: boolean;
+  rangeEnd: boolean;
+  rangeStart: boolean;
   selected: boolean;
   today: boolean;
+  unavailable: boolean;
 };
 
 export type CalendarApi = {
@@ -121,8 +149,10 @@ export type CalendarApi = {
   moveFocus: (value: CalendarValue, amount: number, detail: CalendarMonthChangeDetail) => void;
   nextMonth: (detail: CalendarMonthChangeDetail) => CalendarMonth;
   previousMonth: (detail: CalendarMonthChangeDetail) => CalendarMonth;
+  rangeValue: () => CalendarRangeValue | undefined;
   selectDate: (value: CalendarValue, detail: CalendarValueChangeDetail) => CalendarValue;
   setFocusedValue: (value: CalendarValue, detail: CalendarMonthChangeDetail) => void;
+  selectionMode: () => CalendarSelectionMode;
   value: () => CalendarValue | undefined;
   weekDayLabels: () => string[];
   weeks: () => CalendarDay[][];
@@ -140,9 +170,11 @@ const DatePickerContext = createContext<DatePickerApi>();
 
 export function createCalendar(options: CreateCalendarOptions = {}): CalendarApi {
   let pendingValueDetail: CalendarValueChangeDetail | undefined;
+  let pendingRangeValueDetail: CalendarRangeValueChangeDetail | undefined;
   let pendingMonthDetail: CalendarMonthChangeDetail | undefined;
   const today = todayValue();
-  const initialValue = options.defaultValue ?? options.value?.();
+  const initialRangeValue = options.defaultRangeValue ?? options.rangeValue?.();
+  const initialValue = options.defaultValue ?? options.value?.() ?? initialRangeValue?.start;
   const initialMonth = options.defaultMonth ?? valueToMonth(initialValue ?? today);
   const [value, setValueState] = createControllableSignal<CalendarValue | undefined>({
     value: options.value,
@@ -165,11 +197,31 @@ export function createCalendar(options: CreateCalendarOptions = {}): CalendarApi
     defaultValue: initialValue ?? today,
     value: () => undefined,
   });
+  const [rangeValue, setRangeValueState] = createControllableSignal<CalendarRangeValue | undefined>(
+    {
+      value: options.rangeValue,
+      defaultValue: initialRangeValue,
+      onChange: (nextRangeValue) => {
+        if (nextRangeValue === undefined) return;
+        options.onRangeValueChange?.(
+          nextRangeValue,
+          pendingRangeValueDetail ?? {
+            complete: isCompleteRange(nextRangeValue),
+            reason: "programmatic",
+          },
+        );
+        pendingRangeValueDetail = undefined;
+      },
+    },
+  );
   const disabled = createMemo(() => options.disabled?.() ?? false);
   const locale = createMemo(() => options.locale?.() ?? "en-US");
   const minValue = createMemo(() => options.minValue?.());
   const maxValue = createMemo(() => options.maxValue?.());
-  const weekStartsOn = createMemo(() => clampWeekStart(options.weekStartsOn?.() ?? 0));
+  const selectionMode = createMemo(() => options.selectionMode?.() ?? "single");
+  const weekStartsOn = createMemo(() =>
+    clampWeekStart(options.weekStartsOn?.() ?? getLocaleWeekStart(locale())),
+  );
 
   const setMonth = (nextMonth: CalendarMonth, detail: CalendarMonthChangeDetail) => {
     pendingMonthDetail = detail;
@@ -197,9 +249,20 @@ export function createCalendar(options: CreateCalendarOptions = {}): CalendarApi
     moveFocus: (currentValue, amount, detail) => focusDate(addDays(currentValue, amount), detail),
     nextMonth: (detail) => setMonth(addMonths(month(), 1), detail),
     previousMonth: (detail) => setMonth(addMonths(month(), -1), detail),
+    rangeValue,
     selectDate: (nextValue, detail) => {
-      if (disabled() || isDateDisabled(nextValue, minValue(), maxValue()))
+      if (disabled() || isDateDisabled(nextValue, minValue(), maxValue(), options.unavailable))
         return value() ?? nextValue;
+
+      if (selectionMode() === "range") {
+        const nextRangeValue = getNextRangeValue(rangeValue(), nextValue, options.unavailable);
+        pendingRangeValueDetail = { ...detail, complete: isCompleteRange(nextRangeValue) };
+        setRangeValueState(nextRangeValue);
+        pendingRangeValueDetail = undefined;
+        focusDate(nextValue, { event: detail.event, reason: "focus" });
+        return nextValue;
+      }
+
       pendingValueDetail = detail;
       const result = setValueState(nextValue);
       pendingValueDetail = undefined;
@@ -207,9 +270,20 @@ export function createCalendar(options: CreateCalendarOptions = {}): CalendarApi
       return result ?? nextValue;
     },
     setFocusedValue: focusDate,
+    selectionMode,
     value,
     weekDayLabels: () => getWeekDayLabels(locale(), weekStartsOn()),
-    weeks: () => getMonthWeeks(month(), value(), today, minValue(), maxValue(), weekStartsOn()),
+    weeks: () =>
+      getMonthWeeks(
+        month(),
+        value(),
+        rangeValue(),
+        today,
+        minValue(),
+        maxValue(),
+        weekStartsOn(),
+        options.unavailable,
+      ),
   };
 }
 
@@ -234,6 +308,10 @@ export function createDatePicker(options: CreateDatePickerOptions = {}): DatePic
     onValueChange: (nextValue, detail) => {
       options.onValueChange?.(nextValue, detail);
       setOpen(false, { event: detail.event, reason: "select" });
+    },
+    onRangeValueChange: (nextRangeValue, detail) => {
+      options.onRangeValueChange?.(nextRangeValue, detail);
+      if (detail.complete) setOpen(false, { event: detail.event, reason: "select" });
     },
   });
 
@@ -261,6 +339,7 @@ function CalendarRoot(props: CalendarRootProps) {
   const [local, others] = splitProps(props, [
     "children",
     "defaultMonth",
+    "defaultRangeValue",
     "defaultValue",
     "disabled",
     "locale",
@@ -268,12 +347,17 @@ function CalendarRoot(props: CalendarRootProps) {
     "minValue",
     "month",
     "onMonthChange",
+    "onRangeValueChange",
     "onValueChange",
+    "rangeValue",
+    "selectionMode",
+    "unavailable",
     "value",
     "weekStartsOn",
   ]);
   const calendar = createCalendar({
     defaultMonth: local.defaultMonth,
+    defaultRangeValue: local.defaultRangeValue,
     defaultValue: local.defaultValue,
     disabled: () => local.disabled,
     locale: () => local.locale,
@@ -281,7 +365,11 @@ function CalendarRoot(props: CalendarRootProps) {
     minValue: () => local.minValue,
     month: () => local.month,
     onMonthChange: local.onMonthChange,
+    onRangeValueChange: local.onRangeValueChange,
     onValueChange: local.onValueChange,
+    rangeValue: () => local.rangeValue,
+    selectionMode: () => local.selectionMode,
+    unavailable: local.unavailable,
     value: () => local.value,
     weekStartsOn: () => local.weekStartsOn,
   });
@@ -303,6 +391,9 @@ function CalendarRootView(
     <div
       {...others}
       data-disabled={dataBoolean(calendar.disabled())}
+      data-end-value={calendar.rangeValue()?.end}
+      data-selection-mode={calendar.selectionMode()}
+      data-start-value={calendar.rangeValue()?.start}
       data-value={calendar.value()}
       {...partDataAttributes("calendar", "root")}
     >
@@ -413,9 +504,13 @@ function Grid(props: CalendarGridProps) {
                     role="gridcell"
                     aria-selected={day.selected}
                     data-disabled={dataBoolean(day.disabled)}
+                    data-in-range={dataBoolean(day.inRange)}
                     data-outside-month={dataBoolean(day.outsideMonth)}
+                    data-range-end={dataBoolean(day.rangeEnd)}
+                    data-range-start={dataBoolean(day.rangeStart)}
                     data-selected={dataBoolean(day.selected)}
                     data-today={dataBoolean(day.today)}
+                    data-unavailable={dataBoolean(day.unavailable)}
                     data-value={day.date}
                     {...partDataAttributes("calendar", "cell")}
                   >
@@ -426,9 +521,13 @@ function Grid(props: CalendarGridProps) {
                       aria-label={formatDate(day.date, calendar.locale())}
                       data-date={day.date}
                       data-disabled={dataBoolean(calendar.disabled() || day.disabled)}
+                      data-in-range={dataBoolean(day.inRange)}
                       data-outside-month={dataBoolean(day.outsideMonth)}
+                      data-range-end={dataBoolean(day.rangeEnd)}
+                      data-range-start={dataBoolean(day.rangeStart)}
                       data-selected={dataBoolean(day.selected)}
                       data-today={dataBoolean(day.today)}
+                      data-unavailable={dataBoolean(day.unavailable)}
                       data-value={day.date}
                       onClick={(event) => calendar.selectDate(day.date, { event, reason: "cell" })}
                       onKeyDown={(event) => {
@@ -456,6 +555,7 @@ function DatePickerRoot(props: DatePickerRootProps) {
     "children",
     "defaultMonth",
     "defaultOpen",
+    "defaultRangeValue",
     "defaultValue",
     "disabled",
     "locale",
@@ -464,14 +564,19 @@ function DatePickerRoot(props: DatePickerRootProps) {
     "month",
     "onMonthChange",
     "onOpenChange",
+    "onRangeValueChange",
     "onValueChange",
     "open",
+    "rangeValue",
+    "selectionMode",
+    "unavailable",
     "value",
     "weekStartsOn",
   ]);
   const datePicker = createDatePicker({
     defaultMonth: local.defaultMonth,
     defaultOpen: local.defaultOpen,
+    defaultRangeValue: local.defaultRangeValue,
     defaultValue: local.defaultValue,
     disabled: () => local.disabled,
     locale: () => local.locale,
@@ -480,8 +585,12 @@ function DatePickerRoot(props: DatePickerRootProps) {
     month: () => local.month,
     onMonthChange: local.onMonthChange,
     onOpenChange: local.onOpenChange,
+    onRangeValueChange: local.onRangeValueChange,
     onValueChange: local.onValueChange,
     open: () => local.open,
+    rangeValue: () => local.rangeValue,
+    selectionMode: () => local.selectionMode,
+    unavailable: local.unavailable,
     value: () => local.value,
     weekStartsOn: () => local.weekStartsOn,
   });
@@ -492,6 +601,9 @@ function DatePickerRoot(props: DatePickerRootProps) {
         <div
           {...others}
           data-disabled={dataBoolean(datePicker.calendar.disabled())}
+          data-end-value={datePicker.calendar.rangeValue()?.end}
+          data-selection-mode={datePicker.calendar.selectionMode()}
+          data-start-value={datePicker.calendar.rangeValue()?.start}
           data-state={datePicker.open() ? "open" : "closed"}
           data-value={datePicker.calendar.value()}
           {...partDataAttributes("date-picker", "root")}
@@ -507,6 +619,7 @@ function Trigger(props: DatePickerTriggerProps) {
   const datePicker = useDatePicker("Trigger");
   const [local, others] = splitProps(props, ["children", "onClick", "placeholder", "type"]);
   const selectedValue = createMemo(() => datePicker.calendar.value());
+  const rangeLabel = createMemo(() => formatRangeValue(datePicker.calendar.rangeValue()));
 
   return (
     <button
@@ -517,7 +630,10 @@ function Trigger(props: DatePickerTriggerProps) {
       aria-haspopup="dialog"
       disabled={datePicker.calendar.disabled() || others.disabled}
       data-disabled={dataBoolean(datePicker.calendar.disabled() || others.disabled)}
-      data-placeholder={dataBoolean(!selectedValue())}
+      data-end-value={datePicker.calendar.rangeValue()?.end}
+      data-placeholder={dataBoolean(!selectedValue() && !rangeLabel())}
+      data-selection-mode={datePicker.calendar.selectionMode()}
+      data-start-value={datePicker.calendar.rangeValue()?.start}
       data-state={datePicker.open() ? "open" : "closed"}
       data-value={selectedValue()}
       onClick={(event) => {
@@ -527,7 +643,7 @@ function Trigger(props: DatePickerTriggerProps) {
       }}
       {...partDataAttributes("date-picker", "trigger")}
     >
-      {local.children ?? selectedValue() ?? local.placeholder ?? "Select date"}
+      {local.children ?? selectedValue() ?? rangeLabel() ?? local.placeholder ?? "Select date"}
     </button>
   );
 }
@@ -613,10 +729,12 @@ function handleDayKeyDown(event: KeyboardEvent, calendar: CalendarApi, value: Ca
 function getMonthWeeks(
   monthValue: CalendarMonth,
   selectedValue: CalendarValue | undefined,
+  rangeValue: CalendarRangeValue | undefined,
   today: CalendarValue,
   minValue: CalendarValue | undefined,
   maxValue: CalendarValue | undefined,
   weekStartsOn: number,
+  unavailable: ((value: CalendarValue) => boolean) | undefined,
 ): CalendarDay[][] {
   const monthDate = parseMonthValue(monthValue);
   const startOffset = modulo(monthDate.getUTCDay() - weekStartsOn, 7);
@@ -628,13 +746,21 @@ function getMonthWeeks(
     for (let dayIndex = 0; dayIndex < 7; dayIndex += 1) {
       const date = addDays(gridStart, weekIndex * 7 + dayIndex);
       const parsed = parseDateValue(date);
+      const rangeStart = rangeValue?.start === date;
+      const rangeEnd = rangeValue?.end === date;
+      const inRange = isInRange(date, rangeValue);
+      const isUnavailable = unavailable?.(date) ?? false;
       week.push({
         date,
         day: parsed.getUTCDate(),
-        disabled: isDateDisabled(date, minValue, maxValue),
+        disabled: isDateDisabled(date, minValue, maxValue, unavailable),
+        inRange,
         outsideMonth: valueToMonth(date) !== monthValue,
-        selected: selectedValue === date,
+        rangeEnd,
+        rangeStart,
+        selected: selectedValue === date || rangeStart || rangeEnd,
         today: today === date,
+        unavailable: isUnavailable,
       });
     }
     weeks.push(week);
@@ -651,14 +777,89 @@ function getWeekDayLabels(locale: string, weekStartsOn: number) {
   });
 }
 
+function getLocaleWeekStart(locale: string) {
+  const Locale = (
+    Intl as unknown as {
+      Locale?: new (locale: string) => { weekInfo?: { firstDay?: number } };
+    }
+  ).Locale;
+
+  try {
+    const firstDay = Locale ? new Locale(locale).weekInfo?.firstDay : undefined;
+    if (firstDay === undefined) return 0;
+    return firstDay % 7;
+  } catch {
+    return 0;
+  }
+}
+
 function isDateDisabled(
   value: CalendarValue,
   minValue: CalendarValue | undefined,
   maxValue: CalendarValue | undefined,
+  unavailable: ((value: CalendarValue) => boolean) | undefined,
 ) {
   return (
-    (minValue !== undefined && value < minValue) || (maxValue !== undefined && value > maxValue)
+    (minValue !== undefined && value < minValue) ||
+    (maxValue !== undefined && value > maxValue) ||
+    (unavailable?.(value) ?? false)
   );
+}
+
+function getNextRangeValue(
+  currentRangeValue: CalendarRangeValue | undefined,
+  nextValue: CalendarValue,
+  unavailable: ((value: CalendarValue) => boolean) | undefined,
+): CalendarRangeValue {
+  if (!currentRangeValue?.start || currentRangeValue.end) {
+    return { start: nextValue };
+  }
+
+  if (nextValue < currentRangeValue.start) {
+    const nextRangeValue = { start: nextValue, end: currentRangeValue.start };
+    return rangeContainsUnavailable(nextRangeValue, unavailable)
+      ? { start: nextValue }
+      : nextRangeValue;
+  }
+
+  const nextRangeValue = { start: currentRangeValue.start, end: nextValue };
+  return rangeContainsUnavailable(nextRangeValue, unavailable)
+    ? { start: nextValue }
+    : nextRangeValue;
+}
+
+function isCompleteRange(rangeValue: CalendarRangeValue | undefined) {
+  return rangeValue?.start !== undefined && rangeValue.end !== undefined;
+}
+
+function isInRange(value: CalendarValue, rangeValue: CalendarRangeValue | undefined) {
+  return (
+    rangeValue?.start !== undefined &&
+    rangeValue.end !== undefined &&
+    value >= rangeValue.start &&
+    value <= rangeValue.end
+  );
+}
+
+function rangeContainsUnavailable(
+  rangeValue: Required<CalendarRangeValue>,
+  unavailable: ((value: CalendarValue) => boolean) | undefined,
+) {
+  if (!unavailable) return false;
+
+  let value = rangeValue.start;
+  while (value <= rangeValue.end) {
+    if (unavailable(value)) return true;
+    value = addDays(value, 1);
+  }
+
+  return false;
+}
+
+function formatRangeValue(rangeValue: CalendarRangeValue | undefined) {
+  if (!rangeValue?.start) return undefined;
+  if (!rangeValue.end) return rangeValue.start;
+  return `${rangeValue.start} - ${rangeValue.end}`;
 }
 
 function focusDayButton(value: CalendarValue) {

--- a/packages/keystone/src/dropdown-menu/index.ts
+++ b/packages/keystone/src/dropdown-menu/index.ts
@@ -7,6 +7,7 @@ export type {
   MenuGroupLabelProps as DropdownMenuGroupLabelProps,
   MenuGroupProps as DropdownMenuGroupProps,
   MenuItemProps as DropdownMenuItemProps,
+  MenuLinkProps as DropdownMenuLinkProps,
   MenuOpenChangeDetail as DropdownMenuOpenChangeDetail,
   MenuPartProps as DropdownMenuPartProps,
   MenuPortalProps as DropdownMenuPortalProps,

--- a/packages/keystone/src/index.ts
+++ b/packages/keystone/src/index.ts
@@ -11,7 +11,23 @@ export { createFieldValidity, createFormControl } from "./form/index";
 export { HoverCard, createHoverCard } from "./hover-card/index";
 export { Menu, createMenu } from "./menu/index";
 export { Menubar, createMenubar } from "./menubar/index";
+export {
+  getDocsMetadata,
+  getPartDataAttributes,
+  getPartMetadata,
+  getPrimitiveMetadata,
+  primitiveMetadata,
+} from "./metadata/index";
 export { NavigationMenu, createNavigationMenu } from "./navigation-menu/index";
+export type {
+  DocsPartMetadata,
+  DocsPrimitiveMetadata,
+  PartCssVarMetadata,
+  PartStateAttributeMetadata,
+  PrimitiveMetadata,
+  PrimitivePartMetadata,
+  PrimitiveScope,
+} from "./metadata/index";
 export type {
   AccordionContentProps,
   AccordionHeaderProps,
@@ -203,6 +219,7 @@ export type {
 export type {
   CreateSliderOptions,
   SliderApi,
+  SliderHiddenInputProps,
   SliderOrientation,
   SliderPartProps,
   SliderRangeProps,

--- a/packages/keystone/src/listbox/collection-registry.ts
+++ b/packages/keystone/src/listbox/collection-registry.ts
@@ -23,32 +23,36 @@ export function createCollectionRegistry<T extends CollectionItem>(): Collection
   let order = 0;
   let needsOrderedSort = false;
   const fallbackOrder = new Map<string, number>();
+  const indexByValue = new Map<string, number>();
 
   const registerItem = (item: CollectionRegistration<T>) => {
     const registrationOrder = item.index ?? order++;
     fallbackOrder.set(item.value, registrationOrder);
     const nextItem = item as T;
-    const existingIndex = currentItems.findIndex((candidate) => candidate.value === nextItem.value);
+    const existingIndex = indexByValue.get(nextItem.value) ?? -1;
     needsOrderedSort ||= item.index !== undefined || item.element !== undefined;
 
     if (existingIndex === -1) {
       currentItems.push(nextItem);
+      indexByValue.set(nextItem.value, currentItems.length - 1);
     } else {
       currentItems[existingIndex] = nextItem;
     }
 
     if (needsOrderedSort) {
       currentItems.sort((a, b) => sortCollectionItemOrder(a, b, fallbackOrder));
+      rebuildCollectionIndexes(currentItems, indexByValue);
     }
 
     setItems(currentItems);
 
     const cleanup = () => {
       fallbackOrder.delete(nextItem.value);
-      const index = currentItems.findIndex((candidate) => candidate.value === nextItem.value);
+      const index = indexByValue.get(nextItem.value) ?? -1;
 
       if (index !== -1) {
         currentItems.splice(index, 1);
+        rebuildCollectionIndexes(currentItems, indexByValue);
         setItems(currentItems);
       }
     };
@@ -61,6 +65,16 @@ export function createCollectionRegistry<T extends CollectionItem>(): Collection
     items: () => items(),
     registerItem,
   };
+}
+
+function rebuildCollectionIndexes<T extends CollectionItem>(
+  items: readonly T[],
+  indexByValue: Map<string, number>,
+) {
+  indexByValue.clear();
+  for (const [index, item] of items.entries()) {
+    indexByValue.set(item.value, index);
+  }
 }
 
 function sortCollectionItemOrder<T extends CollectionItem>(

--- a/packages/keystone/src/listbox/listbox.test.tsx
+++ b/packages/keystone/src/listbox/listbox.test.tsx
@@ -115,6 +115,39 @@ describe("Listbox interaction module", () => {
     });
   });
 
+  test("replaces duplicate option values without leaving stale collection indexes", () => {
+    createRoot((dispose) => {
+      const listbox = createListboxInteraction<
+        { disabled?: boolean; label: string; value: string },
+        { reason: string }
+      >({
+        id: () => "project-listbox",
+        labelledBy: () => "project-trigger",
+        optionId: (value) => `project-option-${value}`,
+        optionSelectDetail: () => ({ reason: "item" }),
+        programmaticDetail: { reason: "programmatic" },
+        scope: "test-listbox",
+      });
+
+      const unregisterAlpha = listbox.registerOption({ label: "Alpha", value: "alpha" });
+      listbox.registerOption({ label: "Updated alpha", value: "alpha" });
+      listbox.registerOption({ label: "Bravo", value: "bravo" });
+
+      expect(listbox.collection.items().map((item) => item.label)).toEqual([
+        "Updated alpha",
+        "Bravo",
+      ]);
+      expect(listbox.collection.itemByValue("alpha")?.label).toBe("Updated alpha");
+
+      unregisterAlpha();
+
+      expect(listbox.collection.items().map((item) => item.value)).toEqual(["bravo"]);
+      expect(listbox.collection.itemByValue("alpha")).toBeUndefined();
+      expect(listbox.collection.itemByValue("bravo")?.label).toBe("Bravo");
+      dispose();
+    });
+  });
+
   test("supports grouped options and multiple selection contracts", () => {
     createRoot((dispose) => {
       const changes: Array<readonly string[]> = [];

--- a/packages/keystone/src/menu/index.tsx
+++ b/packages/keystone/src/menu/index.tsx
@@ -111,6 +111,16 @@ export type MenuItemProps = MenuPartProps<HTMLDivElement> &
     textValue?: string;
     value: string;
   };
+export type MenuLinkProps = MenuPartProps<HTMLAnchorElement> &
+  Omit<JSX.AnchorHTMLAttributes<HTMLAnchorElement>, "children" | "ref" | "onSelect" | "role"> & {
+    closeOnSelect?: boolean;
+    description?: string;
+    disabled?: boolean;
+    label?: string;
+    onSelect?: (detail: MenuSelectDetail) => void;
+    textValue?: string;
+    value: string;
+  };
 export type MenuCheckboxItemProps = MenuItemProps & {
   checked?: boolean | "indeterminate";
   defaultChecked?: boolean | "indeterminate";
@@ -752,6 +762,50 @@ function createMenuNamespace(factoryOptions: MenuFactoryOptions) {
     );
   }
 
+  function Link(props: MenuLinkProps) {
+    const menu = useMenu("Link");
+    const [local, others] = splitProps(props, [
+      "children",
+      "closeOnSelect",
+      "description",
+      "disabled",
+      "label",
+      "onClick",
+      "onPointerMove",
+      "onSelect",
+      "textValue",
+      "value",
+    ]);
+    const label = () => local.textValue ?? local.label ?? String(local.children ?? local.value);
+    const itemContext = createMemo(
+      () =>
+        ({
+          descriptionId: menu.itemId(local.value) + "-description",
+          labelId: menu.itemId(local.value) + "-label",
+        }) satisfies MenuItemContextValue,
+    );
+    const linkProps = menu.getItemProps({
+      ...(others as Record<string, unknown>),
+      closeOnSelect: local.closeOnSelect,
+      description: local.description,
+      disabled: local.disabled,
+      label: label(),
+      onClick: local.onClick,
+      onPointerMove: local.onPointerMove,
+      onSelect: local.onSelect,
+      textValue: local.textValue,
+      value: local.value,
+    } as Omit<MenuItemProps, "children" | "label"> & { label: string }) as Record<string, unknown>;
+
+    return (
+      <MenuItemContext.Provider value={itemContext()}>
+        <a {...linkProps} data-scope={menu.scope} data-part="link">
+          {local.children}
+        </a>
+      </MenuItemContext.Provider>
+    );
+  }
+
   function CheckboxItem(props: MenuCheckboxItemProps) {
     const menu = useMenu("CheckboxItem");
     const [local, others] = splitProps(props, [
@@ -1065,6 +1119,7 @@ function createMenuNamespace(factoryOptions: MenuFactoryOptions) {
     GroupLabel,
     Separator,
     Item,
+    Link,
     CheckboxItem,
     RadioGroup,
     RadioItem,

--- a/packages/keystone/src/menubar/index.ts
+++ b/packages/keystone/src/menubar/index.ts
@@ -7,6 +7,7 @@ export type {
   MenuGroupLabelProps as MenubarGroupLabelProps,
   MenuGroupProps as MenubarGroupProps,
   MenuItemProps as MenubarItemProps,
+  MenuLinkProps as MenubarLinkProps,
   MenuOpenChangeDetail as MenubarOpenChangeDetail,
   MenuPartProps as MenubarPartProps,
   MenuPortalProps as MenubarPortalProps,

--- a/packages/keystone/src/navigation-menu/index.ts
+++ b/packages/keystone/src/navigation-menu/index.ts
@@ -7,6 +7,7 @@ export type {
   MenuGroupLabelProps as NavigationMenuGroupLabelProps,
   MenuGroupProps as NavigationMenuGroupProps,
   MenuItemProps as NavigationMenuItemProps,
+  MenuLinkProps as NavigationMenuLinkProps,
   MenuOpenChangeDetail as NavigationMenuOpenChangeDetail,
   MenuPartProps as NavigationMenuPartProps,
   MenuPortalProps as NavigationMenuPortalProps,

--- a/packages/keystone/src/radio-group/index.tsx
+++ b/packages/keystone/src/radio-group/index.tsx
@@ -3,6 +3,7 @@ import {
   createMemo,
   createUniqueId,
   onCleanup,
+  onMount,
   splitProps,
   useContext,
   type Accessor,
@@ -24,6 +25,7 @@ export type RadioGroupRootProps = RadioGroupPartProps<HTMLDivElement> &
   Omit<JSX.HTMLAttributes<HTMLDivElement>, "children" | "ref"> & {
     defaultValue?: string;
     disabled?: boolean;
+    form?: string;
     invalid?: boolean;
     loopFocus?: boolean;
     name?: string;
@@ -63,6 +65,7 @@ type RadioItemRecord = {
 type RadioGroupApi = {
   disabled: Accessor<boolean>;
   invalid: Accessor<boolean>;
+  form: Accessor<string | undefined>;
   loopFocus: Accessor<boolean>;
   name: Accessor<string | undefined>;
   orientation: Accessor<RadioGroupOrientation>;
@@ -73,6 +76,7 @@ type RadioGroupApi = {
     disabled: Accessor<boolean>,
   ) => () => void;
   required: Accessor<boolean>;
+  reset: () => string | undefined;
   selectValue: (
     value: string | undefined,
     detail: RadioGroupValueChangeDetail,
@@ -96,6 +100,7 @@ export function createRadioGroup(
   options: {
     defaultValue?: string;
     disabled?: () => boolean | undefined;
+    form?: () => string | undefined;
     invalid?: () => boolean | undefined;
     loopFocus?: () => boolean | undefined;
     name?: () => string | undefined;
@@ -119,6 +124,7 @@ export function createRadioGroup(
 
   return {
     disabled: createMemo(() => options.disabled?.() ?? false),
+    form: createMemo(() => options.form?.()),
     invalid: createMemo(() => options.invalid?.() ?? false),
     loopFocus: createMemo(() => options.loopFocus?.() ?? true),
     name: createMemo(() => options.name?.()),
@@ -134,6 +140,12 @@ export function createRadioGroup(
       };
     },
     required: createMemo(() => options.required?.() ?? false),
+    reset: () => {
+      pendingDetail = { reason: "programmatic" };
+      const result = setValueState(options.defaultValue);
+      pendingDetail = undefined;
+      return result;
+    },
     selectValue: (nextValue, detail) => {
       pendingDetail = detail;
       const result = setValueState(nextValue);
@@ -162,6 +174,7 @@ function Root(props: RadioGroupRootProps) {
     "children",
     "defaultValue",
     "disabled",
+    "form",
     "invalid",
     "loopFocus",
     "name",
@@ -174,6 +187,7 @@ function Root(props: RadioGroupRootProps) {
   const group = createRadioGroup({
     defaultValue: local.defaultValue,
     disabled: () => local.disabled,
+    form: () => local.form,
     invalid: () => local.invalid,
     loopFocus: () => local.loopFocus,
     name: () => local.name,
@@ -290,12 +304,32 @@ function ItemIndicator(props: RadioGroupItemIndicatorProps) {
 function HiddenInput(props: RadioGroupHiddenInputProps) {
   const group = useRadioGroup("HiddenInput");
   const item = useRadioGroupItem("HiddenInput");
+  let input: HTMLInputElement | undefined;
+
+  onMount(() => {
+    const form = input?.form;
+    if (!form) return;
+
+    const onReset = () => group.reset();
+    form.addEventListener("reset", onReset);
+    onCleanup(() => form.removeEventListener("reset", onReset));
+  });
 
   return (
     <input
       {...props}
+      onChange={(event) => {
+        callEventHandler(props.onChange, event);
+        if (event.defaultPrevented || item.disabled() || group.readOnly()) return;
+        if (event.currentTarget.checked) group.selectValue(item.value, { reason: "item" });
+      }}
+      ref={(element) => {
+        input = element;
+        if (typeof props.ref === "function") props.ref(element);
+      }}
       checked={item.checked()}
       disabled={item.disabled()}
+      form={props.form ?? group.form()}
       id={item.inputId}
       name={group.name()}
       required={group.required()}

--- a/packages/keystone/src/selection-control/controller.ts
+++ b/packages/keystone/src/selection-control/controller.ts
@@ -16,11 +16,13 @@ export type SelectionControlChangeDetail = {
 export type SelectionControlApi = {
   checked: Accessor<SelectionControlCheckedState>;
   disabled: Accessor<boolean>;
+  form: Accessor<string | undefined>;
   inputId: string;
   invalid: Accessor<boolean>;
   name: Accessor<string | undefined>;
   readOnly: Accessor<boolean>;
   required: Accessor<boolean>;
+  reset: () => SelectionControlCheckedState;
   scope: string;
   setChecked: (
     checked: SelectionControlCheckedState,
@@ -34,6 +36,7 @@ export type CreateSelectionControlOptions = {
   checked?: Accessor<SelectionControlCheckedState | undefined>;
   defaultChecked?: SelectionControlCheckedState;
   disabled?: Accessor<boolean | undefined>;
+  form?: Accessor<string | undefined>;
   invalid?: Accessor<boolean | undefined>;
   name?: Accessor<string | undefined>;
   onCheckedChange?: (
@@ -60,6 +63,7 @@ export function createSelectionControl(
   });
 
   const disabled = createMemo(() => options.disabled?.() ?? false);
+  const form = createMemo(() => options.form?.());
   const invalid = createMemo(() => options.invalid?.() ?? false);
   const readOnly = createMemo(() => options.readOnly?.() ?? false);
   const required = createMemo(() => options.required?.() ?? false);
@@ -79,11 +83,13 @@ export function createSelectionControl(
   return {
     checked,
     disabled,
+    form,
     inputId: `keystone-${options.scope}-input-${createUniqueId()}`,
     invalid,
     name,
     readOnly,
     required,
+    reset: () => setChecked(options.defaultChecked ?? false, { reason: "programmatic" }),
     scope: options.scope,
     setChecked,
     toggle: (detail) => setChecked(checked() === true ? false : true, detail),

--- a/packages/keystone/src/selection-control/selection-control.test.tsx
+++ b/packages/keystone/src/selection-control/selection-control.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, test } from "vitest";
 import { Checkbox } from "../checkbox/index";
 import { RadioGroup } from "../radio-group/index";
 import { Switch } from "../switch/index";
-import { click, getByPart, keyDown, render } from "../../test/harness";
+import { click, getByPart, keyDown, render, settled } from "../../test/harness";
 
 function parts(scope: string, part: string) {
   return Array.from(
@@ -40,6 +40,29 @@ describe("Selection controls", () => {
     click(control);
     expect(input.checked).toBe(true);
     expect(changes).toEqual([]);
+  });
+
+  test("switch resets through its native input form owner", async () => {
+    render(() => (
+      <form>
+        <Switch.Root defaultChecked name="notifications">
+          <Switch.Control>
+            <Switch.Thumb />
+          </Switch.Control>
+          <Switch.HiddenInput />
+        </Switch.Root>
+      </form>
+    ));
+
+    const form = document.querySelector("form")!;
+    click(getByPart("switch", "control"));
+    expect(new FormData(form).get("notifications")).toBeNull();
+
+    form.reset();
+    await settled();
+
+    expect(getByPart("switch", "control").getAttribute("aria-checked")).toBe("true");
+    expect(new FormData(form).get("notifications")).toBe("on");
   });
 
   test("checkbox supports indeterminate state and keyboard toggling", () => {
@@ -93,6 +116,39 @@ describe("Selection controls", () => {
     expect(changes).toEqual([true]);
   });
 
+  test("checkbox submits, syncs, and resets through its native input", async () => {
+    render(() => (
+      <form>
+        <Checkbox.Root defaultChecked name="terms">
+          <Checkbox.Control />
+          <Checkbox.HiddenInput />
+        </Checkbox.Root>
+      </form>
+    ));
+
+    const form = document.querySelector("form")!;
+    const input = getByPart("checkbox", "hidden-input") as HTMLInputElement;
+
+    expect(new FormData(form).get("terms")).toBe("on");
+
+    click(getByPart("checkbox", "control"));
+    expect(new FormData(form).get("terms")).toBeNull();
+
+    input.checked = true;
+    input.dispatchEvent(new Event("change", { bubbles: true, cancelable: true }));
+    await settled();
+    expect(getByPart("checkbox", "control").getAttribute("aria-checked")).toBe("true");
+
+    click(getByPart("checkbox", "control"));
+    expect(new FormData(form).get("terms")).toBeNull();
+
+    form.reset();
+    await settled();
+
+    expect(getByPart("checkbox", "control").getAttribute("aria-checked")).toBe("true");
+    expect(new FormData(form).get("terms")).toBe("on");
+  });
+
   test("radio group roves focus and selects with keyboard while skipping disabled items", () => {
     const changes: string[] = [];
 
@@ -135,5 +191,35 @@ describe("Selection controls", () => {
     expect(large.getAttribute("aria-checked")).toBe("true");
     expect((parts("radio-group", "hidden-input")[2] as HTMLInputElement).checked).toBe(true);
     expect(changes).toEqual(["large"]);
+  });
+
+  test("radio group resets through an external form owner", async () => {
+    render(() => (
+      <>
+        <form id="settings" />
+        <RadioGroup.Root defaultValue="small" form="settings" name="size">
+          <RadioGroup.Item value="small">
+            Small
+            <RadioGroup.HiddenInput />
+          </RadioGroup.Item>
+          <RadioGroup.Item value="large">
+            Large
+            <RadioGroup.HiddenInput />
+          </RadioGroup.Item>
+        </RadioGroup.Root>
+      </>
+    ));
+
+    const [, large] = parts("radio-group", "item");
+    click(large);
+
+    const form = document.querySelector<HTMLFormElement>("#settings")!;
+    expect(new FormData(form).get("size")).toBe("large");
+
+    form.reset();
+    await settled();
+
+    expect(new FormData(form).get("size")).toBe("small");
+    expect(parts("radio-group", "item")[0].getAttribute("aria-checked")).toBe("true");
   });
 });

--- a/packages/keystone/src/slider/controller.ts
+++ b/packages/keystone/src/slider/controller.ts
@@ -19,11 +19,16 @@ export type SliderValueChangeDetail = {
 export type SliderControllerOptions = {
   defaultValue?: readonly number[];
   disabled?: Accessor<boolean | undefined>;
+  form?: Accessor<string | undefined>;
+  invalid?: Accessor<boolean | undefined>;
   max?: Accessor<number | undefined>;
   min?: Accessor<number | undefined>;
+  name?: Accessor<string | undefined>;
   onValueChange?: (value: readonly number[], detail: SliderValueChangeDetail) => void;
   onValueCommit?: (value: readonly number[], detail: SliderValueChangeDetail) => void;
   orientation?: Accessor<SliderOrientation | undefined>;
+  readOnly?: Accessor<boolean | undefined>;
+  required?: Accessor<boolean | undefined>;
   step?: Accessor<number | undefined>;
   value?: Accessor<readonly number[] | undefined>;
 };
@@ -57,17 +62,37 @@ export type SliderThumbContractProps = Omit<
   ref?: HTMLButtonElement | ((element: HTMLButtonElement) => void);
 };
 
+export type SliderHiddenInputContractProps = Omit<
+  JSX.InputHTMLAttributes<HTMLInputElement>,
+  "children" | "checked" | "ref" | "type" | "value"
+> & {
+  index: number;
+  ref?: HTMLInputElement | ((element: HTMLInputElement) => void);
+};
+
 export type SliderApi = {
   disabled: Accessor<boolean>;
+  form: Accessor<string | undefined>;
+  getHiddenInputProps: (props: SliderHiddenInputContractProps) => Record<string, unknown>;
   getPercent: (value: number) => number;
   getRangeProps: (props: SliderRangeContractProps) => Record<string, unknown>;
   getRootProps: (props: SliderRootContractProps) => Record<string, unknown>;
   getThumbProps: (props: SliderThumbContractProps) => Record<string, unknown>;
   getTrackProps: (props: SliderTrackContractProps) => Record<string, unknown>;
+  invalid: Accessor<boolean>;
   max: Accessor<number>;
   min: Accessor<number>;
+  name: Accessor<string | undefined>;
   orientation: Accessor<SliderOrientation>;
+  readOnly: Accessor<boolean>;
+  required: Accessor<boolean>;
+  reset: () => readonly number[];
   step: Accessor<number>;
+  setValueAtIndex: (
+    thumbIndex: number,
+    nextValue: number,
+    detail: SliderValueChangeDetail,
+  ) => readonly number[];
   value: Accessor<readonly number[]>;
 };
 
@@ -76,7 +101,12 @@ export function createSliderController(options: SliderControllerOptions = {}): S
   const max = createMemo(() => Math.max(options.max?.() ?? 100, min()));
   const step = createMemo(() => Math.max(options.step?.() ?? 1, Number.EPSILON));
   const disabled = createMemo(() => options.disabled?.() ?? false);
+  const form = createMemo(() => options.form?.());
+  const invalid = createMemo(() => options.invalid?.() ?? false);
+  const name = createMemo(() => options.name?.());
   const orientation = createMemo(() => options.orientation?.() ?? "horizontal");
+  const readOnly = createMemo(() => options.readOnly?.() ?? false);
+  const required = createMemo(() => options.required?.() ?? false);
   let pendingDetail: SliderValueChangeDetail | undefined;
   let trackElement: HTMLDivElement | undefined;
   let activeThumbIndex: number | undefined;
@@ -98,7 +128,7 @@ export function createSliderController(options: SliderControllerOptions = {}): S
     nextValue: number,
     detail: SliderValueChangeDetail,
   ) => {
-    if (disabled() && detail.reason !== "programmatic") return normalizedValue();
+    if ((disabled() || readOnly()) && detail.reason !== "programmatic") return normalizedValue();
 
     pendingDetail = { ...detail, thumbIndex };
     const nextValues = setValueState((currentValue) => {
@@ -139,7 +169,7 @@ export function createSliderController(options: SliderControllerOptions = {}): S
   };
 
   const startDragging = (event: PointerEvent, thumbIndex?: number) => {
-    if (disabled()) return;
+    if (disabled() || readOnly()) return;
 
     activeThumbIndex = thumbIndex;
     setValueFromPoint(event, thumbIndex === undefined ? "track" : "pointer");
@@ -149,6 +179,67 @@ export function createSliderController(options: SliderControllerOptions = {}): S
 
   return {
     disabled,
+    form,
+    getHiddenInputProps: (props) => {
+      const { index, ...inputProps } = props;
+
+      return {
+        ...inputProps,
+        type: "hidden",
+        ...partDataAttributes("slider", "hidden-input"),
+        get disabled() {
+          return inputProps.disabled ?? disabled();
+        },
+        get form() {
+          return inputProps.form ?? form();
+        },
+        get name() {
+          return inputProps.name ?? name();
+        },
+        get required() {
+          return inputProps.required ?? required();
+        },
+        get value() {
+          return String(normalizedValue()[index] ?? min());
+        },
+        get "data-disabled"() {
+          return dataBoolean(disabled());
+        },
+        get "data-invalid"() {
+          return dataBoolean(invalid());
+        },
+        get "data-readonly"() {
+          return dataBoolean(readOnly());
+        },
+        get "data-required"() {
+          return dataBoolean(required());
+        },
+        get "data-orientation"() {
+          return orientation();
+        },
+        get "data-index"() {
+          return String(index);
+        },
+        onChange: (event: Event) => {
+          callEventHandler(inputProps.onChange, event);
+          if (event.defaultPrevented || disabled() || readOnly()) return;
+          setThumbValue(index, Number((event.currentTarget as HTMLInputElement).value), {
+            event,
+            reason: "programmatic",
+            thumbIndex: index,
+          });
+        },
+        onInput: (event: InputEvent) => {
+          callEventHandler(inputProps.onInput, event);
+          if (event.defaultPrevented || disabled() || readOnly()) return;
+          setThumbValue(index, Number((event.currentTarget as HTMLInputElement).value), {
+            event,
+            reason: "programmatic",
+            thumbIndex: index,
+          });
+        },
+      };
+    },
     getPercent,
     getRangeProps: (props) => ({
       ...props,
@@ -156,8 +247,17 @@ export function createSliderController(options: SliderControllerOptions = {}): S
       get "data-disabled"() {
         return dataBoolean(disabled());
       },
+      get "data-invalid"() {
+        return dataBoolean(invalid());
+      },
       get "data-orientation"() {
         return orientation();
+      },
+      get "data-readonly"() {
+        return dataBoolean(readOnly());
+      },
+      get "data-required"() {
+        return dataBoolean(required());
       },
       get style() {
         const values = normalizedValue();
@@ -178,8 +278,17 @@ export function createSliderController(options: SliderControllerOptions = {}): S
       get "data-disabled"() {
         return dataBoolean(disabled());
       },
+      get "data-invalid"() {
+        return dataBoolean(invalid());
+      },
       get "data-orientation"() {
         return orientation();
+      },
+      get "data-readonly"() {
+        return dataBoolean(readOnly());
+      },
+      get "data-required"() {
+        return dataBoolean(required());
       },
     }),
     getThumbProps: (props) => {
@@ -193,8 +302,17 @@ export function createSliderController(options: SliderControllerOptions = {}): S
         get "aria-disabled"() {
           return disabled() ? "true" : undefined;
         },
+        get "aria-invalid"() {
+          return invalid() ? "true" : undefined;
+        },
         get "aria-orientation"() {
           return orientation();
+        },
+        get "aria-readonly"() {
+          return readOnly() ? "true" : undefined;
+        },
+        get "aria-required"() {
+          return required() ? "true" : undefined;
         },
         get "aria-valuemax"() {
           return max();
@@ -211,8 +329,17 @@ export function createSliderController(options: SliderControllerOptions = {}): S
         get "data-disabled"() {
           return dataBoolean(disabled());
         },
+        get "data-invalid"() {
+          return dataBoolean(invalid());
+        },
         get "data-orientation"() {
           return orientation();
+        },
+        get "data-readonly"() {
+          return dataBoolean(readOnly());
+        },
+        get "data-required"() {
+          return dataBoolean(required());
         },
         get "data-index"() {
           return String(index);
@@ -230,6 +357,7 @@ export function createSliderController(options: SliderControllerOptions = {}): S
         onKeyDown: (event: KeyboardEvent) => {
           callEventHandler(thumbProps.onKeyDown, event);
           if (event.defaultPrevented) return;
+          if (disabled() || readOnly()) return;
 
           const delta = getKeyboardDelta(event.key, step(), max() - min());
           if (delta === undefined) return;
@@ -244,6 +372,7 @@ export function createSliderController(options: SliderControllerOptions = {}): S
         onPointerDown: (event: PointerEvent) => {
           callEventHandler(thumbProps.onPointerDown, event);
           if (event.defaultPrevented) return;
+          if (disabled() || readOnly()) return;
 
           event.preventDefault();
           startDragging(event, index);
@@ -260,21 +389,44 @@ export function createSliderController(options: SliderControllerOptions = {}): S
       get "data-disabled"() {
         return dataBoolean(disabled());
       },
+      get "data-invalid"() {
+        return dataBoolean(invalid());
+      },
       get "data-orientation"() {
         return orientation();
+      },
+      get "data-readonly"() {
+        return dataBoolean(readOnly());
+      },
+      get "data-required"() {
+        return dataBoolean(required());
       },
       onPointerDown: (event: PointerEvent) => {
         callEventHandler(props.onPointerDown, event);
         if (event.defaultPrevented) return;
+        if (disabled() || readOnly()) return;
 
         event.preventDefault();
         startDragging(event);
       },
     }),
+    invalid,
     max,
     min,
+    name,
     orientation,
+    readOnly,
+    required,
+    reset: () => {
+      pendingDetail = { reason: "programmatic" };
+      const result = setValueState(() =>
+        normalizeValues(options.defaultValue ?? [min()], min(), max(), step()),
+      );
+      pendingDetail = undefined;
+      return result;
+    },
     step,
+    setValueAtIndex: setThumbValue,
     value: normalizedValue,
   };
 }

--- a/packages/keystone/src/slider/index.tsx
+++ b/packages/keystone/src/slider/index.tsx
@@ -1,7 +1,8 @@
-import { createContext, splitProps, useContext, type JSX } from "solid-js";
+import { createContext, onCleanup, onMount, splitProps, useContext, type JSX } from "solid-js";
 import {
   createSliderController,
   type SliderApi,
+  type SliderHiddenInputContractProps,
   type SliderOrientation,
   type SliderRangeContractProps,
   type SliderRootContractProps,
@@ -31,11 +32,16 @@ export type SliderRootProps = SliderPartProps<HTMLDivElement> &
   SliderRootContractProps & {
     defaultValue?: readonly number[];
     disabled?: boolean;
+    form?: string;
+    invalid?: boolean;
     max?: number;
     min?: number;
+    name?: string;
     onValueChange?: (value: readonly number[], detail: SliderValueChangeDetail) => void;
     onValueCommit?: (value: readonly number[], detail: SliderValueChangeDetail) => void;
     orientation?: SliderOrientation;
+    readOnly?: boolean;
+    required?: boolean;
     step?: number;
     value?: readonly number[];
   };
@@ -44,6 +50,10 @@ export type SliderTrackProps = SliderPartProps<HTMLDivElement> & SliderTrackCont
 export type SliderRangeProps = SliderPartProps<HTMLDivElement> & SliderRangeContractProps;
 export type SliderThumbProps = SliderPartProps<HTMLButtonElement> &
   Omit<SliderThumbContractProps, "index"> & {
+    index?: number;
+  };
+export type SliderHiddenInputProps = SliderPartProps<HTMLInputElement> &
+  Omit<SliderHiddenInputContractProps, "index"> & {
     index?: number;
   };
 
@@ -68,22 +78,32 @@ function Root(props: SliderRootProps) {
     "children",
     "defaultValue",
     "disabled",
+    "form",
+    "invalid",
     "max",
     "min",
+    "name",
     "onValueChange",
     "onValueCommit",
     "orientation",
+    "readOnly",
+    "required",
     "step",
     "value",
   ]);
   const slider = createSlider({
     defaultValue: local.defaultValue,
     disabled: () => local.disabled,
+    form: () => local.form,
+    invalid: () => local.invalid,
     max: () => local.max,
     min: () => local.min,
+    name: () => local.name,
     onValueChange: local.onValueChange,
     onValueCommit: local.onValueCommit,
     orientation: () => local.orientation,
+    readOnly: () => local.readOnly,
+    required: () => local.required,
     step: () => local.step,
     value: () => local.value,
   });
@@ -120,9 +140,36 @@ function Thumb(props: SliderThumbProps) {
   return <button {...thumbProps}>{local.children}</button>;
 }
 
+function HiddenInput(props: SliderHiddenInputProps) {
+  const slider = useSlider("HiddenInput");
+  const [local, others] = splitProps(props, ["index"]);
+  let input: HTMLInputElement | undefined;
+
+  onMount(() => {
+    const form = input?.form;
+    if (!form) return;
+
+    const onReset = () => slider.reset();
+    form.addEventListener("reset", onReset);
+    onCleanup(() => form.removeEventListener("reset", onReset));
+  });
+
+  const inputProps = slider.getHiddenInputProps({
+    ...others,
+    index: local.index ?? 0,
+    ref: (element) => {
+      input = element;
+      if (typeof others.ref === "function") others.ref(element);
+    },
+  });
+
+  return <input {...inputProps} />;
+}
+
 export const Slider = {
   Root,
   Track,
   Range,
   Thumb,
+  HiddenInput,
 };

--- a/packages/keystone/src/slider/slider.test.tsx
+++ b/packages/keystone/src/slider/slider.test.tsx
@@ -1,7 +1,7 @@
 import { createSignal } from "solid-js";
 import { describe, expect, test } from "vitest";
 import { Slider } from "./index";
-import { getByPart, keyDown, render } from "../../test/harness";
+import { getByPart, keyDown, render, settled } from "../../test/harness";
 
 function parts(part: string) {
   return Array.from(
@@ -51,6 +51,7 @@ describe("Slider", () => {
           <Slider.Thumb index={0}>Minimum</Slider.Thumb>
           <Slider.Thumb index={1}>Maximum</Slider.Thumb>
         </Slider.Track>
+        <Slider.HiddenInput index={0} name="range" />
       </Slider.Root>
     ));
 
@@ -66,6 +67,7 @@ describe("Slider", () => {
     expect(firstThumb?.getAttribute("aria-valuenow")).toBe("25");
     expect(firstThumb?.getAttribute("data-index")).toBe("0");
     expect(secondThumb?.getAttribute("aria-valuenow")).toBe("75");
+    expect(getByPart("slider", "hidden-input").getAttribute("data-index")).toBe("0");
   });
 
   test("updates uncontrolled value with keyboard and commits each keyboard change", () => {
@@ -187,6 +189,78 @@ describe("Slider", () => {
     keyDown(getByPart("slider", "thumb"), "ArrowRight");
 
     expect(getByPart("slider", "thumb").getAttribute("aria-valuenow")).toBe("20");
+    expect(changes).toEqual([]);
+  });
+
+  test("submits, syncs, and resets through hidden input form ownership", async () => {
+    render(() => (
+      <>
+        <form id="filters" />
+        <Slider.Root defaultValue={[20]} form="filters" name="price" min={0} max={100} step={10}>
+          <Slider.Track>
+            <Slider.Range />
+            <Slider.Thumb />
+          </Slider.Track>
+          <Slider.HiddenInput />
+        </Slider.Root>
+      </>
+    ));
+
+    const form = document.querySelector<HTMLFormElement>("#filters")!;
+    const input = getByPart("slider", "hidden-input") as HTMLInputElement;
+    const thumb = getByPart("slider", "thumb");
+
+    expect(new FormData(form).get("price")).toBe("20");
+
+    keyDown(thumb, "ArrowRight");
+    expect(new FormData(form).get("price")).toBe("30");
+
+    input.value = "70";
+    input.dispatchEvent(new Event("input", { bubbles: true, cancelable: true }));
+    await settled();
+    expect(thumb.getAttribute("aria-valuenow")).toBe("70");
+
+    form.reset();
+    await settled();
+
+    expect(thumb.getAttribute("aria-valuenow")).toBe("20");
+    expect(new FormData(form).get("price")).toBe("20");
+  });
+
+  test("read-only slider exposes state and blocks keyboard and pointer changes", () => {
+    const changes: readonly number[][] = [];
+
+    render(() => (
+      <Slider.Root
+        readOnly
+        invalid
+        required
+        defaultValue={[20]}
+        min={0}
+        max={100}
+        step={10}
+        onValueChange={(value) => changes.push(value)}
+      >
+        <Slider.Track>
+          <Slider.Range />
+          <Slider.Thumb />
+        </Slider.Track>
+        <Slider.HiddenInput name="price" />
+      </Slider.Root>
+    ));
+
+    const track = getByPart("slider", "track");
+    const thumb = getByPart("slider", "thumb");
+    track.getBoundingClientRect = () =>
+      ({ bottom: 20, height: 20, left: 0, right: 100, top: 0, width: 100 }) as DOMRect;
+
+    keyDown(thumb, "ArrowRight");
+    pointerDown(track, { clientX: 90, clientY: 10 });
+
+    expect(thumb.getAttribute("aria-readonly")).toBe("true");
+    expect(thumb.getAttribute("aria-invalid")).toBe("true");
+    expect(thumb.getAttribute("aria-required")).toBe("true");
+    expect(thumb.getAttribute("aria-valuenow")).toBe("20");
     expect(changes).toEqual([]);
   });
 });

--- a/packages/keystone/src/switch/index.tsx
+++ b/packages/keystone/src/switch/index.tsx
@@ -1,4 +1,4 @@
-import { createContext, splitProps, useContext, type JSX } from "solid-js";
+import { createContext, onCleanup, onMount, splitProps, useContext, type JSX } from "solid-js";
 import {
   createSelectionControl,
   getSelectionControlProps,
@@ -6,7 +6,7 @@ import {
   type SelectionControlChangeDetail,
   type SelectionControlCheckedState,
 } from "../selection-control/controller";
-import { dataBoolean, partDataAttributes } from "../utils/index";
+import { callEventHandler, dataBoolean, partDataAttributes } from "../utils/index";
 
 export type SwitchCheckedChangeDetail = SelectionControlChangeDetail;
 
@@ -15,6 +15,7 @@ export type SwitchRootProps = SwitchPartProps<HTMLSpanElement> &
     checked?: boolean;
     defaultChecked?: boolean;
     disabled?: boolean;
+    form?: string;
     invalid?: boolean;
     name?: string;
     onCheckedChange?: (checked: boolean, detail: SwitchCheckedChangeDetail) => void;
@@ -47,6 +48,7 @@ export function createSwitch(
     checked?: () => boolean | undefined;
     defaultChecked?: boolean;
     disabled?: () => boolean | undefined;
+    form?: () => string | undefined;
     invalid?: () => boolean | undefined;
     name?: () => string | undefined;
     onCheckedChange?: (checked: boolean, detail: SwitchCheckedChangeDetail) => void;
@@ -59,6 +61,7 @@ export function createSwitch(
     checked: options.checked,
     defaultChecked: options.defaultChecked,
     disabled: options.disabled,
+    form: options.form,
     invalid: options.invalid,
     name: options.name,
     onCheckedChange: (checked, detail) => options.onCheckedChange?.(checked === true, detail),
@@ -88,6 +91,7 @@ function Root(props: SwitchRootProps) {
     "children",
     "defaultChecked",
     "disabled",
+    "form",
     "invalid",
     "name",
     "onCheckedChange",
@@ -99,6 +103,7 @@ function Root(props: SwitchRootProps) {
     checked: () => local.checked,
     defaultChecked: local.defaultChecked,
     disabled: () => local.disabled,
+    form: () => local.form,
     invalid: () => local.invalid,
     name: () => local.name,
     onCheckedChange: local.onCheckedChange,
@@ -150,12 +155,32 @@ function Thumb(props: SwitchThumbProps) {
 
 function HiddenInput(props: SwitchHiddenInputProps) {
   const control = useSwitch("HiddenInput");
+  let input: HTMLInputElement | undefined;
+
+  onMount(() => {
+    const form = input?.form;
+    if (!form) return;
+
+    const onReset = () => control.reset();
+    form.addEventListener("reset", onReset);
+    onCleanup(() => form.removeEventListener("reset", onReset));
+  });
 
   return (
     <input
       {...props}
+      onChange={(event) => {
+        callEventHandler(props.onChange, event);
+        if (event.defaultPrevented || control.disabled() || control.readOnly()) return;
+        control.setChecked(event.currentTarget.checked, { reason: "control" });
+      }}
+      ref={(element) => {
+        input = element;
+        if (typeof props.ref === "function") props.ref(element);
+      }}
       checked={control.checked()}
       disabled={control.disabled()}
+      form={props.form ?? control.form()}
       id={control.inputId}
       name={control.name()}
       required={control.required()}

--- a/packages/keystone/src/tabs/index.tsx
+++ b/packages/keystone/src/tabs/index.tsx
@@ -20,6 +20,7 @@ import {
 } from "../utils/index";
 
 export type TabsActivationMode = "automatic" | "manual";
+export type TabsDirection = "ltr" | "rtl";
 export type TabsOrientation = "horizontal" | "vertical";
 export type TabsValueChangeDetail = {
   event?: Event;
@@ -38,6 +39,7 @@ export type TabsRootProps = TabsPartProps<HTMLDivElement> &
   Omit<JSX.HTMLAttributes<HTMLDivElement>, "children" | "ref"> & {
     activationMode?: TabsActivationMode;
     defaultValue?: string;
+    dir?: TabsDirection;
     disabled?: boolean;
     loopFocus?: boolean;
     onValueChange?: (value: string, detail: TabsValueChangeDetail) => void;
@@ -69,6 +71,7 @@ type TriggerRecord = {
 export type CreateTabsOptions = {
   activationMode?: () => TabsActivationMode | undefined;
   defaultValue?: string;
+  dir?: () => TabsDirection | undefined;
   disabled?: () => boolean | undefined;
   loopFocus?: () => boolean | undefined;
   onValueChange?: (value: string, detail: TabsValueChangeDetail) => void;
@@ -78,6 +81,7 @@ export type CreateTabsOptions = {
 
 export type TabsApi = {
   activationMode: () => TabsActivationMode;
+  dir: () => TabsDirection;
   disabled: () => boolean;
   getContentId: (value: string) => string;
   getTriggerId: (value: string) => string;
@@ -111,6 +115,7 @@ export function createTabs(options: CreateTabsOptions = {}): TabsApi {
   const [highlightedValue, setHighlightedValue] = createSignal<string | undefined>();
   const [registryVersion, setRegistryVersion] = createSignal(0);
   const disabled = createMemo(() => options.disabled?.() ?? false);
+  const dir = createMemo(() => options.dir?.() ?? "ltr");
   const activationMode = createMemo(() => options.activationMode?.() ?? "automatic");
   const loopFocus = createMemo(() => options.loopFocus?.() ?? true);
   const orientation = createMemo(() => options.orientation?.() ?? "horizontal");
@@ -151,6 +156,7 @@ export function createTabs(options: CreateTabsOptions = {}): TabsApi {
 
   return {
     activationMode,
+    dir,
     disabled,
     getContentId,
     getTriggerId,
@@ -189,6 +195,7 @@ function Root(props: TabsRootProps) {
     "activationMode",
     "children",
     "defaultValue",
+    "dir",
     "disabled",
     "loopFocus",
     "onValueChange",
@@ -198,6 +205,7 @@ function Root(props: TabsRootProps) {
   const tabs = createTabs({
     activationMode: () => local.activationMode,
     defaultValue: local.defaultValue,
+    dir: () => local.dir,
     disabled: () => local.disabled,
     loopFocus: () => local.loopFocus,
     onValueChange: local.onValueChange,
@@ -211,6 +219,7 @@ function Root(props: TabsRootProps) {
         {...others}
         data-disabled={dataBoolean(tabs.disabled())}
         data-orientation={tabs.orientation()}
+        dir={local.dir}
         {...partDataAttributes("tabs", "root")}
       >
         {local.children}
@@ -372,8 +381,8 @@ function moveFocus(event: KeyboardEvent, tabs: TabsApi) {
   }
 
   const horizontal = tabs.orientation() === "horizontal";
-  const nextKey = horizontal ? "ArrowRight" : "ArrowDown";
-  const previousKey = horizontal ? "ArrowLeft" : "ArrowUp";
+  const nextKey = horizontal ? (tabs.dir() === "rtl" ? "ArrowLeft" : "ArrowRight") : "ArrowDown";
+  const previousKey = horizontal ? (tabs.dir() === "rtl" ? "ArrowRight" : "ArrowLeft") : "ArrowUp";
 
   if (![nextKey, previousKey, "Home", "End"].includes(event.key)) return;
 

--- a/packages/keystone/src/toolbar/index.tsx
+++ b/packages/keystone/src/toolbar/index.tsx
@@ -17,6 +17,7 @@ import {
 } from "../utils/index";
 
 export type ToolbarOrientation = "horizontal" | "vertical";
+export type ToolbarDirection = "ltr" | "rtl";
 
 export type ToolbarPartProps<T extends HTMLElement = HTMLElement> = {
   children?: JSX.Element;
@@ -28,6 +29,7 @@ export type ToolbarPartProps<T extends HTMLElement = HTMLElement> = {
 
 export type ToolbarRootProps = ToolbarPartProps<HTMLDivElement> &
   Omit<JSX.HTMLAttributes<HTMLDivElement>, "children" | "ref"> & {
+    dir?: ToolbarDirection;
     disabled?: boolean;
     loopFocus?: boolean;
     orientation?: ToolbarOrientation;
@@ -48,12 +50,14 @@ export type ToolbarSeparatorProps = ToolbarPartProps<HTMLDivElement> &
   Omit<JSX.HTMLAttributes<HTMLDivElement>, "children" | "ref">;
 
 export type CreateToolbarOptions = {
+  dir?: () => ToolbarDirection | undefined;
   disabled?: () => boolean | undefined;
   loopFocus?: () => boolean | undefined;
   orientation?: () => ToolbarOrientation | undefined;
 };
 
 export type ToolbarApi = {
+  dir: Accessor<ToolbarDirection>;
   disabled: Accessor<boolean>;
   loopFocus: Accessor<boolean>;
   moveFocus: (event: KeyboardEvent) => void;
@@ -69,6 +73,7 @@ type ToolbarItemRecord = {
 const ToolbarContext = createContext<ToolbarApi>();
 
 export function createToolbar(options: CreateToolbarOptions = {}): ToolbarApi {
+  const dir = createMemo(() => options.dir?.() ?? "ltr");
   const disabled = createMemo(() => options.disabled?.() ?? false);
   const loopFocus = createMemo(() => options.loopFocus?.() ?? true);
   const orientation = createMemo(() => options.orientation?.() ?? "horizontal");
@@ -92,8 +97,8 @@ export function createToolbar(options: CreateToolbarOptions = {}): ToolbarApi {
 
   const moveFocus = (event: KeyboardEvent) => {
     const horizontal = orientation() === "horizontal";
-    const nextKey = horizontal ? "ArrowRight" : "ArrowDown";
-    const previousKey = horizontal ? "ArrowLeft" : "ArrowUp";
+    const nextKey = horizontal ? (dir() === "rtl" ? "ArrowLeft" : "ArrowRight") : "ArrowDown";
+    const previousKey = horizontal ? (dir() === "rtl" ? "ArrowRight" : "ArrowLeft") : "ArrowUp";
 
     if (![nextKey, previousKey, "Home", "End"].includes(event.key)) return;
 
@@ -123,6 +128,7 @@ export function createToolbar(options: CreateToolbarOptions = {}): ToolbarApi {
   };
 
   return {
+    dir,
     disabled,
     loopFocus,
     moveFocus,
@@ -165,8 +171,15 @@ function useToolbar(part: string) {
 }
 
 function Root(props: ToolbarRootProps) {
-  const [local, others] = splitProps(props, ["children", "disabled", "loopFocus", "orientation"]);
+  const [local, others] = splitProps(props, [
+    "children",
+    "dir",
+    "disabled",
+    "loopFocus",
+    "orientation",
+  ]);
   const toolbar = createToolbar({
+    dir: () => local.dir,
     disabled: () => local.disabled,
     loopFocus: () => local.loopFocus,
     orientation: () => local.orientation,
@@ -179,6 +192,7 @@ function Root(props: ToolbarRootProps) {
         aria-orientation={toolbar.orientation()}
         data-disabled={dataBoolean(toolbar.disabled())}
         data-orientation={toolbar.orientation()}
+        dir={local.dir}
         role="toolbar"
         {...partDataAttributes("toolbar", "root")}
       >

--- a/packages/keystone/test/accessibility-harness.behavior.test.tsx
+++ b/packages/keystone/test/accessibility-harness.behavior.test.tsx
@@ -1,0 +1,259 @@
+import { describe, expect, test } from "vitest";
+import { Dialog } from "../src/dialog/index";
+import { createFormControl } from "../src/form/index";
+import { Popover } from "../src/popover/index";
+import { Select } from "../src/select/index";
+import { Sheet } from "../src/sheet/index";
+import { Tooltip } from "../src/tooltip/index";
+import {
+  expectAriaRelationship,
+  expectFocusRestore,
+  expectFormReset,
+  expectFormValues,
+  expectHydrationSmoke,
+  expectOutsideDismissal,
+  expectRole,
+  expectStablePartAttributes,
+  runKeyboardTable,
+} from "./accessibility";
+import { click, getByPart, queryByPart, render, settled } from "./harness";
+
+describe("primitive accessibility verification harness adoption", () => {
+  test("checks Dialog focus, ARIA relationships, and hydration smoke", async () => {
+    render(() => (
+      <>
+        <button data-testid="outside">Outside</button>
+        <Dialog.Root>
+          <Dialog.Trigger>Open dialog</Dialog.Trigger>
+          <Dialog.Portal>
+            <Dialog.Content>
+              <Dialog.Title>Project settings</Dialog.Title>
+              <Dialog.Description>Change project metadata.</Dialog.Description>
+              <button data-testid="first-field">First</button>
+              <button data-testid="last-field">Last</button>
+              <Dialog.Close>Close</Dialog.Close>
+            </Dialog.Content>
+          </Dialog.Portal>
+        </Dialog.Root>
+      </>
+    ));
+
+    const trigger = getByPart("dialog", "trigger");
+
+    await expectFocusRestore({
+      trigger,
+      open: () => click(trigger),
+      close: () => click(getByPart("dialog", "close")),
+    });
+
+    click(trigger);
+    await settled();
+
+    const content = getByPart("dialog", "content");
+    expectRole(content, "dialog");
+    expectStablePartAttributes({
+      target: content,
+      scope: "dialog",
+      part: "content",
+      attributes: ["aria-labelledby", "aria-describedby", "data-state"],
+    });
+    expectAriaRelationship({
+      source: content,
+      attribute: "aria-labelledby",
+      targets: [getByPart("dialog", "title")],
+    });
+    expectAriaRelationship({
+      source: content,
+      attribute: "aria-describedby",
+      targets: [getByPart("dialog", "description")],
+    });
+
+    expectHydrationSmoke({
+      html: `<button type="button" data-scope="dialog" data-part="trigger">Open dialog</button>`,
+      expectedText: "Open dialog",
+    });
+  });
+
+  test("checks outside dismissal with a Dialog fixture", async () => {
+    render(() => (
+      <>
+        <button data-testid="outside">Outside</button>
+        <Dialog.Root>
+          <Dialog.Trigger>Open dialog</Dialog.Trigger>
+          <Dialog.Portal>
+            <Dialog.Content>
+              <Dialog.Title>Project settings</Dialog.Title>
+              <Dialog.Description>Change project metadata.</Dialog.Description>
+            </Dialog.Content>
+          </Dialog.Portal>
+        </Dialog.Root>
+      </>
+    ));
+
+    await expectOutsideDismissal({
+      open: () => click(getByPart("dialog", "trigger")),
+      outside: document.querySelector<HTMLElement>("[data-testid='outside']")!,
+      assertDismissed: () => expect(queryByPart("dialog", "content")).toBeNull(),
+    });
+  });
+
+  test("checks overlay family part contracts through Popover, Tooltip, and Sheet", async () => {
+    render(() => (
+      <>
+        <Popover.Root defaultOpen>
+          <Popover.Trigger>Popover trigger</Popover.Trigger>
+          <Popover.Content>Popover content</Popover.Content>
+        </Popover.Root>
+        <Tooltip.Root defaultOpen>
+          <Tooltip.Trigger>Tooltip trigger</Tooltip.Trigger>
+          <Tooltip.Content>Tooltip content</Tooltip.Content>
+        </Tooltip.Root>
+        <Sheet.Root defaultOpen side="left">
+          <Sheet.Trigger>Sheet trigger</Sheet.Trigger>
+          <Sheet.Content>
+            <Sheet.Title>Sheet title</Sheet.Title>
+            <Sheet.Description>Sheet description</Sheet.Description>
+          </Sheet.Content>
+        </Sheet.Root>
+      </>
+    ));
+    await settled();
+
+    expectStablePartAttributes({
+      target: getByPart("popover", "content"),
+      scope: "popover",
+      part: "content",
+      attributes: ["role", "data-state"],
+    });
+    expectStablePartAttributes({
+      target: getByPart("tooltip", "content"),
+      scope: "tooltip",
+      part: "content",
+      attributes: ["role", "data-state"],
+    });
+    expectStablePartAttributes({
+      target: getByPart("sheet", "content"),
+      scope: "sheet",
+      part: "content",
+      attributes: ["role", "aria-labelledby", "aria-describedby", "data-side"],
+    });
+
+    expect(getByPart("sheet", "content")).not.toBeNull();
+  });
+
+  test("checks Select and Listbox keyboard, parts, form submission, and reset", async () => {
+    render(() => (
+      <form>
+        <Select.Root name="project" defaultOpen defaultValue="alpha">
+          <Select.Trigger>Choose project</Select.Trigger>
+          <Select.Value />
+          <Select.Content>
+            <Select.Listbox>
+              <Select.Item value="alpha">Alpha</Select.Item>
+              <Select.Item value="beta" disabled>
+                Beta
+              </Select.Item>
+              <Select.Item value="bravo">Bravo</Select.Item>
+            </Select.Listbox>
+          </Select.Content>
+        </Select.Root>
+      </form>
+    ));
+
+    const listbox = getByPart("select", "listbox");
+    expectRole(listbox, "listbox");
+    expectStablePartAttributes({
+      target: listbox,
+      scope: "select",
+      part: "listbox",
+    });
+
+    await runKeyboardTable([
+      {
+        key: "ArrowDown",
+        target: listbox,
+        after: () => {
+          expect(document.querySelector('[data-part="item"][data-highlighted]')?.textContent).toBe(
+            "Alpha",
+          );
+        },
+      },
+      {
+        key: "b",
+        target: listbox,
+        after: () => {
+          expect(document.querySelector('[data-part="item"][data-highlighted]')?.textContent).toBe(
+            "Bravo",
+          );
+        },
+      },
+      {
+        key: "Enter",
+        target: listbox,
+      },
+    ]);
+
+    const form = document.querySelector("form")!;
+    expectFormValues(form, { project: "bravo" });
+    await expectFormReset({
+      form,
+      beforeReset: { project: "bravo" },
+      afterReset: { project: "alpha" },
+    });
+  });
+
+  test("checks Field/FormControl ARIA, data attributes, form values, and hydration smoke", () => {
+    render(() => {
+      const field = createFormControl({
+        id: () => "project",
+        name: () => "project",
+        value: () => "alpha",
+        invalid: () => true,
+        required: () => true,
+      });
+
+      return (
+        <form>
+          <div {...field.getRootProps()}>
+            <label {...field.getLabelProps()}>Project</label>
+            <input {...field.getControlProps()} value="alpha" />
+            <p {...field.getDescriptionProps()}>Choose the active project.</p>
+            <p {...field.getErrorMessageProps()}>Project is required.</p>
+            <input {...field.getHiddenInputProps()} />
+          </div>
+        </form>
+      );
+    });
+
+    const control = getByPart("form-control", "control");
+    const hiddenInput = getByPart("form-control", "hidden-input") as HTMLInputElement;
+    const form = document.querySelector("form")!;
+
+    expectStablePartAttributes({
+      target: control,
+      scope: "form-control",
+      part: "control",
+      attributes: ["aria-labelledby", "aria-describedby", "aria-invalid", "data-required"],
+    });
+    expectAriaRelationship({
+      source: control,
+      attribute: "aria-labelledby",
+      targets: [getByPart("form-control", "label")],
+    });
+    expectAriaRelationship({
+      source: control,
+      attribute: "aria-describedby",
+      targets: [
+        getByPart("form-control", "description"),
+        getByPart("form-control", "error-message"),
+      ],
+    });
+    expectFormValues(form, { project: "alpha" });
+    expect(hiddenInput.value).toBe("alpha");
+
+    expectHydrationSmoke({
+      html: `<form><label id="project-label" for="project" data-scope="form-control" data-part="label">Project</label><input id="project" aria-labelledby="project-label" value="alpha" data-scope="form-control" data-part="control"></form>`,
+      expectedText: "Project",
+    });
+  });
+});

--- a/packages/keystone/test/accessibility-ssr.test.tsx
+++ b/packages/keystone/test/accessibility-ssr.test.tsx
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "vitest";
+import { expectSsrSmoke } from "./accessibility";
+
+describe("primitive accessibility SSR smoke", () => {
+  test("validates Dialog server fixture IDs, ARIA relationships, and force-mounted portal content", () => {
+    const html = expectSsrSmoke({
+      html: `<button type="button" data-scope="dialog" data-part="trigger">Open dialog</button><div role="dialog" data-scope="dialog" data-part="content" aria-labelledby="dialog-title" aria-describedby="dialog-description"><h2 id="dialog-title" data-scope="dialog" data-part="title">Project settings</h2><p id="dialog-description" data-scope="dialog" data-part="description">Change project metadata.</p></div>`,
+      expectedText: "Project settings",
+    });
+
+    expect(html).toContain("Open dialog");
+    expect(html).toContain('data-scope="dialog"');
+    expect(html).toContain('data-part="content"');
+    expect(html).toContain("aria-labelledby=");
+    expect(html).toContain("aria-describedby=");
+  });
+
+  test("validates FormControl server fixture stable IDs and relationships", () => {
+    const html = expectSsrSmoke({
+      html: `<form><div id="project-root" data-scope="form-control" data-part="root"><label id="project-label" for="project" data-scope="form-control" data-part="label">Project</label><input id="project" aria-labelledby="project-label" aria-describedby="project-description project-error-message" aria-invalid="true" value="alpha" data-scope="form-control" data-part="control"><p id="project-description" data-scope="form-control" data-part="description">Choose the active project.</p><p id="project-error-message" data-scope="form-control" data-part="error-message">Project is required.</p><input type="hidden" name="project" value="alpha" data-scope="form-control" data-part="hidden-input"></div></form>`,
+      expectedText: "Project",
+    });
+
+    expect(html).toContain('id="project-label"');
+    expect(html).toContain('aria-labelledby="project-label"');
+    expect(html).toContain("project-description");
+    expect(html).toContain("project-error-message");
+    expect(html).toContain('data-part="hidden-input"');
+  });
+});

--- a/packages/keystone/test/accessibility.test.tsx
+++ b/packages/keystone/test/accessibility.test.tsx
@@ -4,11 +4,16 @@ import {
   expectAriaRelationship,
   expectAriaState,
   expectFocus,
+  expectFocusTrap,
   expectFormValues,
+  expectHydrationSmoke,
   expectPart,
   expectRole,
+  expectSsrSmoke,
+  expectStablePartAttributes,
   runKeyboardTable,
   withDirection,
+  withForcedColors,
   withReducedMotion,
 } from "./accessibility";
 
@@ -42,6 +47,12 @@ describe("accessibility spec harness", () => {
     });
 
     expectPart(trigger, "select", "trigger");
+    expectStablePartAttributes({
+      target: trigger,
+      scope: "select",
+      part: "trigger",
+      attributes: ["aria-controls", "aria-expanded"],
+    });
     expectRole(listbox, "listbox");
     expectAriaRelationship({
       source: trigger,
@@ -64,7 +75,35 @@ describe("accessibility spec harness", () => {
     expectFormValues(form, { project: "alpha" });
   });
 
-  test("scopes direction and reduced-motion hooks", async () => {
+  test("asserts focus traps and hydration smoke output", () => {
+    const first = document.createElement("button");
+    const last = document.createElement("button");
+    const container = document.createElement("div");
+    container.append(first, last);
+    document.body.append(container);
+
+    container.addEventListener("keydown", (event) => {
+      if (event.key === "Tab" && event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (event.key === "Tab" && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    });
+
+    expectFocusTrap({ container, first, last });
+    expectSsrSmoke({
+      html: `<button data-scope="button">Rendered</button>`,
+      expectedText: "Rendered",
+    });
+    expectHydrationSmoke({
+      html: `<label for="project">Project</label>`,
+      expectedText: "Project",
+    });
+  });
+
+  test("scopes direction, reduced-motion, and forced-colors hooks", async () => {
     await withDirection("rtl", () => {
       expect(document.documentElement.dir).toBe("rtl");
     });
@@ -72,6 +111,10 @@ describe("accessibility spec harness", () => {
 
     await withReducedMotion(() => {
       expect(matchMedia("(prefers-reduced-motion: reduce)").matches).toBe(true);
+    });
+
+    await withForcedColors(() => {
+      expect(matchMedia("(forced-colors: active)").matches).toBe(true);
     });
   });
 });

--- a/packages/keystone/test/accessibility.ts
+++ b/packages/keystone/test/accessibility.ts
@@ -1,5 +1,5 @@
 import { expect } from "vitest";
-import { keyDown, settled } from "./harness";
+import { keyDown, pointerDown, settled } from "./harness";
 
 type MaybePromise<T> = T | Promise<T>;
 type ElementTarget<T extends HTMLElement = HTMLElement> = T | (() => T);
@@ -25,9 +25,47 @@ export type AriaRelationshipSpec = {
 
 export type FormValueSpec = Record<string, string | readonly string[] | null>;
 
-export type ReducedMotionOptions = {
-  reduce?: boolean;
+export type MediaQueryOptions = {
+  matches?: boolean;
 };
+
+export type StablePartSpec = {
+  part: string;
+  scope: string;
+  target: AttributeTarget;
+  attributes?: readonly string[];
+};
+
+export type FocusTrapSpec = {
+  container: ElementTarget;
+  first: ElementTarget;
+  last: ElementTarget;
+};
+
+export type FocusRestoreSpec = {
+  close: () => MaybePromise<void>;
+  open: () => MaybePromise<void>;
+  trigger: ElementTarget;
+};
+
+export type OutsideDismissalSpec = {
+  assertDismissed: () => void;
+  open: () => MaybePromise<void>;
+  outside: ElementTarget;
+};
+
+export type FormResetSpec = {
+  afterReset: FormValueSpec;
+  beforeReset: FormValueSpec;
+  form: HTMLFormElement;
+};
+
+export type SsrSmokeSpec = {
+  expectedText?: string;
+  html: string;
+};
+
+export type HydrationSmokeSpec = SsrSmokeSpec;
 
 export function resolveElement<T extends HTMLElement>(target: ElementTarget<T>): T {
   return typeof target === "function" ? (target as () => T)() : target;
@@ -56,6 +94,14 @@ export function expectRole(target: AttributeTarget, role: string) {
 export function expectPart(target: AttributeTarget, scope: string, part: string) {
   expect(attributeValue(target, "data-scope")).toBe(scope);
   expect(attributeValue(target, "data-part")).toBe(part);
+}
+
+export function expectStablePartAttributes(spec: StablePartSpec) {
+  expectPart(spec.target, spec.scope, spec.part);
+
+  for (const attribute of spec.attributes ?? []) {
+    expect(attributeValue(spec.target, attribute)).not.toBeNull();
+  }
 }
 
 export function expectAriaRelationship(spec: AriaRelationshipSpec) {
@@ -92,6 +138,57 @@ export function expectFocusWithin(target: ElementTarget) {
   expect(resolveElement(target).contains(document.activeElement)).toBe(true);
 }
 
+export function expectFocusTrap(spec: FocusTrapSpec) {
+  const container = resolveElement(spec.container);
+  const first = resolveElement(spec.first);
+  const last = resolveElement(spec.last);
+
+  last.focus();
+  keyDown(
+    document.activeElement instanceof HTMLElement ? document.activeElement : container,
+    "Tab",
+  );
+  expectFocus(first);
+
+  first.focus();
+  (document.activeElement instanceof HTMLElement
+    ? document.activeElement
+    : container
+  ).dispatchEvent(
+    new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      key: "Tab",
+      shiftKey: true,
+    }),
+  );
+  expectFocus(last);
+}
+
+export async function expectFocusRestore(spec: FocusRestoreSpec) {
+  const trigger = resolveElement(spec.trigger);
+  trigger.focus();
+  await spec.open();
+  await settled();
+
+  expectFocusWithin(document.body);
+
+  await spec.close();
+  await settled();
+
+  expectFocus(trigger);
+}
+
+export async function expectOutsideDismissal(spec: OutsideDismissalSpec) {
+  await spec.open();
+  await settled();
+
+  pointerDown(resolveElement(spec.outside));
+  await settled();
+
+  spec.assertDismissed();
+}
+
 export function expectFormValues(form: HTMLFormElement, expected: FormValueSpec) {
   const data = new FormData(form);
 
@@ -102,6 +199,36 @@ export function expectFormValues(form: HTMLFormElement, expected: FormValueSpec)
       expect(data.get(name)).toBe(value);
     }
   }
+}
+
+export async function expectFormReset(spec: FormResetSpec) {
+  expectFormValues(spec.form, spec.beforeReset);
+
+  spec.form.reset();
+  await settled();
+
+  expectFormValues(spec.form, spec.afterReset);
+}
+
+export function expectSsrSmoke(spec: SsrSmokeSpec) {
+  expect(spec.html.length).toBeGreaterThan(0);
+
+  if (spec.expectedText) {
+    expect(spec.html).toContain(spec.expectedText);
+  }
+
+  return spec.html;
+}
+
+export function expectHydrationSmoke(spec: HydrationSmokeSpec) {
+  const container = document.createElement("div");
+  container.innerHTML = expectSsrSmoke(spec);
+  document.body.append(container);
+
+  expect(container.childNodes.length).toBeGreaterThan(0);
+  container.remove();
+
+  return spec.html;
 }
 
 export async function withDirection<T>(
@@ -124,27 +251,30 @@ export async function withDirection<T>(
 
 export async function withReducedMotion<T>(
   callback: () => MaybePromise<T>,
-  options: ReducedMotionOptions = {},
+  options: MediaQueryOptions = {},
+): Promise<T> {
+  return withMediaQuery("prefers-reduced-motion", callback, options);
+}
+
+export async function withForcedColors<T>(
+  callback: () => MaybePromise<T>,
+  options: MediaQueryOptions = {},
+): Promise<T> {
+  return withMediaQuery("forced-colors", callback, options);
+}
+
+async function withMediaQuery<T>(
+  pattern: string,
+  callback: () => MaybePromise<T>,
+  options: MediaQueryOptions = {},
 ): Promise<T> {
   const previous = globalThis.matchMedia;
-  const reduce = options.reduce ?? true;
+  const expected = options.matches ?? true;
 
   Object.defineProperty(globalThis, "matchMedia", {
     configurable: true,
-    value: (query: string) => {
-      const matches = query.includes("prefers-reduced-motion") ? reduce : false;
-
-      return {
-        addEventListener: () => undefined,
-        addListener: () => undefined,
-        dispatchEvent: () => false,
-        matches,
-        media: query,
-        onchange: null,
-        removeEventListener: () => undefined,
-        removeListener: () => undefined,
-      } satisfies MediaQueryList;
-    },
+    value: (query: string) =>
+      createMediaQueryList(query, query.includes(pattern) ? expected : false),
   });
 
   try {
@@ -159,6 +289,19 @@ export async function withReducedMotion<T>(
       });
     }
   }
+}
+
+function createMediaQueryList(query: string, matches: boolean): MediaQueryList {
+  return {
+    addEventListener: () => undefined,
+    addListener: () => undefined,
+    dispatchEvent: () => false,
+    matches,
+    media: query,
+    onchange: null,
+    removeEventListener: () => undefined,
+    removeListener: () => undefined,
+  } satisfies MediaQueryList;
 }
 
 function tokenSet(value: string | null) {

--- a/packages/keystone/test/date-picker.behavior.test.tsx
+++ b/packages/keystone/test/date-picker.behavior.test.tsx
@@ -103,6 +103,65 @@ describe("Calendar behavior", () => {
       dispose();
     });
   });
+
+  test("uses locale week info when weekStartsOn is not provided", () => {
+    render(() => <Calendar.Root defaultMonth="2026-05" locale="en-GB" />);
+
+    expect(
+      document.body.querySelector('[data-scope="calendar"][data-part="column-header"]')
+        ?.textContent,
+    ).toBe("Mon");
+  });
+
+  test("supports unavailable dates and range selection state", async () => {
+    const ranges: string[] = [];
+
+    render(() => (
+      <Calendar.Root
+        defaultMonth="2026-05"
+        selectionMode="range"
+        unavailable={(value) => value === "2026-05-12"}
+        onRangeValueChange={(value, detail) =>
+          ranges.push(`${value.start ?? ""}:${value.end ?? ""}:${detail.complete}`)
+        }
+      />
+    ));
+
+    const unavailable = getDay("2026-05-12");
+    expect(unavailable.disabled).toBe(true);
+    expect(unavailable.getAttribute("data-unavailable")).toBe("");
+
+    click(unavailable);
+    await settled();
+    expect(ranges).toEqual([]);
+
+    click(getDay("2026-05-20"));
+    await settled();
+    expect(ranges).toEqual(["2026-05-20::false"]);
+    expect(getDay("2026-05-20").getAttribute("data-range-start")).toBe("");
+
+    click(getDay("2026-05-18"));
+    await settled();
+    expect(ranges).toEqual(["2026-05-20::false", "2026-05-18:2026-05-20:true"]);
+    expect(getDay("2026-05-18").getAttribute("data-range-start")).toBe("");
+    expect(getDay("2026-05-19").getAttribute("data-in-range")).toBe("");
+    expect(getDay("2026-05-20").getAttribute("data-range-end")).toBe("");
+    expect(getByPart("calendar", "root").getAttribute("data-start-value")).toBe("2026-05-18");
+    expect(getByPart("calendar", "root").getAttribute("data-end-value")).toBe("2026-05-20");
+
+    click(getDay("2026-05-10"));
+    await settled();
+    click(getDay("2026-05-14"));
+    await settled();
+    expect(ranges).toEqual([
+      "2026-05-20::false",
+      "2026-05-18:2026-05-20:true",
+      "2026-05-10::false",
+      "2026-05-14::false",
+    ]);
+    expect(getByPart("calendar", "root").getAttribute("data-start-value")).toBe("2026-05-14");
+    expect(getByPart("calendar", "root").getAttribute("data-end-value")).toBeNull();
+  });
 });
 
 describe("DatePicker behavior", () => {
@@ -139,5 +198,44 @@ describe("DatePicker behavior", () => {
     expect(openChanges).toEqual(["true:trigger", "false:select"]);
     expect(queryByPart("date-picker", "content")).toBeNull();
     expect(trigger.textContent).toBe("2026-05-18");
+  });
+
+  test("keeps range picker open until the range has an end date", async () => {
+    const openChanges: string[] = [];
+    const ranges: string[] = [];
+
+    render(() => (
+      <DatePicker.Root
+        defaultMonth="2026-05"
+        selectionMode="range"
+        onOpenChange={(open, detail) => openChanges.push(`${open}:${detail.reason}`)}
+        onRangeValueChange={(value, detail) =>
+          ranges.push(`${value.start ?? ""}:${value.end ?? ""}:${detail.complete}`)
+        }
+      >
+        <DatePicker.Trigger placeholder="Pick dates" />
+        <DatePicker.Content />
+      </DatePicker.Root>
+    ));
+
+    const trigger = getByPart("date-picker", "trigger");
+    click(trigger);
+    await settled();
+
+    click(getDay("2026-05-10"));
+    await settled();
+
+    expect(ranges).toEqual(["2026-05-10::false"]);
+    expect(openChanges).toEqual(["true:trigger"]);
+    expect(queryByPart("date-picker", "content")).not.toBeNull();
+    expect(trigger.textContent).toBe("2026-05-10");
+
+    click(getDay("2026-05-12"));
+    await settled();
+
+    expect(ranges).toEqual(["2026-05-10::false", "2026-05-10:2026-05-12:true"]);
+    expect(openChanges).toEqual(["true:trigger", "false:select"]);
+    expect(queryByPart("date-picker", "content")).toBeNull();
+    expect(trigger.textContent).toBe("2026-05-10 - 2026-05-12");
   });
 });

--- a/packages/keystone/test/listbox.performance.test.tsx
+++ b/packages/keystone/test/listbox.performance.test.tsx
@@ -1,0 +1,95 @@
+import { createRoot } from "solid-js";
+import { afterAll, describe, expect, test } from "vitest";
+import { createListboxInteraction } from "../src/listbox/index";
+
+type ListboxPerfSample = {
+  itemCount: number;
+  navigationMs: number;
+  registrationMs: number;
+  typeaheadMs: number;
+};
+
+const itemCounts = [100, 1000] as const;
+const samples: ListboxPerfSample[] = [];
+
+function createKeyEvent(key: string): KeyboardEvent {
+  return new KeyboardEvent("keydown", { bubbles: true, cancelable: true, key });
+}
+
+function createBenchmarkListbox() {
+  return createListboxInteraction<
+    { disabled?: boolean; label: string; value: string },
+    { reason: string }
+  >({
+    id: () => "bench-listbox",
+    labelledBy: () => "bench-trigger",
+    optionId: (value) => `bench-option-${value}`,
+    optionSelectDetail: () => ({ reason: "item" }),
+    programmaticDetail: { reason: "programmatic" },
+    scope: "bench-listbox",
+  });
+}
+
+describe("Listbox performance harness", () => {
+  test.each(itemCounts)(
+    "measures collection registration, navigation, and typeahead for %i kernel items",
+    (itemCount) => {
+      createRoot((dispose) => {
+        const listbox = createBenchmarkListbox();
+
+        const registrationStart = performance.now();
+        for (let index = 0; index < itemCount; index += 1) {
+          listbox.registerOption({
+            disabled: index % 17 === 0,
+            label: `Item ${String(index).padStart(5, "0")}`,
+            value: `item-${index}`,
+          });
+        }
+        const registrationMs = performance.now() - registrationStart;
+
+        const navigationStart = performance.now();
+        for (let index = 0; index < 1000; index += 1) {
+          listbox.keyboard.highlight("next");
+        }
+        const navigationMs = performance.now() - navigationStart;
+
+        const typeaheadStart = performance.now();
+        for (const key of ["I", "t", "e", "m", " ", "0", "9"]) {
+          listbox.typeahead.handleKeyDown(createKeyEvent(key));
+        }
+        const typeaheadMs = performance.now() - typeaheadStart;
+
+        samples.push({
+          itemCount,
+          navigationMs,
+          registrationMs,
+          typeaheadMs,
+        });
+
+        expect(listbox.collection.items()).toHaveLength(itemCount);
+        expect(listbox.collection.itemByValue(`item-${itemCount - 1}`)?.label).toBe(
+          `Item ${String(itemCount - 1).padStart(5, "0")}`,
+        );
+        expect(listbox.activeDescendant.highlightedValue()).toBeTruthy();
+        expect(registrationMs).toBeLessThan(150);
+        expect(navigationMs).toBeLessThan(25);
+        expect(typeaheadMs).toBeLessThan(50);
+
+        dispose();
+      });
+    },
+  );
+});
+
+afterAll(() => {
+  for (const sample of samples) {
+    console.info(
+      [
+        `[listbox-perf] items=${sample.itemCount}`,
+        `registration=${sample.registrationMs.toFixed(2)}ms`,
+        `navigation1000=${sample.navigationMs.toFixed(2)}ms`,
+        `typeahead7=${sample.typeaheadMs.toFixed(2)}ms`,
+      ].join(" "),
+    );
+  }
+});

--- a/packages/keystone/test/navigation-menu.behavior.test.tsx
+++ b/packages/keystone/test/navigation-menu.behavior.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 import { NavigationMenu } from "../src/navigation-menu/index";
-import { getByPart, keyDown, render } from "./harness";
+import { click, getByPart, keyDown, render, settled } from "./harness";
 
 describe("NavigationMenu behavior", () => {
   test("exposes a navigation-menu scoped menubar contract over the menu kernel", () => {
@@ -57,5 +57,51 @@ describe("NavigationMenu behavior", () => {
       document.querySelector('[data-scope="navigation-menu"][data-part="item"][data-highlighted]')
         ?.textContent,
     ).toBe("Bravo");
+  });
+
+  test("exposes routed link behavior with navigation-menu scoped metadata", async () => {
+    const selected: string[] = [];
+
+    render(() => (
+      <NavigationMenu.Root defaultOpen onOpenChange={(open) => selected.push(String(open))}>
+        <NavigationMenu.Trigger>Explore</NavigationMenu.Trigger>
+        <NavigationMenu.Content>
+          <NavigationMenu.Link href="/docs" value="docs" onSelect={() => selected.push("docs")}>
+            Docs
+          </NavigationMenu.Link>
+          <NavigationMenu.Link
+            href="/disabled"
+            value="disabled"
+            disabled
+            onSelect={() => selected.push("disabled")}
+          >
+            Disabled
+          </NavigationMenu.Link>
+        </NavigationMenu.Content>
+      </NavigationMenu.Root>
+    ));
+
+    const trigger = getByPart("navigation-menu", "trigger");
+    const links = Array.from(
+      document.body.querySelectorAll<HTMLAnchorElement>(
+        '[data-scope="navigation-menu"][data-part="link"]',
+      ),
+    );
+
+    expect(links[0].getAttribute("role")).toBe("menuitem");
+    expect(links[0].getAttribute("href")).toBe("/docs");
+    expect(links[1].getAttribute("aria-disabled")).toBe("true");
+
+    click(links[1]);
+    await settled();
+
+    expect(selected).not.toContain("disabled");
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+
+    click(links[0]);
+    await settled();
+
+    expect(selected).toContain("docs");
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
   });
 });

--- a/packages/keystone/test/tabs.behavior.test.tsx
+++ b/packages/keystone/test/tabs.behavior.test.tsx
@@ -74,6 +74,30 @@ describe("Tabs behavior", () => {
     expect(triggers[2].getAttribute("aria-selected")).toBe("true");
   });
 
+  test("uses RTL-aware horizontal arrow navigation", () => {
+    render(() => (
+      <Tabs.Root defaultValue="one" dir="rtl">
+        <Tabs.List>
+          <Tabs.Trigger value="one">One</Tabs.Trigger>
+          <Tabs.Trigger value="two">Two</Tabs.Trigger>
+          <Tabs.Trigger value="three">Three</Tabs.Trigger>
+        </Tabs.List>
+        <Tabs.Content value="one">One panel</Tabs.Content>
+        <Tabs.Content value="two">Two panel</Tabs.Content>
+        <Tabs.Content value="three">Three panel</Tabs.Content>
+      </Tabs.Root>
+    ));
+
+    const triggers = getTriggers();
+
+    triggers[0].focus();
+    keyDown(triggers[0], "ArrowLeft");
+    expect(document.activeElement).toBe(triggers[1]);
+
+    keyDown(triggers[1], "ArrowRight");
+    expect(document.activeElement).toBe(triggers[0]);
+  });
+
   test("supports controlled state and respects prevented user events", () => {
     createRoot((dispose) => {
       const [value, setValue] = createSignal("alpha");

--- a/packages/keystone/test/toolbar.behavior.test.tsx
+++ b/packages/keystone/test/toolbar.behavior.test.tsx
@@ -54,6 +54,29 @@ describe("Toolbar behavior", () => {
     expect(document.activeElement).toBe(controls[0]);
   });
 
+  test("uses RTL-aware horizontal arrow navigation", () => {
+    render(() => (
+      <Toolbar.Root dir="rtl">
+        <Toolbar.Button>Bold</Toolbar.Button>
+        <Toolbar.Button>Italic</Toolbar.Button>
+        <Toolbar.Link href="/docs">Docs</Toolbar.Link>
+      </Toolbar.Root>
+    ));
+
+    const controls = Array.from(
+      document.body.querySelectorAll<HTMLElement>(
+        '[data-scope="toolbar"][data-part="button"], [data-scope="toolbar"][data-part="link"]',
+      ),
+    );
+
+    controls[0].focus();
+    keyDown(controls[0], "ArrowLeft");
+    expect(document.activeElement).toBe(controls[1]);
+
+    keyDown(controls[1], "ArrowRight");
+    expect(document.activeElement).toBe(controls[0]);
+  });
+
   test("respects prevented keyboard events and non-looping focus boundaries", () => {
     render(() => (
       <Toolbar.Root loopFocus={false}>

--- a/packages/mason-cli/src/commands/lifecycle.ts
+++ b/packages/mason-cli/src/commands/lifecycle.ts
@@ -1,0 +1,309 @@
+import { existsSync } from "node:fs";
+import { readFile, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { createHash } from "node:crypto";
+import { installCommand } from "../install/dependencies";
+import { createWritePlan, type FileWrite, type WritePlan } from "../install/plan";
+import { applyWritePlan } from "../install/write";
+import { configPath, readMasonConfig } from "../project/config";
+import { detectProject, type ProjectShape } from "../project/detect";
+
+type InstalledRecord = {
+  files: string[];
+  fileHashes?: Record<string, string>;
+  version: string;
+};
+
+type InstalledMap = Record<string, InstalledRecord>;
+
+type FileDiff = {
+  file: FileWrite;
+  localChanged: boolean;
+  status: "create" | "delete" | "update" | "unchanged";
+};
+
+function hashContent(content: string): string {
+  return `sha256:${createHash("sha256").update(content).digest("hex")}`;
+}
+
+async function readPackageJson(cwd: string): Promise<Record<string, unknown>> {
+  return JSON.parse(await readFile(path.join(cwd, "package.json"), "utf8")) as Record<
+    string,
+    unknown
+  >;
+}
+
+async function writePackageJson(cwd: string, packageJson: Record<string, unknown>): Promise<void> {
+  await writeFile(path.join(cwd, "package.json"), `${JSON.stringify(packageJson, null, 2)}\n`);
+}
+
+function installedItems(project: ProjectShape): InstalledMap {
+  const mason = project.packageJson.mason;
+  if (!mason || typeof mason !== "object" || Array.isArray(mason)) return {};
+  const installed = (mason as { installed?: unknown }).installed;
+  if (!installed || typeof installed !== "object" || Array.isArray(installed)) return {};
+  return installed as InstalledMap;
+}
+
+function installedItem(project: ProjectShape, item: string): InstalledRecord {
+  const record = installedItems(project)[item];
+  if (!record) {
+    throw new Error(`Mason item is not installed: ${item}`);
+  }
+  return record;
+}
+
+function fileHash(record: InstalledRecord, target: string): string | null {
+  return record.fileHashes?.[target] ?? null;
+}
+
+function diffPlan(plan: WritePlan, record?: InstalledRecord): FileDiff[] {
+  const plannedTargets = new Set(plan.files.map((file) => file.target));
+  const diffs = plan.files.map((file): FileDiff => {
+    const recordedHash = record ? fileHash(record, file.target) : null;
+    const localChanged = Boolean(
+      file.existing.exists && recordedHash && file.existing.hash !== recordedHash,
+    );
+    const status = !file.existing.exists
+      ? "create"
+      : file.existing.hash === file.contentHash
+        ? "unchanged"
+        : "update";
+    return { file, localChanged, status };
+  });
+
+  for (const target of record?.files ?? []) {
+    if (plannedTargets.has(target)) continue;
+    diffs.push({
+      file: {
+        item: "",
+        source: "",
+        target,
+        absoluteTarget: "",
+        content: "",
+        contentHash: "",
+        existing: { exists: true, hash: null, size: null },
+        conflict: null,
+        mode: "create",
+      },
+      localChanged: false,
+      status: "delete",
+    });
+  }
+
+  return diffs.sort((a, b) => a.file.target.localeCompare(b.file.target));
+}
+
+function formatPlanHeader(command: string, item: string): string {
+  return `Mason ${command} plan for ${item}:`;
+}
+
+function formatDiffLines(
+  command: string,
+  item: string,
+  plan: WritePlan,
+  packageManager: ProjectShape["packageManager"],
+  record?: InstalledRecord,
+) {
+  const lines = [formatPlanHeader(command, item)];
+  const diffs = diffPlan(plan, record);
+
+  for (const diff of diffs) {
+    const suffix = diff.localChanged ? " (local changes)" : "";
+    lines.push(`${diff.status} ${diff.file.target}${suffix}`);
+  }
+
+  for (const dependency of [...plan.dependencies, ...plan.devDependencies]) {
+    lines.push(
+      `add ${dependency.name}@${dependency.version}${
+        dependency.existing ? ` (was ${dependency.existing})` : ""
+      }`,
+    );
+  }
+
+  const commandLine = installCommand(packageManager, [
+    ...plan.dependencies,
+    ...plan.devDependencies,
+  ]);
+  if (commandLine) lines.push(`install command: ${commandLine}`);
+  if (lines.length === 1) lines.push("no changes");
+  return lines;
+}
+
+export async function diffCommand(options: {
+  cwd: string;
+  item: string;
+  registry: string;
+}): Promise<string> {
+  const project = await detectProject(options.cwd);
+  const record = installedItems(project)[options.item];
+  const plan = await createWritePlan(project, {
+    allowConflicts: true,
+    item: options.item,
+    registry: options.registry,
+  });
+  return formatDiffLines("diff", options.item, plan, project.packageManager, record).join("\n");
+}
+
+export async function updateCommand(options: {
+  cwd: string;
+  dryRun?: boolean;
+  force?: boolean;
+  item: string;
+  registry: string;
+}): Promise<string> {
+  const project = await detectProject(options.cwd);
+  const record = installedItem(project, options.item);
+  const plan = await createWritePlan(project, {
+    allowConflicts: true,
+    item: options.item,
+    registry: options.registry,
+  });
+  const diffs = diffPlan(plan, record);
+  const localChanges = diffs.filter((diff) => diff.localChanged);
+  const lines = formatDiffLines(
+    options.dryRun ? "update dry run" : "update",
+    options.item,
+    plan,
+    project.packageManager,
+    record,
+  );
+
+  if (localChanges.length > 0 && !options.force) {
+    lines.push("blocked: local changes detected; rerun with --force to overwrite");
+    return lines.join("\n");
+  }
+
+  if (!options.dryRun) {
+    await applyWritePlan(project, {
+      ...plan,
+      files: plan.files.map((file) => ({
+        ...file,
+        conflict: null,
+        mode: file.mode === "create" && file.existing.exists ? "overwrite" : file.mode,
+      })),
+    });
+  }
+
+  return lines.join("\n");
+}
+
+export async function removeCommand(options: {
+  cwd: string;
+  dryRun?: boolean;
+  force?: boolean;
+  item: string;
+}): Promise<string> {
+  const project = await detectProject(options.cwd);
+  const record = installedItem(project, options.item);
+  const lines = [formatPlanHeader(options.dryRun ? "remove dry run" : "remove", options.item)];
+  const localChanges: string[] = [];
+
+  for (const target of [...record.files].sort()) {
+    const absoluteTarget = path.join(project.cwd, target);
+    if (!existsSync(absoluteTarget)) {
+      lines.push(`missing ${target}`);
+      continue;
+    }
+    const content = await readFile(absoluteTarget, "utf8");
+    const currentHash = hashContent(content);
+    const recordedHash = fileHash(record, target);
+    if (recordedHash && currentHash !== recordedHash) {
+      localChanges.push(target);
+      lines.push(`keep ${target} (local changes)`);
+      continue;
+    }
+    lines.push(`delete ${target}`);
+  }
+
+  if (localChanges.length > 0 && !options.force) {
+    lines.push("blocked: local changes detected; rerun with --force to delete");
+    return lines.join("\n");
+  }
+
+  if (!options.dryRun) {
+    for (const target of record.files) {
+      const absoluteTarget = path.join(project.cwd, target);
+      if (existsSync(absoluteTarget)) await rm(absoluteTarget);
+    }
+
+    const packageJson = await readPackageJson(project.cwd);
+    const mason = packageJson.mason as { installed?: Record<string, unknown> } | undefined;
+    if (mason?.installed) {
+      delete mason.installed[options.item];
+      packageJson.mason = mason;
+      await writePackageJson(project.cwd, packageJson);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+export async function doctorCommand(options: {
+  cwd: string;
+  registry?: string | null;
+}): Promise<string> {
+  const project = await detectProject(options.cwd);
+  const lines = ["Mason doctor:"];
+  const issues: string[] = [];
+
+  if (!existsSync(configPath(project.cwd))) {
+    issues.push("missing mason.config.json");
+  } else {
+    const config = await readMasonConfig(project.cwd);
+    for (const [name, alias] of Object.entries(config.aliases)) {
+      if (!alias) issues.push(`empty alias: ${name}`);
+    }
+    const styleTarget = path.isAbsolute(config.aliases.theme)
+      ? config.aliases.theme
+      : path.join(project.cwd, config.aliases.theme.replace(/^@\//, "src/"));
+    if (!existsSync(styleTarget)) issues.push(`missing style entry: ${config.aliases.theme}`);
+  }
+
+  if (project.packageManager === "unknown") issues.push("unknown package manager");
+
+  const installed = installedItems(project);
+  for (const [name, record] of Object.entries(installed).sort(([a], [b]) => a.localeCompare(b))) {
+    if (!Array.isArray(record.files)) {
+      issues.push(`invalid installed metadata for ${name}: files must be an array`);
+      continue;
+    }
+    for (const target of record.files) {
+      const absoluteTarget = path.join(project.cwd, target);
+      if (!existsSync(absoluteTarget)) {
+        issues.push(`missing installed file for ${name}: ${target}`);
+        continue;
+      }
+      const recordedHash = fileHash(record, target);
+      if (!recordedHash) issues.push(`missing recorded hash for ${name}: ${target}`);
+    }
+  }
+
+  if (options.registry) {
+    const registryIndex = path.join(path.resolve(options.registry), "registry.json");
+    if (!existsSync(registryIndex)) issues.push(`registry not reachable: ${options.registry}`);
+  }
+
+  if (Object.keys(installed).length > 0) {
+    const dependencies = {
+      ...(project.packageJson.dependencies as Record<string, string> | undefined),
+      ...(project.packageJson.devDependencies as Record<string, string> | undefined),
+    };
+    if (
+      Object.keys(installed).some((name) =>
+        ["accordion", "dialog", "popover", "select", "sheet", "tooltip"].includes(name),
+      ) &&
+      !dependencies["@keystone-ui/keystone"]
+    ) {
+      issues.push("missing @keystone-ui/keystone dependency for Keystone-backed installed items");
+    }
+  }
+
+  if (issues.length === 0) {
+    lines.push("ok");
+  } else {
+    for (const issue of issues) lines.push(`issue ${issue}`);
+  }
+
+  return lines.join("\n");
+}

--- a/packages/mason-cli/src/index.ts
+++ b/packages/mason-cli/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 import { addCommand } from "./commands/add";
 import { initCommand } from "./commands/init";
+import { diffCommand, doctorCommand, removeCommand, updateCommand } from "./commands/lifecycle";
 
 type ParsedArgs = {
   command: string | null;
@@ -50,7 +51,35 @@ export async function run(argv: string[] = process.argv.slice(2)): Promise<strin
       dryRun: args.dryRun,
     });
   }
-  throw new Error("Usage: mason init|add");
+  if (args.command === "diff") {
+    if (!args.item) throw new Error("Usage: mason diff <item> --registry <path>");
+    if (!args.registry) throw new Error("mason diff requires --registry <path>.");
+    return diffCommand({ cwd: args.cwd, item: args.item, registry: args.registry });
+  }
+  if (args.command === "update") {
+    if (!args.item) throw new Error("Usage: mason update <item> --registry <path>");
+    if (!args.registry) throw new Error("mason update requires --registry <path>.");
+    return updateCommand({
+      cwd: args.cwd,
+      item: args.item,
+      registry: args.registry,
+      dryRun: args.dryRun,
+      force: args.force,
+    });
+  }
+  if (args.command === "remove") {
+    if (!args.item) throw new Error("Usage: mason remove <item>");
+    return removeCommand({
+      cwd: args.cwd,
+      item: args.item,
+      dryRun: args.dryRun,
+      force: args.force,
+    });
+  }
+  if (args.command === "doctor") {
+    return doctorCommand({ cwd: args.cwd, registry: args.registry });
+  }
+  throw new Error("Usage: mason init|add|diff|update|remove|doctor");
 }
 
 if (import.meta.main) {

--- a/packages/mason-cli/test/mason-cli.test.ts
+++ b/packages/mason-cli/test/mason-cli.test.ts
@@ -4,6 +4,13 @@ import path from "node:path";
 import { afterEach, describe, expect, test } from "bun:test";
 import { addCommand } from "../src/commands/add";
 import { initCommand } from "../src/commands/init";
+import {
+  diffCommand,
+  doctorCommand,
+  removeCommand,
+  updateCommand,
+} from "../src/commands/lifecycle";
+import { run } from "../src/index";
 import { createWritePlan } from "../src/install/plan";
 import { rejectUnsafeRelativePath } from "../src/install/paths";
 import { applyWritePlan } from "../src/install/write";
@@ -371,6 +378,92 @@ describe("add planning and writes", () => {
       enabled: true,
     });
     expect(await readFile(path.join(app, "src/readme.md"), "utf8")).toBe("installed\n");
+  });
+});
+
+describe("registry lifecycle commands", () => {
+  test("diff reports unchanged and locally changed installed files", async () => {
+    const app = await fixtureApp();
+    await initCommand({ cwd: app, yes: true });
+    await addCommand({ cwd: app, item: "button", registry });
+
+    expect(await diffCommand({ cwd: app, item: "button", registry })).toBe(
+      ["Mason diff plan for button:", "unchanged src/components/ui/button.tsx"].join("\n"),
+    );
+
+    await writeFile(path.join(app, "src/components/ui/button.tsx"), "user edit\n");
+
+    expect(await diffCommand({ cwd: app, item: "button", registry })).toBe(
+      ["Mason diff plan for button:", "update src/components/ui/button.tsx (local changes)"].join(
+        "\n",
+      ),
+    );
+  });
+
+  test("update blocks local edits unless forced and refreshes recorded hashes", async () => {
+    const app = await fixtureApp();
+    await initCommand({ cwd: app, yes: true });
+    await addCommand({ cwd: app, item: "button", registry });
+    await writeFile(path.join(app, "src/components/ui/button.tsx"), "user edit\n");
+
+    const blocked = await updateCommand({ cwd: app, item: "button", registry });
+    expect(blocked).toContain("blocked: local changes detected");
+    expect(await readFile(path.join(app, "src/components/ui/button.tsx"), "utf8")).toBe(
+      "user edit\n",
+    );
+
+    const output = await updateCommand({ cwd: app, item: "button", registry, force: true });
+    expect(output).toContain("update src/components/ui/button.tsx (local changes)");
+    expect(await readFile(path.join(app, "src/components/ui/button.tsx"), "utf8")).toContain(
+      "export function Button",
+    );
+
+    expect(await diffCommand({ cwd: app, item: "button", registry })).toBe(
+      ["Mason diff plan for button:", "unchanged src/components/ui/button.tsx"].join("\n"),
+    );
+  });
+
+  test("remove deletes clean installed files and clears installed metadata", async () => {
+    const app = await fixtureApp();
+    await initCommand({ cwd: app, yes: true });
+    await addCommand({ cwd: app, item: "button", registry });
+
+    expect(await removeCommand({ cwd: app, item: "button", dryRun: true })).toBe(
+      ["Mason remove dry run plan for button:", "delete src/components/ui/button.tsx"].join("\n"),
+    );
+
+    await removeCommand({ cwd: app, item: "button" });
+
+    await expect(stat(path.join(app, "src/components/ui/button.tsx"))).rejects.toThrow();
+    const packageJson = JSON.parse(await readFile(path.join(app, "package.json"), "utf8")) as {
+      mason: { installed: Record<string, unknown> };
+    };
+    expect(packageJson.mason.installed.button).toBeUndefined();
+  });
+
+  test("doctor validates config, registry reachability, and installed metadata", async () => {
+    const app = await fixtureApp();
+    await initCommand({ cwd: app, yes: true });
+    await addCommand({ cwd: app, item: "button", registry });
+
+    expect(await doctorCommand({ cwd: app, registry })).toBe("Mason doctor:\nok");
+
+    await rm(path.join(app, "src/components/ui/button.tsx"));
+
+    expect(await doctorCommand({ cwd: app, registry })).toContain(
+      "issue missing installed file for button: src/components/ui/button.tsx",
+    );
+  });
+
+  test("CLI routes lifecycle commands", async () => {
+    const app = await fixtureApp();
+    await initCommand({ cwd: app, yes: true });
+    await addCommand({ cwd: app, item: "button", registry });
+
+    expect(await run(["diff", "button", "--cwd", app, "--registry", registry])).toContain(
+      "Mason diff plan for button:",
+    );
+    expect(await run(["doctor", "--cwd", app, "--registry", registry])).toBe("Mason doctor:\nok");
   });
 });
 

--- a/packages/mason-registry/src/registry-validation.test.ts
+++ b/packages/mason-registry/src/registry-validation.test.ts
@@ -51,7 +51,7 @@ describe("Mason registry validation tracer", () => {
     }
   });
 
-  test("validates every real default registry item against its source files", async () => {
+  test("validates every default registry item and its parity metadata contract", async () => {
     const rootRegistry = JSON.parse(
       await readFile(resolve(defaultRegistryRoot, "registry.json"), "utf8"),
     ) as unknown;

--- a/packages/mason-registry/src/resolve-dependencies.ts
+++ b/packages/mason-registry/src/resolve-dependencies.ts
@@ -34,11 +34,12 @@ export function resolveRegistryDependencies(
     }
 
     if (temporary.has(name)) {
+      const cycle = [...stack, name];
       errors.push({
         code: "registryDependency.cycle",
-        message: `Registry dependency cycle detected: ${[...stack, name].join(" -> ")}.`,
+        message: `Registry dependency cycle detected: ${cycle.join(" -> ")}.`,
         value: name,
-        details: { cycle: [...stack, name] },
+        details: { cycle },
       });
       return;
     }
@@ -65,9 +66,11 @@ export function resolveRegistryDependencies(
     }
 
     temporary.add(name);
+    stack.push(name);
     for (const dependency of item.registryDependencies ?? []) {
-      visit(dependency, [...stack, name]);
+      visit(dependency, stack);
     }
+    stack.pop();
     temporary.delete(name);
     permanent.add(name);
     resolved.push(item);
@@ -96,11 +99,12 @@ export async function resolveRegistryDependencyGraph(
     }
 
     if (temporary.has(name)) {
+      const cycle = [...stack, name];
       errors.push({
         code: "registryDependency.cycle",
-        message: `Registry dependency cycle detected: ${[...stack, name].join(" -> ")}.`,
+        message: `Registry dependency cycle detected: ${cycle.join(" -> ")}.`,
         value: name,
-        details: { cycle: [...stack, name] },
+        details: { cycle },
       });
       return;
     }
@@ -129,9 +133,11 @@ export async function resolveRegistryDependencyGraph(
     }
 
     temporary.add(name);
+    stack.push(name);
     for (const dependency of itemValidation.value.registryDependencies ?? []) {
-      await visit(dependency, [...stack, name]);
+      await visit(dependency, stack);
     }
+    stack.pop();
     temporary.delete(name);
     permanent.add(name);
     resolved.push(itemValidation.value);

--- a/registry/default/items/date-picker.json
+++ b/registry/default/items/date-picker.json
@@ -16,7 +16,7 @@
   "registryDependencies": ["cn"],
   "meta": {
     "install": "mason add date-picker",
-    "customization": "Style the generated wrappers through mason-date-picker and mason-calendar classes while Keystone keeps calendar grid generation, selected date state, month navigation, keyboard movement, ARIA roles, and data attributes.",
+    "customization": "Style the generated wrappers through mason-date-picker and mason-calendar classes while Keystone keeps calendar grid generation, single-date and range state, unavailable dates, locale week starts, month navigation, keyboard movement, ARIA roles, and data attributes.",
     "sourceFiles": ["registry/default/ui/date-picker.tsx"],
     "dependencies": ["@keystone-ui/keystone", "cn"],
     "parts": {
@@ -37,8 +37,8 @@
       "datePicker": ["root", "trigger", "content"]
     },
     "parity": {
-      "baseUi": "Thin vertical covers calendar grid and popup trigger contract, selected date state, disabled bounds, month navigation, keyboard movement, ARIA roles, and Mason metadata. Gaps: date field segment editing, validation/form semantics, richer unavailable date policies, range calendars, focus restoration depth, and locale calendar systems remain follow-up work.",
-      "kobalte": "Matches the Solid calendar/date-picker direction for grid parts, trigger/content composition, controlled selected value, min/max bounds, and keyboard navigation. Gaps: DateField segments, DateRangePicker, granular unavailable dates, multi-month rendering, locale/calendar-system depth, and reset/submission tests remain follow-up work."
+      "baseUi": "Covers calendar grid and popup trigger contract, selected date state, range state, unavailable date policy, disabled bounds, locale week starts, month navigation, keyboard movement, ARIA roles, and Mason metadata. Gaps: date field segment editing, validation/form semantics, multi-month rendering, focus restoration depth, and full locale calendar systems remain follow-up work.",
+      "kobalte": "Matches the Solid calendar/date-picker direction for grid parts, trigger/content composition, controlled selected value, controlled range value, min/max bounds, granular unavailable dates, locale week starts, and keyboard navigation. Gaps: DateField segments, DateRangePicker composition, multi-month rendering, full locale/calendar-system depth, and reset/submission tests remain follow-up work."
     }
   },
   "files": [

--- a/registry/default/items/navigation-menu.json
+++ b/registry/default/items/navigation-menu.json
@@ -27,11 +27,12 @@
       "group-label",
       "separator",
       "item",
+      "link",
       "item-indicator"
     ],
     "parity": {
-      "baseUi": "Thin vertical covers the core NavigationMenu trigger/content item contract through Keystone overlay positioning and menubar semantics. Gaps: Viewport, Popup-specific layout APIs, animation metadata, link activation helpers, touch pointer intent, and edge-case tests remain follow-up work.",
-      "kobalte": "Thin vertical maps Root/Trigger/Content/Item/Group/Separator behavior onto Keystone menu kernel with navigation-menu scope, controlled open state, typeahead, disabled skipping, and Mason wrappers. Gaps: explicit Root nav/List/Viewport parts, hover intent tuning, submenu cursor safety, focus restoration across routed links, and richer nested coordination remain follow-up work."
+      "baseUi": "Thin vertical covers the core NavigationMenu trigger/content item/link contract through Keystone overlay positioning and menubar semantics. Gaps: Viewport, Popup-specific layout APIs, animation metadata, touch pointer intent, and edge-case tests remain follow-up work.",
+      "kobalte": "Thin vertical maps Root/Trigger/Content/Item/Link/Group/Separator behavior onto Keystone menu kernel with navigation-menu scope, controlled open state, typeahead, disabled skipping, routed anchor activation, and Mason wrappers. Gaps: explicit Root nav/List/Viewport parts, hover intent tuning, submenu cursor safety, focus restoration across dynamic route transitions, and richer nested coordination remain follow-up work."
     }
   },
   "files": [

--- a/registry/default/items/slider.json
+++ b/registry/default/items/slider.json
@@ -16,18 +16,18 @@
   "registryDependencies": ["cn"],
   "meta": {
     "install": "mason add slider",
-    "customization": "Style the generated wrappers through mason-slider classes while Keystone keeps range math, thumb ARIA, controlled state, keyboard stepping, pointer commits, data attributes, and CSS variables.",
+    "customization": "Style the generated wrappers through mason-slider classes while Keystone keeps range math, thumb ARIA, controlled state, keyboard stepping, pointer commits, hidden input form serialization, data attributes, and CSS variables.",
     "sourceFiles": ["registry/default/ui/slider.tsx"],
     "dependencies": ["@keystone-ui/keystone", "cn"],
-    "parts": ["root", "track", "range", "thumb"],
+    "parts": ["root", "track", "range", "thumb", "hidden-input"],
     "cssVars": [
       "--keystone-slider-range-start",
       "--keystone-slider-range-end",
       "--keystone-slider-thumb-percent"
     ],
     "parity": {
-      "baseUi": "Thin vertical covers controlled/uncontrolled values, multi-thumb sorting, thumb ARIA, orientation metadata, keyboard step/page/home/end, pointer track selection, data attributes, CSS variables, and Mason wrapper metadata. Gaps: minimum thumb distance, root-level focus coordination, stable field integration, advanced disabled/read-only semantics, and edge-case pointer capture remain follow-up work.",
-      "kobalte": "Matches Solid Slider anatomy direction for root/track/range/thumb, controlled values, orientation, keyboard stepping, and data attributes. Gaps: hidden input/form submission, origin/tooltip helpers, richer touch behavior, and broader SSR/form tests remain follow-up work.",
+      "baseUi": "Thin vertical covers controlled/uncontrolled values, multi-thumb sorting, thumb ARIA, orientation metadata, read-only/invalid/required state attributes, keyboard step/page/home/end, pointer track selection, hidden input form serialization/reset, data attributes, CSS variables, and Mason wrapper metadata. Gaps: minimum thumb distance, root-level focus coordination, richer field validation, and edge-case pointer capture remain follow-up work.",
+      "kobalte": "Matches Solid Slider anatomy direction for root/track/range/thumb, controlled values, orientation, keyboard stepping, hidden input form submission/reset, and data attributes. Gaps: origin/tooltip helpers, richer touch behavior, and broader SSR/form tests remain follow-up work.",
       "tanstackRanger": "TanStack Ranger remains an exception reference for range math: compare active handle lifecycle, tick helpers, interpolation, touch behavior, and commit timing before deepening Keystone beyond the current intrinsic primitive."
     }
   },

--- a/registry/default/items/tabs.json
+++ b/registry/default/items/tabs.json
@@ -21,8 +21,8 @@
     "dependencies": ["@keystone-ui/keystone", "cn"],
     "parts": ["root", "list", "trigger", "indicator", "content"],
     "parity": {
-      "baseUi": "Thin vertical covers controlled and uncontrolled value state, disabled triggers, horizontal and vertical roving focus, automatic/manual activation, tablist/tabpanel ARIA, Mason wrapper metadata, and behavior tests. Gaps: RTL horizontal key behavior, measured indicator positioning, delete/closable tab coordination, activation latency policy, dynamic removal focus restoration, and broader touch/cursor tests remain follow-up work.",
-      "kobalte": "Matches Solid Tabs Root/List/Trigger/Content direction with controlled value, orientation, activation mode, disabled triggers, and stable data attributes. Gaps: indicator measurement, create-dom-collection depth, dynamic tab lifecycle, and SSR edge-case coverage remain follow-up work."
+      "baseUi": "Thin vertical covers controlled and uncontrolled value state, disabled triggers, horizontal and vertical roving focus, RTL-aware horizontal keys, automatic/manual activation, tablist/tabpanel ARIA, Mason wrapper metadata, and behavior tests. Gaps: measured indicator positioning, delete/closable tab coordination, activation latency policy, dynamic removal focus restoration, and broader touch/cursor tests remain follow-up work.",
+      "kobalte": "Matches Solid Tabs Root/List/Trigger/Content direction with controlled value, orientation, direction, activation mode, disabled triggers, and stable data attributes. Gaps: indicator measurement, create-dom-collection depth, dynamic tab lifecycle, and SSR edge-case coverage remain follow-up work."
     }
   },
   "files": [

--- a/registry/default/items/toolbar.json
+++ b/registry/default/items/toolbar.json
@@ -21,7 +21,7 @@
     "dependencies": ["@keystone-ui/keystone", "cn"],
     "parts": ["root", "button", "link", "separator"],
     "parity": {
-      "baseUi": "Thin vertical covers toolbar role, horizontal and vertical orientation, roving focus, disabled item skipping, pressed button metadata, separator semantics, Mason wrappers, and registry metadata. Gaps: toggle-group coordination, radio-group coordination, richer cursor/touch behavior, RTL arrow behavior, nested toolbar/menu coordination, focus restoration from popover/menu tools, controlled active item state, and broader edge-case tests remain follow-up work.",
+      "baseUi": "Thin vertical covers toolbar role, horizontal and vertical orientation, RTL-aware horizontal keys, roving focus, disabled item skipping, pressed button metadata, separator semantics, Mason wrappers, and registry metadata. Gaps: toggle-group coordination, radio-group coordination, richer cursor/touch behavior, nested toolbar/menu coordination, focus restoration from popover/menu tools, controlled active item state, and broader edge-case tests remain follow-up work.",
       "kobalte": "Kobalte has related toggle, toggle-group, and composite primitives rather than a direct toolbar surface; Solid parity is scoped to roving focus, orientation, disabled skipping, and part composition. Gaps: toggle/radio group integration and nested composite policy remain follow-up work."
     }
   },

--- a/registry/default/ui/navigation-menu.tsx
+++ b/registry/default/ui/navigation-menu.tsx
@@ -5,6 +5,7 @@ import {
   type NavigationMenuGroupLabelProps as KeystoneNavigationMenuGroupLabelProps,
   type NavigationMenuGroupProps as KeystoneNavigationMenuGroupProps,
   type NavigationMenuItemProps as KeystoneNavigationMenuItemProps,
+  type NavigationMenuLinkProps as KeystoneNavigationMenuLinkProps,
   type NavigationMenuPartProps as KeystoneNavigationMenuPartProps,
   type NavigationMenuPortalProps as KeystoneNavigationMenuPortalProps,
   type NavigationMenuPositionerProps as KeystoneNavigationMenuPositionerProps,
@@ -29,6 +30,7 @@ export type NavigationMenuGroupProps = KeystoneNavigationMenuGroupProps;
 export type NavigationMenuGroupLabelProps = KeystoneNavigationMenuGroupLabelProps;
 export type NavigationMenuSeparatorProps = KeystoneNavigationMenuSeparatorProps;
 export type NavigationMenuItemProps = KeystoneNavigationMenuItemProps;
+export type NavigationMenuLinkProps = KeystoneNavigationMenuLinkProps;
 export type NavigationMenuCheckboxItemProps = KeystoneNavigationMenuCheckboxItemProps;
 export type NavigationMenuRadioGroupProps = KeystoneNavigationMenuRadioGroupProps;
 export type NavigationMenuRadioItemProps = KeystoneNavigationMenuRadioItemProps;
@@ -112,6 +114,13 @@ export function NavigationMenuItem(props: NavigationMenuItemProps) {
   const [local, rest] = splitProps(props, ["class"]);
   return (
     <KeystoneNavigationMenu.Item {...rest} class={cn("mason-navigation-menu-item", local.class)} />
+  );
+}
+
+export function NavigationMenuLink(props: NavigationMenuLinkProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return (
+    <KeystoneNavigationMenu.Link {...rest} class={cn("mason-navigation-menu-link", local.class)} />
   );
 }
 

--- a/registry/default/ui/slider.tsx
+++ b/registry/default/ui/slider.tsx
@@ -1,5 +1,6 @@
 import {
   Slider as KeystoneSlider,
+  type SliderHiddenInputProps as KeystoneSliderHiddenInputProps,
   type SliderRangeProps as KeystoneSliderRangeProps,
   type SliderRootProps as KeystoneSliderRootProps,
   type SliderThumbProps as KeystoneSliderThumbProps,
@@ -12,6 +13,7 @@ export type SliderProps = KeystoneSliderRootProps;
 export type SliderTrackProps = KeystoneSliderTrackProps;
 export type SliderRangeProps = KeystoneSliderRangeProps;
 export type SliderThumbProps = KeystoneSliderThumbProps;
+export type SliderHiddenInputProps = KeystoneSliderHiddenInputProps;
 
 export function Slider(props: SliderProps) {
   const [local, rest] = splitProps(props, ["class"]);
@@ -39,4 +41,8 @@ export function SliderThumb(props: SliderThumbProps) {
   const [local, rest] = splitProps(props, ["class"]);
 
   return <KeystoneSlider.Thumb {...rest} class={cn("mason-slider-thumb", local.class)} />;
+}
+
+export function SliderHiddenInput(props: SliderHiddenInputProps) {
+  return <KeystoneSlider.HiddenInput {...props} />;
 }


### PR DESCRIPTION
## Summary

Expands Keystone primitive behavior depth, docs contract surfaces, Mason registry lifecycle support, and validation around the current primitive/registry direction.

## Core changes

- Adds metadata-backed Keystone and Mason docs contract pages plus docs contract tests.
- Extends Keystone date-picker range selection, slider form/read-only behavior, selection-control coverage, menu exports, and stable part/data attributes.
- Adds accessibility, SSR, and listbox performance harness coverage.
- Adds Mason CLI diff/update/remove/doctor lifecycle commands and registry dependency cycle detail fixes.
- Documents and validates first-party registry parity metadata.

## Validation

- bun run check
- bun run check-types
- bun run test:keystone
- bun run test:docs
- bun run test:mason-cli
- bun run test:mason-registry
- bun run build