### PR TITLE
[codex] ship command menu registry item

### DIFF
--- a/apps/docs/src/lib/registry-contracts.ts
+++ b/apps/docs/src/lib/registry-contracts.ts
@@ -8,6 +8,7 @@ import checkbox from "../../../../registry/default/items/checkbox.json";
 import cn from "../../../../registry/default/items/cn.json";
 import collapsible from "../../../../registry/default/items/collapsible.json";
 import combobox from "../../../../registry/default/items/combobox.json";
+import commandMenu from "../../../../registry/default/items/command-menu.json";
 import contextMenu from "../../../../registry/default/items/context-menu.json";
 import dataTableTanstackRouter from "../../../../registry/default/items/data-table-tanstack-router.json";
 import dataTable from "../../../../registry/default/items/data-table.json";
@@ -66,6 +67,7 @@ const rawItems = [
   cn,
   collapsible,
   combobox,
+  commandMenu,
   contextMenu,
   dataTableTanstackRouter,
   dataTable,

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,8 @@
     "": {
       "name": "keystone-ui",
       "devDependencies": {
+        "@tanstack/solid-hotkeys": "^0.10.0",
+        "@tanstack/solid-store": "^0.11.0",
         "@tanstack/solid-table": "^8.21.3",
         "oxfmt": "^0.46.0",
         "oxlint": "^1.61.0",
@@ -387,6 +389,8 @@
 
     "@tanstack/history": ["@tanstack/history@1.161.6", "", {}, "sha512-NaOGLRrddszbQj9upGat6HG/4TKvXLvu+osAIgfxPYA+eIvYKv8GKDJOrY2D3/U9MRnKfMWD7bU4jeD4xmqyIg=="],
 
+    "@tanstack/hotkeys": ["@tanstack/hotkeys@0.8.0", "", { "dependencies": { "@tanstack/store": "^0.11.0" } }, "sha512-vqH7X9nb0MTJ/O08++dB5bP9jgj4+BIPOUu/U+6myG86lDsirZSVSobpq5UQpE7nBuk62i8eIYeOhd+OMl/UrA=="],
+
     "@tanstack/pacer-lite": ["@tanstack/pacer-lite@0.1.1", "", {}, "sha512-y/xtNPNt/YeyoVxE/JCx+T7yjEzpezmbb+toK8DDD1P4m7Kzs5YR956+7OKexG3f8aXgC3rLZl7b1V+yNUSy5w=="],
 
     "@tanstack/react-router": ["@tanstack/react-router@1.169.1", "", { "dependencies": { "@tanstack/history": "1.161.6", "@tanstack/react-store": "^0.9.3", "@tanstack/router-core": "1.169.1", "isbot": "^5.1.22" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-MBtQKSvac3OCcsSa6oBpDrrN90IV47I6Gtv05NxhbFVh+gVjtqvs6HSU4XM9+y5sHZPgS+35eArflX4vM8GEnQ=="],
@@ -405,6 +409,8 @@
 
     "@tanstack/solid-form": ["@tanstack/solid-form@1.29.1", "", { "dependencies": { "@tanstack/form-core": "1.29.1", "@tanstack/solid-store": "^0.9.1" }, "peerDependencies": { "solid-js": ">=1.9.9" } }, "sha512-ZIkqyNSKISpglPNMEwqBa1Mo+SbmbUQgfEyDCBYt5jaLQYoXpsBq6Fsq4+fup5nDyhH3ScB9ZOFpUuZxNHgrjQ=="],
 
+    "@tanstack/solid-hotkeys": ["@tanstack/solid-hotkeys@0.10.0", "", { "dependencies": { "@tanstack/hotkeys": "0.8.0", "@tanstack/solid-store": "^0.11.0" }, "peerDependencies": { "solid-js": ">=1.7.0" } }, "sha512-jThxkZMt1ShaQ/ynvyzHfwdbl15gTxJWXnQtbHuRHrzYFvuBB5fx4+D0jKQJ3sSq6XN3HwB3f9cVI0na5rN+Bw=="],
+
     "@tanstack/solid-router": ["@tanstack/solid-router@1.169.1", "", { "dependencies": { "@solid-devtools/logger": "^0.9.4", "@solid-primitives/refs": "^1.0.8", "@solidjs/meta": "^0.29.4", "@tanstack/history": "1.161.6", "@tanstack/router-core": "1.169.1", "isbot": "^5.1.22" }, "peerDependencies": { "solid-js": "^1.9.10" }, "bin": { "intent": "bin/intent.js" } }, "sha512-Ij0kD/nh8h7JupF6obPZvmYFLPF74tlPDuwIGdWWS3vJWYx8SXuDrI11rMTJPmftnkgYDfhrwvhYQzz4K3/+cQ=="],
 
     "@tanstack/solid-router-devtools": ["@tanstack/solid-router-devtools@1.166.13", "", { "dependencies": { "@tanstack/router-devtools-core": "1.167.3" }, "peerDependencies": { "@tanstack/router-core": "^1.168.11", "@tanstack/solid-router": "^1.168.14", "solid-js": "^1.9.10" }, "optionalPeers": ["@tanstack/router-core"] }, "sha512-0K/bhEWPuBjHjI9h9Ckc9iioHmHr/DW+rXbfETa6G+lNK9nArUgtvuVM58sITRaSmlpImm/OCMCuNkUhXrPP/w=="],
@@ -415,7 +421,7 @@
 
     "@tanstack/solid-start-server": ["@tanstack/solid-start-server@1.166.49", "", { "dependencies": { "@solidjs/meta": "^0.29.4", "@tanstack/history": "1.161.6", "@tanstack/router-core": "1.169.1", "@tanstack/solid-router": "1.169.1", "@tanstack/start-client-core": "1.168.1", "@tanstack/start-server-core": "1.167.28" }, "peerDependencies": { "solid-js": "^1.0.0" } }, "sha512-acqezofCdL1mgrOv8bPQz4xPOiwwkhO+vYJTmEN6rjdlxpJFyKqJ3Gik4KY8vaDeptvi97pqlruzPkYhZ5Mkhw=="],
 
-    "@tanstack/solid-store": ["@tanstack/solid-store@0.9.3", "", { "dependencies": { "@tanstack/store": "0.9.3" }, "peerDependencies": { "solid-js": "^1.6.0" } }, "sha512-XThXDzwJT8zeatmxFK1UISikfzz1z76mMlpg1IBDPrJp6df6U3cpJInZRbYs3xlVsnhMziuZigaSkzMyZESK9Q=="],
+    "@tanstack/solid-store": ["@tanstack/solid-store@0.11.0", "", { "dependencies": { "@tanstack/store": "0.11.0" }, "peerDependencies": { "solid-js": "^1.6.0" } }, "sha512-2isL0ZnnyI1iN0V+QPrxE3OcPndohBgVlBcHZYoAOIAiU1WoWjVy0q5gb0suPu1Id0h5cKC23JnwzQTxWDZD0w=="],
 
     "@tanstack/solid-table": ["@tanstack/solid-table@8.21.3", "", { "dependencies": { "@tanstack/table-core": "8.21.3" }, "peerDependencies": { "solid-js": ">=1.3" } }, "sha512-PmhfSLBxVKiFs01LtYOYrCRhCyTUjxmb4KlxRQiqcALtip8+DOJeeezQM4RSX/GUS0SMVHyH/dNboCpcO++k2A=="],
 
@@ -429,7 +435,7 @@
 
     "@tanstack/start-storage-context": ["@tanstack/start-storage-context@1.166.34", "", { "dependencies": { "@tanstack/router-core": "1.169.1" } }, "sha512-mIre+HDvahOnUmP3vQx+x4kvUzam/uVYpCphudR/Czzi0Crfm0JyyLMNv7hHxkfqMg9aTrxYtDTZHR3isrUKhg=="],
 
-    "@tanstack/store": ["@tanstack/store@0.9.3", "", {}, "sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw=="],
+    "@tanstack/store": ["@tanstack/store@0.11.0", "", {}, "sha512-WlzzCt3xi0G6pCAJu1U+2jiECwabETDpQDi3hfkFZvJii9AuZqEKbOiVarX1/bWhTNjU486yQtJCCasi/0q+Cw=="],
 
     "@tanstack/table-core": ["@tanstack/table-core@8.21.3", "", {}, "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg=="],
 
@@ -789,9 +795,15 @@
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "@tanstack/form-core/@tanstack/store": ["@tanstack/store@0.9.3", "", {}, "sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw=="],
+
+    "@tanstack/react-store/@tanstack/store": ["@tanstack/store@0.9.3", "", {}, "sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw=="],
+
     "@tanstack/router-generator/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@tanstack/router-plugin/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@tanstack/solid-form/@tanstack/solid-store": ["@tanstack/solid-store@0.9.3", "", { "dependencies": { "@tanstack/store": "0.9.3" }, "peerDependencies": { "solid-js": "^1.6.0" } }, "sha512-XThXDzwJT8zeatmxFK1UISikfzz1z76mMlpg1IBDPrJp6df6U3cpJInZRbYs3xlVsnhMziuZigaSkzMyZESK9Q=="],
 
     "@tanstack/start-plugin-core/@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
 
@@ -810,5 +822,7 @@
     "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "readdirp/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
+
+    "@tanstack/solid-form/@tanstack/solid-store/@tanstack/store": ["@tanstack/store@0.9.3", "", {}, "sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "check": "oxlint && oxfmt --write"
   },
   "devDependencies": {
+    "@tanstack/solid-hotkeys": "^0.10.0",
+    "@tanstack/solid-store": "^0.11.0",
     "@tanstack/solid-table": "^8.21.3",
     "oxfmt": "^0.46.0",
     "oxlint": "^1.61.0",

--- a/packages/mason-registry/src/registry-validation.test.ts
+++ b/packages/mason-registry/src/registry-validation.test.ts
@@ -86,6 +86,7 @@ describe("Mason registry validation tracer", () => {
       "cn",
       "collapsible",
       "combobox",
+      "command-menu",
       "context-menu",
       "data-table-tanstack-router",
       "data-table",
@@ -142,6 +143,25 @@ describe("Mason registry validation tracer", () => {
       expect(result.value.registryDependencies).toEqual(["data-table"]);
       expect(result.value.meta?.searchParams).toBeString();
       expect(result.value.meta?.stateMapping).toBeString();
+      expect(result.value.meta?.limitations).toBeString();
+    }
+  });
+
+  test("validates docs-ready metadata on the real default command-menu item", async () => {
+    const item = await import("../../../registry/default/items/command-menu.json");
+    const result = validateItem(item.default, { registryRoot: defaultRegistryRoot });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.dependencies).toContain("@tanstack/solid-store@^0.11.0");
+      expect(result.value.dependencies).toContain("@tanstack/solid-hotkeys@^0.10.0");
+      expect(result.value.registryDependencies).toEqual(["cn"]);
+      expect(result.value.meta?.commandItems).toBeString();
+      expect(result.value.meta?.searchFiltering).toBeString();
+      expect(result.value.meta?.store).toBeString();
+      expect(result.value.meta?.shortcutDisplay).toBeString();
+      expect(result.value.meta?.hotkeysPreview).toContain("preview");
+      expect(result.value.meta?.accessibility).toContain("Keystone Combobox");
       expect(result.value.meta?.limitations).toBeString();
     }
   });

--- a/registry/default/items/command-menu.json
+++ b/registry/default/items/command-menu.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://mason.build/schema/registry-item.json",
+  "name": "command-menu",
+  "type": "registry:ui",
+  "title": "CommandMenu",
+  "description": "Command palette source built from Keystone Combobox behavior, TanStack Store command state, and preview TanStack Hotkeys shortcuts.",
+  "version": "0.1.0",
+  "dependencies": [
+    "@keystone-ui/keystone@^0.0.0",
+    "@tanstack/solid-store@^0.11.0",
+    "@tanstack/solid-hotkeys@^0.10.0"
+  ],
+  "compatibility": {
+    "mason": ">=0.1.0 <0.2.0",
+    "solid": ">=1.9.9 <2.0.0"
+  },
+  "categories": ["command", "combobox", "tanstack", "hotkeys"],
+  "keywords": [
+    "command-menu",
+    "command-palette",
+    "combobox",
+    "store",
+    "hotkeys",
+    "keystone",
+    "tanstack"
+  ],
+  "docs": "https://mason.build/docs/components/command-menu",
+  "registryDependencies": ["cn"],
+  "meta": {
+    "install": "mason add command-menu",
+    "commandItems": "Pass readable CommandMenuItemData objects with value, label, optional description, group, keywords, disabled state, shortcut, and per-item onSelect handlers. The generated component filters by label, value, group, description, and keywords.",
+    "searchFiltering": "The high-level CommandMenu controls Keystone Combobox inputValue from the command store and renders only matching items. Replace filterCommandItems in user-owned source for fuzzy ranking, remote search, or permission-aware item visibility.",
+    "store": "createCommandMenuStore uses TanStack Store for app-level open/query/lastSelectedValue coordination. Pass a shared store when a shell trigger, route action, and command menu need to coordinate outside one component tree.",
+    "shortcutDisplay": "Item shortcuts use TanStack Hotkeys RegisterableHotkey values and formatForDisplay for platform-aware shortcut labels. Provide shortcutLabel when product copy needs a fixed display string.",
+    "hotkeysPreview": "Shortcut registration uses @tanstack/solid-hotkeys, which is still preview/alpha in the TanStack ecosystem. Keep the generated source easy to remove or adjust if upstream APIs change.",
+    "accessibility": "Keystone Combobox owns input/listbox roles, aria-activedescendant, highlighted item state, disabled skipping, typeahead/list keyboard behavior, portal positioning, dismissal, and controlled open/input state. Mason only adds command item data, filtering, shortcut display, and app-level shortcut registration.",
+    "customization": "Use mason-command-menu classes and data-part values for trigger, input, content, list, group, group-label, item, item-text, item-label, item-description, shortcut, and empty.",
+    "limitations": "This source is a local command palette pattern. It does not include fuzzy scoring, async search, nested command pages, command history, user preference persistence, route-specific command discovery, or a final Hotkeys API guarantee.",
+    "sourceFiles": ["registry/default/ui/command-menu.tsx"],
+    "dependencies": [
+      "@keystone-ui/keystone",
+      "@tanstack/solid-store",
+      "@tanstack/solid-hotkeys",
+      "cn"
+    ],
+    "parity": {
+      "baseUi": "Runtime behavior intentionally leans on Keystone Combobox toward Base UI-style accessible combobox/listbox depth: input ownership, aria-activedescendant, item highlighting, disabled items, typeahead/list navigation, overlay positioning, and dismissal. Gaps: nested command pages, fuzzy scorer conventions, async collection loading, and command history remain app-code follow-up work.",
+      "kobalte": "Solid primitive shape tracks Kobalte-style Combobox composition through root/input/content/listbox/group/item parts. Gaps: richer command-specific examples, virtualized command lists, and route-scoped collection discovery remain follow-up work.",
+      "tanstackStore": "TanStack Store is used only for app-level command menu state that benefits from sharing across shell controls: open, query, and last selected value. It deliberately does not replace Keystone primitive state or list navigation.",
+      "tanstackHotkeys": "TanStack Hotkeys powers preview app shortcuts for opening the menu and invoking command items, with shortcut display via formatForDisplay. Caveat: Hotkeys remains preview/alpha, so Mason metadata and source comments keep this integration removable while the API stabilizes."
+    }
+  },
+  "files": [
+    {
+      "path": "ui/command-menu.tsx",
+      "type": "registry:ui"
+    }
+  ]
+}

--- a/registry/default/registry.json
+++ b/registry/default/registry.json
@@ -106,6 +106,12 @@
       "description": "Styled Solid combobox backed by Keystone input, listbox, selection, and floating behavior."
     },
     {
+      "name": "command-menu",
+      "type": "registry:ui",
+      "title": "CommandMenu",
+      "description": "Command palette source built from Keystone Combobox behavior, TanStack Store command state, and preview TanStack Hotkeys shortcuts."
+    },
+    {
       "name": "autocomplete",
       "type": "registry:ui",
       "title": "Autocomplete",

--- a/registry/default/ui/command-menu.tsx
+++ b/registry/default/ui/command-menu.tsx
@@ -1,0 +1,478 @@
+import {
+  Combobox as KeystoneCombobox,
+  type ComboboxContentProps as KeystoneComboboxContentProps,
+  type ComboboxGroupLabelProps as KeystoneComboboxGroupLabelProps,
+  type ComboboxGroupProps as KeystoneComboboxGroupProps,
+  type ComboboxInputProps as KeystoneComboboxInputProps,
+  type ComboboxItemProps as KeystoneComboboxItemProps,
+  type ComboboxItemTextProps as KeystoneComboboxItemTextProps,
+  type ComboboxListboxProps as KeystoneComboboxListboxProps,
+  type ComboboxPortalProps as KeystoneComboboxPortalProps,
+  type ComboboxPositionerProps as KeystoneComboboxPositionerProps,
+  type ComboboxRootProps as KeystoneComboboxRootProps,
+  type ComboboxTriggerProps as KeystoneComboboxTriggerProps,
+} from "@keystone-ui/keystone/combobox";
+import {
+  createHotkeys,
+  formatForDisplay,
+  type CreateHotkeyOptions,
+  type RegisterableHotkey,
+} from "@tanstack/solid-hotkeys";
+import { createStore, useSelector, type Store } from "@tanstack/solid-store";
+import { For, Show, createMemo, splitProps, type JSX } from "solid-js";
+import { cn } from "@/lib/cn";
+
+export type CommandMenuItemData = {
+  value: string;
+  label: string;
+  description?: string;
+  disabled?: boolean;
+  group?: string;
+  keywords?: readonly string[];
+  shortcut?: RegisterableHotkey;
+  shortcutLabel?: string;
+  onSelect?: (item: CommandMenuItemData) => void;
+};
+
+export type CommandMenuState = {
+  open: boolean;
+  query: string;
+  lastSelectedValue?: string;
+};
+
+export type CommandMenuStore = {
+  store: Store<CommandMenuState>;
+  close: () => void;
+  open: () => void;
+  resetQuery: () => void;
+  selectValue: (value: string) => void;
+  setOpen: (open: boolean) => void;
+  setQuery: (query: string) => void;
+  toggleOpen: () => void;
+};
+
+export type CommandMenuHotkeysOptions = Omit<CreateHotkeyOptions, "target"> & {
+  enabled?: boolean;
+  itemShortcuts?: boolean;
+  openShortcut?: RegisterableHotkey;
+  target?: HTMLElement | Document | Window | null;
+};
+
+export type CommandMenuProps = Omit<
+  KeystoneComboboxRootProps,
+  "children" | "inputValue" | "open"
+> & {
+  children?: JSX.Element;
+  contentClass?: string;
+  empty?: JSX.Element;
+  hotkeys?: boolean | CommandMenuHotkeysOptions;
+  inputClass?: string;
+  inputPlaceholder?: string;
+  items: readonly CommandMenuItemData[];
+  listboxClass?: string;
+  onSelect?: (item: CommandMenuItemData) => void;
+  portal?: CommandMenuPortalProps;
+  positionerClass?: string;
+  resetQueryOnSelect?: boolean;
+  shortcutClass?: string;
+  store?: CommandMenuStore;
+  trigger?: JSX.Element;
+  triggerClass?: string;
+};
+
+export type CommandMenuRootProps = KeystoneComboboxRootProps;
+export type CommandMenuTriggerProps = KeystoneComboboxTriggerProps;
+export type CommandMenuInputProps = KeystoneComboboxInputProps;
+export type CommandMenuPortalProps = KeystoneComboboxPortalProps;
+export type CommandMenuPositionerProps = KeystoneComboboxPositionerProps;
+export type CommandMenuContentProps = KeystoneComboboxContentProps & {
+  portal?: CommandMenuPortalProps;
+  positionerClass?: string;
+};
+export type CommandMenuListProps = KeystoneComboboxListboxProps;
+export type CommandMenuGroupProps = KeystoneComboboxGroupProps;
+export type CommandMenuGroupLabelProps = KeystoneComboboxGroupLabelProps;
+export type CommandMenuItemProps = KeystoneComboboxItemProps & {
+  shortcut?: JSX.Element;
+};
+export type CommandMenuItemTextProps = KeystoneComboboxItemTextProps;
+export type CommandMenuShortcutProps = JSX.HTMLAttributes<HTMLSpanElement>;
+export type CommandMenuEmptyProps = JSX.HTMLAttributes<HTMLDivElement>;
+
+type CommandMenuGroupModel = {
+  value: string;
+  label?: string;
+  items: readonly CommandMenuItemData[];
+};
+
+const defaultOpenShortcut = "Mod+K";
+const ungroupedValue = "__mason-command-menu";
+
+export function createCommandMenuStore(initialState: Partial<CommandMenuState> = {}) {
+  const store = createStore<CommandMenuState>({
+    open: initialState.open ?? false,
+    query: initialState.query ?? "",
+    lastSelectedValue: initialState.lastSelectedValue,
+  });
+
+  const setOpen = (open: boolean) => store.setState((state) => ({ ...state, open }));
+  const setQuery = (query: string) => store.setState((state) => ({ ...state, query }));
+
+  return {
+    store,
+    close: () => setOpen(false),
+    open: () => setOpen(true),
+    resetQuery: () => setQuery(""),
+    selectValue: (value: string) =>
+      store.setState((state) => ({
+        ...state,
+        lastSelectedValue: value,
+      })),
+    setOpen,
+    setQuery,
+    toggleOpen: () => store.setState((state) => ({ ...state, open: !state.open })),
+  } satisfies CommandMenuStore;
+}
+
+export function CommandMenu(props: CommandMenuProps) {
+  const [local, rootProps] = splitProps(props, [
+    "children",
+    "contentClass",
+    "empty",
+    "hotkeys",
+    "inputClass",
+    "inputPlaceholder",
+    "items",
+    "listboxClass",
+    "onSelect",
+    "portal",
+    "positionerClass",
+    "resetQueryOnSelect",
+    "shortcutClass",
+    "store",
+    "trigger",
+    "triggerClass",
+  ]);
+  const commandStore = local.store ?? createCommandMenuStore({ open: rootProps.defaultOpen });
+  const open = useSelector(commandStore.store, (state) => state.open);
+  const query = useSelector(commandStore.store, (state) => state.query);
+  const visibleItems = createMemo(() => filterCommandItems(local.items, query()));
+  const groups = createMemo(() => groupCommandItems(visibleItems()));
+  const hotkeys = createMemo(() => normalizeHotkeys(local.hotkeys));
+
+  const selectItem = (item: CommandMenuItemData) => {
+    if (item.disabled) return;
+    commandStore.selectValue(item.value);
+    item.onSelect?.(item);
+    local.onSelect?.(item);
+    commandStore.close();
+
+    if (local.resetQueryOnSelect !== false) {
+      commandStore.resetQuery();
+    }
+  };
+
+  createHotkeys(
+    () => {
+      const options = hotkeys();
+      if (!options.enabled) return [];
+      const definitions = [
+        {
+          hotkey: options.openShortcut,
+          callback: (event: KeyboardEvent) => {
+            event.preventDefault();
+            commandStore.toggleOpen();
+          },
+          options: {
+            ignoreInputs: false,
+            meta: {
+              name: "Open command menu",
+              description: "Preview TanStack Hotkeys shortcut for the command menu.",
+            },
+          },
+        },
+      ];
+
+      if (!options.itemShortcuts) return definitions;
+
+      for (const item of local.items) {
+        if (!item.shortcut || item.disabled) continue;
+        definitions.push({
+          hotkey: item.shortcut,
+          callback: (event: KeyboardEvent) => {
+            event.preventDefault();
+            selectItem(item);
+          },
+          options: {
+            ignoreInputs: true,
+            meta: {
+              name: item.label,
+              description: "Preview TanStack Hotkeys command item shortcut.",
+            },
+          },
+        });
+      }
+
+      return definitions;
+    },
+    () => {
+      const options = hotkeys();
+      return {
+        enabled: options.enabled && !rootProps.disabled,
+        preventDefault: options.preventDefault ?? true,
+        requireReset: options.requireReset ?? true,
+        stopPropagation: options.stopPropagation ?? true,
+        target: options.target,
+      };
+    },
+  );
+
+  return (
+    <CommandMenuRoot
+      {...rootProps}
+      inputValue={query()}
+      open={open()}
+      onInputValueChange={(value, detail) => {
+        commandStore.setQuery(value);
+        rootProps.onInputValueChange?.(value, detail);
+      }}
+      onOpenChange={(nextOpen, detail) => {
+        commandStore.setOpen(nextOpen);
+        rootProps.onOpenChange?.(nextOpen, detail);
+      }}
+      onValueChange={(value, detail) => {
+        const item = local.items.find((candidate) => candidate.value === value);
+        if (item) {
+          selectItem(item);
+        }
+        rootProps.onValueChange?.(value, detail);
+      }}
+    >
+      <Show when={local.trigger}>
+        <CommandMenuTrigger class={local.triggerClass}>{local.trigger}</CommandMenuTrigger>
+      </Show>
+      <CommandMenuContent
+        class={local.contentClass}
+        portal={local.portal}
+        positionerClass={local.positionerClass}
+      >
+        <CommandMenuInput
+          class={local.inputClass}
+          placeholder={local.inputPlaceholder ?? "Search commands"}
+        />
+        <CommandMenuList class={local.listboxClass}>
+          <Show
+            when={visibleItems().length > 0}
+            fallback={<CommandMenuEmpty>{local.empty ?? "No commands found."}</CommandMenuEmpty>}
+          >
+            <For each={groups()}>
+              {(group) => (
+                <CommandMenuGroup value={group.value} label={group.label ?? "Commands"}>
+                  <Show when={group.label}>
+                    <CommandMenuGroupLabel>{group.label}</CommandMenuGroupLabel>
+                  </Show>
+                  <For each={group.items}>
+                    {(item) => (
+                      <CommandMenuItem
+                        disabled={item.disabled}
+                        group={group.value}
+                        label={item.label}
+                        value={item.value}
+                        shortcut={
+                          item.shortcut ? (
+                            <CommandMenuShortcut class={local.shortcutClass}>
+                              {item.shortcutLabel ?? formatForDisplay(item.shortcut)}
+                            </CommandMenuShortcut>
+                          ) : undefined
+                        }
+                      >
+                        <CommandMenuItemText>
+                          <span data-scope="mason-command-menu" data-part="item-label">
+                            {item.label}
+                          </span>
+                          <Show when={item.description}>
+                            <span data-scope="mason-command-menu" data-part="item-description">
+                              {item.description}
+                            </span>
+                          </Show>
+                        </CommandMenuItemText>
+                      </CommandMenuItem>
+                    )}
+                  </For>
+                </CommandMenuGroup>
+              )}
+            </For>
+          </Show>
+        </CommandMenuList>
+        {local.children}
+      </CommandMenuContent>
+    </CommandMenuRoot>
+  );
+}
+
+export function CommandMenuRoot(props: CommandMenuRootProps) {
+  return <KeystoneCombobox.Root {...props} />;
+}
+
+export function CommandMenuTrigger(props: CommandMenuTriggerProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return (
+    <KeystoneCombobox.Trigger {...rest} class={cn("mason-command-menu-trigger", local.class)} />
+  );
+}
+
+export function CommandMenuInput(props: CommandMenuInputProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return <KeystoneCombobox.Input {...rest} class={cn("mason-command-menu-input", local.class)} />;
+}
+
+export function CommandMenuPortal(props: CommandMenuPortalProps) {
+  return <KeystoneCombobox.Portal {...props} />;
+}
+
+export function CommandMenuPositioner(props: CommandMenuPositionerProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return (
+    <KeystoneCombobox.Positioner
+      {...rest}
+      class={cn("mason-command-menu-positioner", local.class)}
+    />
+  );
+}
+
+export function CommandMenuContent(props: CommandMenuContentProps) {
+  const [local, rest] = splitProps(props, ["children", "class", "portal", "positionerClass"]);
+  return (
+    <CommandMenuPortal {...local.portal}>
+      <CommandMenuPositioner class={local.positionerClass}>
+        <KeystoneCombobox.Content {...rest} class={cn("mason-command-menu-content", local.class)}>
+          {local.children}
+        </KeystoneCombobox.Content>
+      </CommandMenuPositioner>
+    </CommandMenuPortal>
+  );
+}
+
+export function CommandMenuList(props: CommandMenuListProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return <KeystoneCombobox.Listbox {...rest} class={cn("mason-command-menu-list", local.class)} />;
+}
+
+export function CommandMenuGroup(props: CommandMenuGroupProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return <KeystoneCombobox.Group {...rest} class={cn("mason-command-menu-group", local.class)} />;
+}
+
+export function CommandMenuGroupLabel(props: CommandMenuGroupLabelProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return (
+    <KeystoneCombobox.GroupLabel
+      {...rest}
+      class={cn("mason-command-menu-group-label", local.class)}
+    />
+  );
+}
+
+export function CommandMenuItem(props: CommandMenuItemProps) {
+  const [local, rest] = splitProps(props, ["children", "class", "shortcut"]);
+  return (
+    <KeystoneCombobox.Item {...rest} class={cn("mason-command-menu-item", local.class)}>
+      {local.children}
+      {local.shortcut}
+    </KeystoneCombobox.Item>
+  );
+}
+
+export function CommandMenuItemText(props: CommandMenuItemTextProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return (
+    <KeystoneCombobox.ItemText {...rest} class={cn("mason-command-menu-item-text", local.class)} />
+  );
+}
+
+export function CommandMenuShortcut(props: CommandMenuShortcutProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return (
+    <span
+      {...rest}
+      data-scope="mason-command-menu"
+      data-part="shortcut"
+      class={cn("mason-command-menu-shortcut", local.class)}
+    />
+  );
+}
+
+export function CommandMenuEmpty(props: CommandMenuEmptyProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return (
+    <div
+      {...rest}
+      data-scope="mason-command-menu"
+      data-part="empty"
+      class={cn("mason-command-menu-empty", local.class)}
+    />
+  );
+}
+
+function normalizeHotkeys(
+  options: CommandMenuProps["hotkeys"],
+): Required<Pick<CommandMenuHotkeysOptions, "enabled" | "itemShortcuts" | "openShortcut">> &
+  Omit<CommandMenuHotkeysOptions, "enabled" | "itemShortcuts" | "openShortcut"> {
+  if (options === false) {
+    return { enabled: false, itemShortcuts: false, openShortcut: defaultOpenShortcut };
+  }
+
+  if (options === true || options === undefined) {
+    return { enabled: true, itemShortcuts: true, openShortcut: defaultOpenShortcut };
+  }
+
+  return {
+    ...options,
+    enabled: options.enabled ?? true,
+    itemShortcuts: options.itemShortcuts ?? true,
+    openShortcut: options.openShortcut ?? defaultOpenShortcut,
+  };
+}
+
+function filterCommandItems(items: readonly CommandMenuItemData[], query: string) {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) return items;
+
+  return items.filter((item) => {
+    const haystack = [
+      item.label,
+      item.value,
+      item.description,
+      item.group,
+      ...(item.keywords ?? []),
+    ]
+      .filter(Boolean)
+      .join(" ")
+      .toLowerCase();
+    return haystack.includes(normalizedQuery);
+  });
+}
+
+function groupCommandItems(items: readonly CommandMenuItemData[]) {
+  const groups: CommandMenuGroupModel[] = [];
+  const byValue = new Map<string, CommandMenuGroupModel>();
+
+  for (const item of items) {
+    const value = item.group ?? ungroupedValue;
+    let group = byValue.get(value);
+
+    if (!group) {
+      group = {
+        value,
+        label: item.group,
+        items: [],
+      };
+      byValue.set(value, group);
+      groups.push(group);
+    }
+
+    group.items = [...group.items, item];
+  }
+
+  return groups;
+}

--- a/scripts/verify-example-app.ts
+++ b/scripts/verify-example-app.ts
@@ -60,9 +60,11 @@ async function main() {
       "@tanstack/form-core",
       "@tanstack/pacer-lite",
       "@tanstack/solid-form",
+      "@tanstack/solid-hotkeys",
       "@tanstack/solid-router",
       "@tanstack/solid-table",
       "@tanstack/solid-store",
+      "@tanstack/hotkeys",
       "@tanstack/router-core",
       "@tanstack/router-utils",
       "@tanstack/store",
@@ -90,6 +92,7 @@ async function main() {
     await addCommand({ cwd: app, item: "sheet", registry });
     await addCommand({ cwd: app, item: "text-field", registry });
     await addCommand({ cwd: app, item: "select-field", registry });
+    await addCommand({ cwd: app, item: "command-menu", registry });
     await addCommand({ cwd: app, item: "data-table", registry });
     await addCommand({ cwd: app, item: "data-table-tanstack-router", registry });
     await writeFile(
@@ -112,6 +115,11 @@ export default defineConfig({
     await writeFile(
       path.join(app, "src/main.tsx"),
       `import { render } from "solid-js/web";
+import {
+  CommandMenu,
+  createCommandMenuStore,
+  type CommandMenuItemData,
+} from "@/components/ui/command-menu";
 import {
   Dialog,
   DialogClose,
@@ -187,6 +195,26 @@ const invoiceColumns: ColumnDef<Invoice, unknown>[] = [
   },
 ];
 
+const commandItems: CommandMenuItemData[] = [
+  {
+    value: "open-dashboard",
+    label: "Open dashboard",
+    description: "Navigate to the dashboard overview.",
+    group: "Navigation",
+    shortcut: "Mod+D",
+    shortcutLabel: "Mod+D",
+    onSelect: (item) => item.value,
+  },
+  {
+    value: "create-invoice",
+    label: "Create invoice",
+    description: "Start a new invoice draft.",
+    group: "Actions",
+    shortcut: "Mod+I",
+    shortcutLabel: "Mod+I",
+  },
+];
+
 function App() {
   const form = createForm(() => ({
     defaultValues: {
@@ -203,6 +231,7 @@ function App() {
       pagination: { pageIndex: 0, pageSize: 2 },
     },
   });
+  const commandMenuStore = createCommandMenuStore({ open: true, query: "invoice" });
 
   return (
     <main>
@@ -239,6 +268,13 @@ function App() {
       <DataTable table={table}>
         <DataTableToolbar table={table} />
       </DataTable>
+      <CommandMenu
+        items={commandItems}
+        store={commandMenuStore}
+        hotkeys={false}
+        portal={{ forceMount: true }}
+        trigger="Open command menu"
+      />
       <Dialog>
         <DialogTrigger>Open Mason dialog</DialogTrigger>
         <DialogContent>
@@ -279,6 +315,11 @@ render(() => <App />, document.getElementById("root")!);
     await writeFile(
       path.join(app, "src/ssr.tsx"),
       `import { renderToString } from "solid-js/web";
+import {
+  CommandMenu,
+  createCommandMenuStore,
+  type CommandMenuItemData,
+} from "@/components/ui/command-menu";
 import {
   Dialog,
   DialogClose,
@@ -353,6 +394,25 @@ const invoiceColumns: ColumnDef<Invoice, unknown>[] = [
   },
 ];
 
+const commandItems: CommandMenuItemData[] = [
+  {
+    value: "open-dashboard",
+    label: "Open dashboard",
+    description: "Navigate to the dashboard overview.",
+    group: "Navigation",
+    shortcut: "Mod+D",
+    shortcutLabel: "Mod+D",
+  },
+  {
+    value: "create-invoice",
+    label: "Create invoice",
+    description: "Start a new invoice draft.",
+    group: "Actions",
+    shortcut: "Mod+I",
+    shortcutLabel: "Mod+I",
+  },
+];
+
 function App() {
   const form = createForm(() => ({
     defaultValues: {
@@ -371,6 +431,7 @@ function App() {
       sorting: [{ id: "total", desc: true }],
     },
   });
+  const commandMenuStore = createCommandMenuStore({ open: true, query: "invoice" });
 
   return (
     <main>
@@ -396,6 +457,13 @@ function App() {
       <DataTable table={table}>
         <DataTableToolbar table={table} />
       </DataTable>
+      <CommandMenu
+        items={commandItems}
+        store={commandMenuStore}
+        hotkeys={false}
+        portal={{ forceMount: true }}
+        trigger="Open command menu"
+      />
       <Dialog defaultOpen>
         <DialogTrigger>Open Mason dialog</DialogTrigger>
         <DialogContent portal={{ forceMount: true }}>
@@ -438,6 +506,7 @@ for (const expected of [
   "mason-sheet-trigger",
   "mason-text-field-input",
   "mason-select-field-trigger",
+  "mason-command-menu-trigger",
   "mason-data-table-table",
   "mason-data-table-pagination",
   "Ada Lovelace",


### PR DESCRIPTION
## Summary

Adds a Mason `command-menu` registry item that composes Keystone Combobox behavior with TanStack Store state and preview TanStack Hotkeys shortcuts.

## Core changes

- Adds `registry/default/ui/command-menu.tsx` with high-level `CommandMenu`, composable parts, command filtering, grouped items, shortcut display, and a shared command menu store.
- Registers `command-menu` in the default registry and docs registry contract list with metadata covering install, customization, accessibility, limitations, and parity notes.
- Adds root TanStack Store and Hotkeys dependencies used by generated command-menu source.
- Extends the generated example-app verification path to install and render the command menu in CSR and SSR smoke surfaces.

## Known limitations

- Command menu source does not include fuzzy ranking, async search, nested command pages, command history, route-specific discovery, or a final Hotkeys API guarantee.

## Validation

- `bun test packages/mason-registry/src/registry-validation.test.ts`
- `bun run check`
- `bun run verify:example-app`
