### PR TITLE
[codex] Fix Keystone layer stack reactivity

### DIFF
--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -14,6 +14,7 @@ Start with:
 - [Mason Registry RFC](../rfcs/mason-registry.md)
 - [End-state primitive/component inventory](./end-state-primitive-component-inventory.md)
 - [Keystone internal kernel guidance](./keystone-internal-kernel-guidance.md)
+- [Keystone layer stack vertical](./layer-stack-vertical.md)
 - [Controllable state vertical](./controllable-state-vertical.md)
 - [Solid polymorphic `as` rendering](./solid-polymorphic-as-rendering.md)
 - [Accordion and Collapsible vertical](./accordion-collapsible-vertical.md)

--- a/docs/agents/layer-stack-vertical.md
+++ b/docs/agents/layer-stack-vertical.md
@@ -1,0 +1,113 @@
+# Keystone Layer Stack Vertical
+
+## Scope
+
+Issue #78 covers the Keystone `Layer stack` inventory item from
+`docs/agents/end-state-primitive-component-inventory.md`.
+
+The layer stack is a private Keystone overlay kernel. It is consumed by Dialog, Popover,
+Tooltip, Sheet, menu-derived primitives, and `DismissableLayer`; it is not a promoted public
+package subpath yet. That matches `docs/agents/keystone-internal-kernel-guidance.md`, which keeps
+overlay internals private until a later API decision freezes selected helpers.
+
+## Current Audit
+
+Reusable implementation:
+
+- `packages/keystone/src/overlay/layer-kernel.tsx` owns stack registration, top-layer checks,
+  outside pointer/focus dismissal, Escape routing, modal outside hiding, inert application, body
+  scroll locking, body pointer-event blocking, and focus lifecycle integration.
+- `packages/keystone/src/overlay/focus-scope.tsx` owns preventable mount/unmount autofocus,
+  focus trapping, and focus restore.
+- `packages/keystone/src/overlay/dismissal-policy.ts` centralizes modal/non-modal dismissal policy
+  and trigger containment.
+- `packages/keystone/src/overlay/controller.ts` adapts the stack to public primitive parts and
+  exposes `data-layer-id`, `data-layer-index`, and `data-top-layer`.
+- `packages/keystone/src/overlay/layer-kernel.test.tsx` and
+  `packages/keystone/test/overlay-vertical.behavior.test.tsx` cover observable stack behavior.
+
+Reusable docs:
+
+- `apps/docs/src/routes/docs.overlay.popover-tooltip-sheet.tsx` documents the shared overlay
+  vertical through Popover, Tooltip, and Sheet.
+- `apps/docs/src/lib/primitive-contracts.ts` includes the overlay contract summary used by the
+  docs app.
+- `docs/agents/keystone-internals-inspiration-map.md` records the Base UI/Kobalte/Radix parity
+  references that shaped this kernel.
+
+Gaps closed in this pass:
+
+- Layer registration now stores live accessors for modal and pointer-blocking options instead of
+  mount-time snapshots.
+- The stack now resyncs modal hiding, inert state, scroll lock, and pointer blocking when a
+  controlled primitive changes modal behavior after mount.
+- Cleanup now resyncs every document touched by a layer, including the fallback owner document and
+  the eventual mounted element document.
+
+Known limitations:
+
+- Outside hiding uses a direct sibling walk plus native `inert` and `aria-hidden`. It does not yet
+  implement a mutation observer/ref-counted hide-outside utility for nodes inserted while a modal
+  layer is open.
+- Scroll locking is body `overflow: hidden` only. Advanced scrollbar compensation and mobile touch
+  edge cases remain a future prevent-scroll module.
+- The kernel remains private. Public promotion of `@keystone-ui/keystone/overlay` should wait for
+  an ADR/RFC that decides which helpers are stable API.
+
+## End-State Contract
+
+API shape:
+
+- `createOverlayLayerStack()` creates the stack used by overlay roots.
+- `OverlayLayerProvider` shares a stack across nested overlay roots and portal children.
+- `createOverlayLayer(options)` registers a layer and returns `id`, `index()`, and `isTopLayer()`.
+- `DismissableLayer` and public primitives consume the kernel rather than duplicating dismissal or
+  focus behavior.
+
+Behavior:
+
+- Layers are ordered by registration, and only the top layer handles outside pointer/focus and
+  Escape dismissal.
+- User event handlers run before internal dismissal; `preventDefault()` cancels internal close.
+- Modal layers hide/inert outside elements, lock body scroll, and default to outside pointer-event
+  blocking.
+- Non-modal layers may still opt into outside pointer-event blocking.
+- Nested overlays share stack state through Solid context, including across portals.
+- Controlled option changes after mount update the stack's modal and pointer-blocking effects.
+- Cleanup restores body styles and outside element attributes to their prior values.
+
+Accessibility and SSR:
+
+- Modal primitives layered on this kernel expose the appropriate primitive roles and ARIA
+  relationships at their public parts.
+- The stack avoids document access before Solid mount and resyncs again once the layer element is
+  available.
+- Focus entry and restore are preventable through Keystone autofocus events.
+
+Data attributes:
+
+- `data-scope="overlay"` and `data-part="layer"` on the standalone `OverlayLayer` component.
+- `data-layer-id` on public content/layer parts that consume the kernel.
+- `data-layer-index` for stack order.
+- `data-top-layer` on the current top layer.
+- `data-modal` on standalone `OverlayLayer` when modal.
+
+CSS variables:
+
+- Layer stack itself owns no CSS variables.
+- Floating overlays compose this kernel with the floating adapter, which owns
+  `--keystone-anchor-width`, `--keystone-anchor-height`, `--keystone-available-width`,
+  `--keystone-available-height`, and `--keystone-transform-origin`.
+
+## Verification
+
+Focused coverage:
+
+- `packages/keystone/src/overlay/layer-kernel.test.tsx` verifies ordering, top-layer dismissal,
+  pointer-event blocking, modal hiding, cleanup restore, and reactive modal/pointer option changes.
+- `packages/keystone/test/overlay-vertical.behavior.test.tsx` verifies Popover, Tooltip, and Sheet
+  reuse of the layer model for outside dismissal, Escape dismissal, focus restore, and modal
+  pointer blocking.
+
+Status: ready for future overlay work to build on, with the limitations above tracked as separate
+kernel modules rather than rework inside each primitive.

--- a/packages/keystone/src/overlay/layer-kernel.test.tsx
+++ b/packages/keystone/src/overlay/layer-kernel.test.tsx
@@ -7,6 +7,7 @@ function TestLayer(props: {
   children?: JSX.Element;
   id: string;
   modal?: boolean;
+  disableOutsidePointerEvents?: boolean;
   onDismiss?: (event: Event) => void;
   onFocusOutside?: (event: CustomEvent<{ originalEvent: Event }>) => void;
 }) {
@@ -15,6 +16,7 @@ function TestLayer(props: {
     id: props.id,
     element,
     modal: () => props.modal ?? false,
+    disableOutsidePointerEvents: () => props.disableOutsidePointerEvents ?? props.modal ?? false,
     onFocusOutside: props.onFocusOutside,
     onDismiss: props.onDismiss,
   });
@@ -100,5 +102,63 @@ describe("Overlay layer kernel", () => {
     expect(document.body.style.pointerEvents).toBe("");
     expect(document.body.style.overflow).toBe("");
     expect(outside.getAttribute("aria-hidden")).toBeNull();
+  });
+
+  test("reacts to modal and pointer-blocking changes after registration", async () => {
+    let stack!: ReturnType<typeof createOverlayLayerStack>;
+    let setModal!: (modal: boolean) => void;
+    let setBlocksPointer!: (blocksPointer: boolean) => void;
+
+    render(() => {
+      stack = createOverlayLayerStack();
+      const [modal, updateModal] = createSignal(true);
+      const [blocksPointer, updateBlocksPointer] = createSignal(true);
+      setModal = updateModal;
+      setBlocksPointer = updateBlocksPointer;
+
+      return (
+        <OverlayLayerProvider stack={stack}>
+          <button data-testid="outside">Outside</button>
+          <TestLayer id="layer" modal={modal()} disableOutsidePointerEvents={blocksPointer()} />
+        </OverlayLayerProvider>
+      );
+    });
+    await settled();
+
+    const outside = document.querySelector<HTMLElement>("[data-testid='outside']")!;
+    const layer = document.querySelector<HTMLElement>("[data-testid='layer']")!;
+
+    expect(stack.layers()).toEqual([{ id: "layer", modal: true }]);
+    expect(document.body.style.overflow).toBe("hidden");
+    expect(document.body.style.pointerEvents).toBe("none");
+    expect(outside.getAttribute("aria-hidden")).toBe("true");
+    expect(layer.style.pointerEvents).toBe("auto");
+
+    setModal(false);
+    await settled();
+
+    expect(stack.layers()).toEqual([{ id: "layer", modal: false }]);
+    expect(document.body.style.overflow).toBe("");
+    expect(outside.getAttribute("aria-hidden")).toBeNull();
+    expect(document.body.style.pointerEvents).toBe("none");
+
+    setBlocksPointer(false);
+    await settled();
+
+    expect(document.body.style.pointerEvents).toBe("");
+
+    setModal(true);
+    await settled();
+
+    expect(stack.layers()).toEqual([{ id: "layer", modal: true }]);
+    expect(document.body.style.overflow).toBe("hidden");
+    expect(document.body.style.pointerEvents).toBe("");
+    expect(outside.getAttribute("aria-hidden")).toBe("true");
+
+    setBlocksPointer(true);
+    await settled();
+
+    expect(document.body.style.pointerEvents).toBe("none");
+    expect(outside.getAttribute("aria-hidden")).toBe("true");
   });
 });

--- a/packages/keystone/src/overlay/layer-kernel.tsx
+++ b/packages/keystone/src/overlay/layer-kernel.tsx
@@ -1,5 +1,6 @@
 import {
   createContext,
+  createEffect,
   createMemo,
   createSignal,
   onCleanup,
@@ -25,9 +26,11 @@ export type OverlayLayerEntry = {
   modal: boolean;
 };
 
-type OverlayLayerRegistration = OverlayLayerEntry & {
+type OverlayLayerRegistration = {
+  id: string;
   element?: HTMLElement;
   getElement?: Accessor<HTMLElement | undefined>;
+  modal: Accessor<boolean>;
   disableOutsidePointerEvents: Accessor<boolean>;
 };
 
@@ -103,7 +106,7 @@ export function createOverlayLayerStack(): OverlayLayerStack {
   const layers = createMemo(() =>
     registrations().map((layer) => ({
       id: layer.id,
-      modal: layer.modal,
+      modal: layer.modal(),
     })),
   );
   const indexOf = (id: string) => registrations().findIndex((layer) => layer.id === id);
@@ -167,7 +170,7 @@ export function createOverlayLayerStack(): OverlayLayerStack {
 
     state.hiddenElements = [];
 
-    const modalLayers = registrations().filter((layer) => layer.modal);
+    const modalLayers = registrations().filter((layer) => layer.modal());
     const topModal = modalLayers[modalLayers.length - 1];
     const topModalElement = untrack(() => topModal?.getElement?.() ?? topModal?.element);
 
@@ -235,12 +238,31 @@ export function createOverlayLayer(options: CreateOverlayLayerOptions): OverlayL
   const stack = options.stack ?? useContext(OverlayLayerContext) ?? getDefaultOverlayLayerStack();
   const modal = () => options.modal?.() ?? false;
   const isTopLayer = createMemo(() => stack.isTopLayer(options.id));
+  const ownerDocuments = new Set<Document>();
+  let syncLayerDocument: ((document: Document) => void) | undefined;
+
+  createEffect(() => {
+    const element = options.element?.();
+    modal();
+    options.disableOutsidePointerEvents?.();
+
+    if (!syncLayerDocument) {
+      return;
+    }
+
+    syncLayerDocument(getOwnerDocument(element));
+  });
 
   onMount(() => {
     const ownerDocument = getOwnerDocument(options.element?.());
+    syncLayerDocument = (document: Document) => {
+      ownerDocuments.add(document);
+      stack.syncPointerEvents(document);
+      stack.syncModalState(document);
+    };
     const unregister = stack.register({
       id: options.id,
-      modal: modal(),
+      modal,
       element: options.element?.(),
       getElement: options.element,
       disableOutsidePointerEvents: () => options.disableOutsidePointerEvents?.() ?? modal(),
@@ -248,8 +270,7 @@ export function createOverlayLayer(options: CreateOverlayLayerOptions): OverlayL
     let isReady = false;
     let restoreFocus: (() => void) | undefined;
 
-    stack.syncPointerEvents(ownerDocument);
-    stack.syncModalState(ownerDocument);
+    syncLayerDocument(ownerDocument);
     scheduleMicrotask(() => {
       isReady = true;
 
@@ -267,8 +288,7 @@ export function createOverlayLayer(options: CreateOverlayLayerOptions): OverlayL
         onMountAutoFocus: options.onMountAutoFocus,
         onUnmountAutoFocus: options.onUnmountAutoFocus,
       });
-      stack.syncPointerEvents(getOwnerDocument(element));
-      stack.syncModalState(getOwnerDocument(element));
+      syncLayerDocument?.(getOwnerDocument(element));
     });
 
     const element = options.element?.();
@@ -343,8 +363,11 @@ export function createOverlayLayer(options: CreateOverlayLayerOptions): OverlayL
       ownerDocument.removeEventListener("keydown", onKeyDown);
       restoreFocus?.();
       unregister();
-      stack.syncPointerEvents(ownerDocument);
-      stack.syncModalState(ownerDocument);
+      ownerDocuments.add(ownerDocument);
+      for (const document of ownerDocuments) {
+        stack.syncPointerEvents(document);
+        stack.syncModalState(document);
+      }
     });
   });
 


### PR DESCRIPTION
## Summary

Completes the Keystone layer stack pass for issue #78 by making layer registration react to controlled modal and pointer-blocking changes after mount. Adds the durable audit/status note for the layer stack contract and links it from the agent docs index.

## Core changes

- Stores live modal accessors in overlay layer registrations and reads current values when exposing stack entries or selecting the top modal layer.
- Resyncs modal hiding, inert state, scroll lock, and pointer-event blocking when layer options or mounted elements change.
- Resyncs every document touched by a layer during cleanup.
- Adds regression coverage for reactive modal and pointer-blocking changes.
- Documents the layer stack audit, end-state contract, verification coverage, and known limitations.

## Behavior / invariants

- Only current modal layers participate in modal hiding and scroll lock.
- Explicit pointer-blocking overrides remain independent from modal state.
- Layer cleanup restores body styles and outside element attributes through the stack sync path.

## Known limitations

- Outside hiding still uses the current direct sibling walk with `inert` and `aria-hidden`; mutation-observer/ref-counted hide-outside remains deferred.
- Scroll locking remains body `overflow: hidden` only; scrollbar compensation and mobile touch handling remain future prevent-scroll work.
- The layer stack remains a private Keystone kernel rather than a promoted public overlay subpath.

## Validation

- `bun --filter @keystone-ui/keystone test`
- `bun --filter @keystone-ui/keystone check-types`
- `bun run check`
