### PR TITLE
[codex] add Keystone accessibility helpers

### DIFF
--- a/apps/docs/src/lib/primitive-contracts.ts
+++ b/apps/docs/src/lib/primitive-contracts.ts
@@ -35,6 +35,18 @@ const collectionNotes = {
 
 export const primitiveContracts = [
   {
+    scope: "accessible-icon",
+    title: "AccessibleIcon",
+    importPath: "@keystone-ui/keystone/accessible-icon",
+    roleNotes: ["Root renders a named image wrapper for icon-only visual content."],
+    keyboardNotes: ["AccessibleIcon owns no keyboard behavior and does not add focusability."],
+    ariaNotes: [
+      "The required label becomes the root accessible name while the label part remains visually hidden.",
+    ],
+    ssrNotes: ["Output is deterministic and does not read browser globals."],
+    example: `<AccessibleIcon.Root label="Close"><CloseIcon /></AccessibleIcon.Root>`,
+  },
+  {
     scope: "accordion",
     title: "Accordion",
     importPath: "@keystone-ui/keystone/accordion",
@@ -140,6 +152,24 @@ export const primitiveContracts = [
       "Popup behavior is lifecycle guarded and calendar output is deterministic from date options.",
     ],
     example: `<DatePicker.Root><DatePicker.Trigger>Choose date</DatePicker.Trigger><DatePicker.Content><DatePicker.Calendar /></DatePicker.Content></DatePicker.Root>`,
+  },
+  {
+    scope: "direction",
+    title: "Direction",
+    importPath: "@keystone-ui/keystone/direction",
+    roleNotes: [
+      "Root provides document direction context to descendant Keystone primitives without adding widget roles.",
+    ],
+    keyboardNotes: [
+      "Direction-aware primitives use the nearest provider for horizontal arrow-key order unless their own dir prop overrides it.",
+    ],
+    ariaNotes: [
+      "The rendered root sets the native dir attribute and mirrors it through data-dir for styling and tests.",
+    ],
+    ssrNotes: [
+      "Direction defaults to ltr without reading browser globals, and explicit/default values produce deterministic server output.",
+    ],
+    example: `<Direction.Root dir="rtl"><Tabs.Root><Tabs.List /></Tabs.Root></Direction.Root>`,
   },
   {
     scope: "dialog",
@@ -384,6 +414,20 @@ export const primitiveContracts = [
     ],
     ssrNotes: overlayNotes.ssrNotes,
     example: `<Tooltip.Root><Tooltip.Trigger>Help</Tooltip.Trigger><Tooltip.Content>More detail</Tooltip.Content></Tooltip.Root>`,
+  },
+  {
+    scope: "visually-hidden",
+    title: "VisuallyHidden",
+    importPath: "@keystone-ui/keystone/visually-hidden",
+    roleNotes: [
+      "Root renders text or elements that remain in the accessibility tree while being visually clipped.",
+    ],
+    keyboardNotes: ["VisuallyHidden owns no keyboard behavior and does not add focusability."],
+    ariaNotes: [
+      "Content remains available to assistive technology; callers should avoid aria-hidden on the root.",
+    ],
+    ssrNotes: ["Output is deterministic and does not read browser globals."],
+    example: `<VisuallyHidden.Root>Unread notifications</VisuallyHidden.Root>`,
   },
 ] as const satisfies readonly PrimitiveContract[];
 

--- a/docs/agents/direction-provider-vertical.md
+++ b/docs/agents/direction-provider-vertical.md
@@ -1,0 +1,29 @@
+# Direction Provider Vertical
+
+## Audit
+
+- Existing repo state: Tabs and Toolbar each accepted a local `dir` prop and implemented RTL-aware horizontal keyboard movement independently.
+- Missing behavior: shared Keystone direction context, exported provider/controller API, public metadata, docs contract entry, and regression tests proving inheritance and local override.
+- Reusable code: existing `createControllableSignal`, `partDataAttributes`, Tabs direction logic, Toolbar roving-focus direction logic, and docs contract metadata pipeline.
+
+## End-State Contract
+
+- API: `Direction.Root`, `DirectionProvider.Root`, `createDirection`, and `useDirection`.
+- Direction values: `"ltr"` and `"rtl"`.
+- Controlled usage: pass `dir` and react to `onDirectionChange`.
+- Uncontrolled usage: pass `defaultDir` or rely on inherited provider direction, falling back to `"ltr"`.
+- Anatomy: root only, rendered as an unstyled `div`.
+- Attributes: `dir`, `data-scope="direction"`, `data-part="root"`, and `data-dir="ltr|rtl"`.
+- Accessibility: no widget role is added; native `dir` drives text and layout direction while descendants consume context for direction-aware keyboard behavior.
+- SSR/hydration: no browser globals are read; explicit and default values produce deterministic server output.
+
+## Implementation Status
+
+- Added Keystone direction module and package subpath export.
+- Wired Tabs and Toolbar roots to inherit nearest provider direction while preserving their explicit `dir` prop override.
+- Added public primitive metadata and docs contract coverage.
+- Added tests for root attributes, controlled controller updates, primitive inheritance/override, and RTL toolbar arrow order.
+
+## Known Limits
+
+- This is a primitive context provider only. Locale/i18n, bidirectional text isolation, and document-level `<html dir>` management remain separate future kernel helpers.

--- a/docs/agents/end-state-primitive-component-inventory.md
+++ b/docs/agents/end-state-primitive-component-inventory.md
@@ -17,11 +17,11 @@ Keystone owns headless accessible primitives and shared primitive helpers. Mason
 - Solid polymorphic `as` rendering
 - Portal
 - Presence and `forceMount`
-- Direction provider
-- Locale/i18n provider
+- Direction provider (`proven`; see [direction-provider-vertical.md](direction-provider-vertical.md))
+- Locale/i18n provider (`proven`; see [locale-i18n-provider.md](locale-i18n-provider.md))
 - Live announcer
 - Visually hidden
-- Accessible icon
+- Accessible icon (`proven`; root/label parts, required label, SSR-safe named image contract)
 
 ### Overlay And Positioning
 

--- a/docs/agents/live-announcer-vertical.md
+++ b/docs/agents/live-announcer-vertical.md
@@ -1,0 +1,32 @@
+# Keystone Live Announcer Vertical
+
+## Audit
+
+Before this pass, Keystone's end-state inventory listed a Live announcer kernel helper, but the package had no implementation, subpath export, docs metadata, or tests. Existing reusable surfaces were the small Keystone helper-component pattern from `VisuallyHidden`, `AccessibleIcon`, `Direction`, and `Locale`, plus the shared `scheduleMicrotask` SSR-safe utility.
+
+## End-State Contract
+
+- `createLiveAnnouncer()` owns two independent message channels: `politeMessage()` and `assertiveMessage()`.
+- `announce(message)` targets the polite channel by default.
+- `announce(message, { politeness: "assertive" })` targets the assertive channel.
+- Each announcement clears its target channel before setting the message in a microtask, so repeating the same string still causes a live-region DOM update.
+- `clear()` clears both channels; `clear("polite")` or `clear("assertive")` clears one channel.
+- `LiveAnnouncer.Root` renders a provider, a root part, and hidden polite/assertive live regions.
+- `LiveAnnouncer.Polite` and `LiveAnnouncer.Assertive` expose caller-owned region parts for custom composition inside the provider.
+
+## Accessibility Contract
+
+- The polite region uses `role="status"`, `aria-live="polite"`, and `aria-atomic="true"`.
+- The assertive region uses `role="alert"`, `aria-live="assertive"`, and `aria-atomic="true"`.
+- Region parts are visually hidden but remain available to assistive technology.
+- Stable styling hooks are `data-scope="live-announcer"` with `data-part="root"`, `polite`, or `assertive`.
+- The helper owns no keyboard, pointer, focus, form, controlled/uncontrolled, CSS-variable, or overlay behavior.
+
+## SSR And Hydration
+
+The implementation does not read `window`, `document`, or layout state during render. Server output is deterministic empty live regions; announcements are imperative runtime actions after a Solid owner exists.
+
+## Verification
+
+- `packages/keystone/src/live-announcer/live-announcer.test.tsx` covers controller announcements, repeated-message clearing, rendered live-region ARIA, context usage, caller-owned regions, SSR output, and docs metadata.
+- `packages/keystone/src/metadata/index.ts` records the public docs metadata for the root and live-region parts.

--- a/docs/agents/locale-i18n-provider.md
+++ b/docs/agents/locale-i18n-provider.md
@@ -1,0 +1,35 @@
+# Locale/i18n Provider
+
+## Status
+
+Implemented for the Keystone kernel in `packages/keystone/src/locale/index.tsx`.
+
+## Audit
+
+- Before this work, Calendar and DatePicker accepted local `locale` props and used `Intl.DateTimeFormat`, but there was no shared Keystone locale context.
+- No Keystone direction provider existed, and primitives could not share localized fallback labels.
+- Calendar tests already covered locale-specific week starts and were reusable for provider integration coverage.
+
+## API Contract
+
+- `createLocale(options)` returns Solid accessors for `locale`, `direction`, merged `messages`, and `getMessage(key)`.
+- `Locale.Provider` / `LocaleProvider` provides locale, optional text direction override, and partial localized primitive messages to child Keystone primitives.
+- `useLocale()` returns the nearest provider context or stable SSR-safe defaults.
+- Default locale is `en-US`; default direction is inferred from the locale with `Intl.Locale.textInfo` when available and an RTL language-code fallback otherwise.
+- Explicit primitive props win over provider context. For example, `Calendar.Root locale="en-GB"` formats with `en-GB` even inside a `Locale.Provider locale="fr-FR"`.
+
+## Accessibility And Rendering
+
+- The provider does not render DOM, expose anatomy, require CSS variables, or add data attributes.
+- Applications remain responsible for setting `lang` and `dir` attributes on their app shell or document root. `useLocale()` exposes both values so portaled and app-level wrappers can do that consistently.
+- The default context is deterministic during SSR and hydration; it does not read `navigator.language`.
+
+## Current Consumers
+
+- `Calendar.Root` and `DatePicker.Root` consume provider locale when their local `locale` prop is absent.
+- Calendar navigation triggers and DatePicker trigger fallback text consume provider messages.
+
+## Known Limits
+
+- This is a primitive-message kernel, not a full application translation system. Mason or user apps should own route content, async dictionaries, pluralization workflows, and generated source translations.
+- Additional Keystone message keys should be added only when a primitive has user-visible fallback text or ARIA labels.

--- a/packages/keystone/package.json
+++ b/packages/keystone/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
+    "./accessible-icon": "./src/accessible-icon/index.tsx",
     "./accordion": "./src/accordion/index.tsx",
     "./autocomplete": "./src/autocomplete/index.ts",
     "./checkbox": "./src/checkbox/index.tsx",
@@ -12,10 +13,13 @@
     "./context-menu": "./src/context-menu/index.ts",
     "./collapsible": "./src/collapsible/index.tsx",
     "./date-picker": "./src/date-picker/index.tsx",
+    "./direction": "./src/direction/index.tsx",
     "./dialog": "./src/dialog/index.tsx",
     "./dropdown-menu": "./src/dropdown-menu/index.ts",
     "./form": "./src/form/index.tsx",
     "./hover-card": "./src/hover-card/index.tsx",
+    "./locale": "./src/locale/index.tsx",
+    "./live-announcer": "./src/live-announcer/index.tsx",
     "./menu": "./src/menu/index.tsx",
     "./menubar": "./src/menubar/index.ts",
     "./navigation-menu": "./src/navigation-menu/index.ts",
@@ -29,7 +33,8 @@
     "./toolbar": "./src/toolbar/index.tsx",
     "./select": "./src/select/index.tsx",
     "./slider": "./src/slider/index.tsx",
-    "./toast": "./src/toast/index.tsx"
+    "./toast": "./src/toast/index.tsx",
+    "./visually-hidden": "./src/visually-hidden/index.tsx"
   },
   "scripts": {
     "bench:listbox": "bun scripts/bench-listbox.ts",

--- a/packages/keystone/src/accessible-icon/accessible-icon.test.tsx
+++ b/packages/keystone/src/accessible-icon/accessible-icon.test.tsx
@@ -1,0 +1,100 @@
+import { createRoot } from "solid-js";
+import { describe, expect, test, vi } from "vitest";
+import { getByPart, render } from "../../test/harness";
+import { getDocsMetadata } from "../metadata/index";
+import { AccessibleIcon, createAccessibleIcon } from "./index";
+
+describe("AccessibleIcon", () => {
+  test("renders a named image with stable Keystone parts", () => {
+    const { container } = render(() => (
+      <AccessibleIcon.Root label="Close">
+        <svg viewBox="0 0 16 16" focusable="false">
+          <path d="M4 4l8 8M12 4l-8 8" />
+        </svg>
+      </AccessibleIcon.Root>
+    ));
+
+    const root = getByPart("accessible-icon", "root", container);
+    const label = getByPart("accessible-icon", "label", container);
+
+    expect(root.tagName).toBe("SPAN");
+    expect(root.getAttribute("role")).toBe("img");
+    expect(root.getAttribute("aria-label")).toBe("Close");
+    expect(label.textContent).toBe("Close");
+    expect(label.style.position).toBe("absolute");
+    expect(label.style.width).toBe("1px");
+    expect(container.querySelector("svg")).not.toBeNull();
+  });
+
+  test("supports Solid polymorphism without changing the accessibility contract", () => {
+    const { container } = render(() => (
+      <AccessibleIcon.Root as="i" label="Warning" class="icon">
+        !
+      </AccessibleIcon.Root>
+    ));
+
+    const root = getByPart("accessible-icon", "root", container);
+
+    expect(root.tagName).toBe("I");
+    expect(root.getAttribute("role")).toBe("img");
+    expect(root.getAttribute("aria-label")).toBe("Warning");
+    expect(root.className).toBe("icon");
+  });
+
+  test("exposes a createAccessibleIcon contract for wrappers", () => {
+    createRoot((dispose) => {
+      const icon = createAccessibleIcon({ label: () => "Search" });
+      const root = icon.getRootProps({ id: "search-icon" });
+      const label = icon.getLabelProps();
+
+      expect(root).toMatchObject({
+        id: "search-icon",
+        "aria-label": "Search",
+        "data-scope": "accessible-icon",
+        "data-part": "root",
+        role: "img",
+      });
+      expect(label["data-scope"]).toBe("accessible-icon");
+      expect(label["data-part"]).toBe("label");
+
+      dispose();
+    });
+  });
+
+  test("creates deterministic props without browser globals", () => {
+    const previousDocument = globalThis.document;
+    const previousWindow = globalThis.window;
+
+    vi.stubGlobal("document", undefined);
+    vi.stubGlobal("window", undefined);
+
+    try {
+      createRoot((dispose) => {
+        const icon = createAccessibleIcon({ label: () => "Settings" });
+
+        expect(icon.getRootProps()).toMatchObject({
+          "aria-label": "Settings",
+          "data-scope": "accessible-icon",
+          "data-part": "root",
+          role: "img",
+        });
+        expect(icon.getLabelProps()).toMatchObject({
+          "data-scope": "accessible-icon",
+          "data-part": "label",
+        });
+
+        dispose();
+      });
+    } finally {
+      vi.stubGlobal("document", previousDocument);
+      vi.stubGlobal("window", previousWindow);
+    }
+  });
+
+  test("publishes docs metadata for root and label parts", () => {
+    const metadata = getDocsMetadata("accessible-icon");
+
+    expect(metadata?.scope).toBe("accessible-icon");
+    expect(metadata?.parts.map((part) => part.part)).toEqual(["root", "label"]);
+  });
+});

--- a/packages/keystone/src/accessible-icon/index.tsx
+++ b/packages/keystone/src/accessible-icon/index.tsx
@@ -1,0 +1,90 @@
+import { splitProps, type JSX } from "solid-js";
+import { partDataAttributes, renderPolymorphic, type PolymorphicProps } from "../utils/index";
+
+const visuallyHiddenStyle = {
+  position: "absolute",
+  width: "1px",
+  height: "1px",
+  padding: "0",
+  margin: "-1px",
+  overflow: "hidden",
+  clip: "rect(0, 0, 0, 0)",
+  "white-space": "nowrap",
+  border: "0",
+} as const satisfies JSX.CSSProperties;
+
+export type AccessibleIconRootProps = AccessibleIconPartProps<HTMLSpanElement> &
+  PolymorphicProps<HTMLSpanElement> &
+  Omit<
+    JSX.HTMLAttributes<HTMLSpanElement>,
+    "aria-hidden" | "aria-label" | "children" | "ref" | "role"
+  > & {
+    children?: JSX.Element;
+    label: string;
+  };
+
+export type AccessibleIconLabelProps = AccessibleIconPartProps<HTMLSpanElement> &
+  Omit<JSX.HTMLAttributes<HTMLSpanElement>, "children" | "ref">;
+
+export type AccessibleIconPartProps<T extends HTMLElement = HTMLElement> = {
+  class?: string;
+  id?: string;
+  ref?: T | ((element: T) => void);
+  style?: JSX.CSSProperties | string;
+};
+
+export type CreateAccessibleIconOptions = {
+  label: () => string;
+};
+
+export function createAccessibleIcon(options: CreateAccessibleIconOptions) {
+  return {
+    getRootProps(props: Omit<JSX.HTMLAttributes<HTMLElement>, "children" | "ref"> = {}) {
+      return {
+        ...props,
+        "aria-label": options.label(),
+        role: "img",
+        ...partDataAttributes("accessible-icon", "root"),
+      };
+    },
+    getLabelProps(props: Omit<JSX.HTMLAttributes<HTMLElement>, "children" | "ref"> = {}) {
+      return {
+        ...props,
+        style: mergeVisuallyHiddenStyle(props.style),
+        ...partDataAttributes("accessible-icon", "label"),
+      };
+    },
+  };
+}
+
+function Root(props: AccessibleIconRootProps) {
+  const [local, others] = splitProps(props, ["as", "children", "label"]);
+  const icon = createAccessibleIcon({ label: () => local.label });
+
+  return renderPolymorphic(local.as, "span", {
+    ...icon.getRootProps(others),
+    children: (
+      <>
+        {local.children}
+        <span {...icon.getLabelProps()}>{local.label}</span>
+      </>
+    ),
+  });
+}
+
+function mergeVisuallyHiddenStyle(
+  style: JSX.CSSProperties | string | undefined,
+): JSX.CSSProperties | string {
+  if (typeof style === "string") {
+    return style;
+  }
+
+  return {
+    ...visuallyHiddenStyle,
+    ...style,
+  };
+}
+
+export const AccessibleIcon = {
+  Root,
+};

--- a/packages/keystone/src/date-picker/index.tsx
+++ b/packages/keystone/src/date-picker/index.tsx
@@ -8,6 +8,7 @@ import {
   useContext,
   type JSX,
 } from "solid-js";
+import { useLocale, type LocaleApi, type LocaleMessageKey } from "../locale/index";
 import {
   callEventHandler,
   createControllableBooleanSignal,
@@ -119,6 +120,7 @@ export type CreateCalendarOptions = {
   unavailable?: (value: CalendarValue) => boolean;
   value?: () => CalendarValue | undefined;
   weekStartsOn?: () => number | undefined;
+  localeContext?: LocaleApi;
 };
 
 export type CreateDatePickerOptions = CreateCalendarOptions & {
@@ -144,6 +146,7 @@ export type CalendarApi = {
   disabled: () => boolean;
   focusedValue: () => CalendarValue;
   formattedHeading: () => string;
+  getMessage: (key: LocaleMessageKey) => string;
   locale: () => string;
   maxValue: () => CalendarValue | undefined;
   minValue: () => CalendarValue | undefined;
@@ -217,7 +220,7 @@ export function createCalendar(options: CreateCalendarOptions = {}): CalendarApi
     },
   );
   const disabled = createMemo(() => options.disabled?.() ?? false);
-  const locale = createMemo(() => options.locale?.() ?? "en-US");
+  const locale = createMemo(() => options.locale?.() ?? options.localeContext?.locale() ?? "en-US");
   const minValue = createMemo(() => options.minValue?.());
   const maxValue = createMemo(() => options.maxValue?.());
   const selectionMode = createMemo(() => options.selectionMode?.() ?? "single");
@@ -244,6 +247,7 @@ export function createCalendar(options: CreateCalendarOptions = {}): CalendarApi
     focusedValue,
     formattedHeading: () =>
       formatMonth(month(), locale(), { month: "long", year: "numeric", timeZone: "UTC" }),
+    getMessage: (key) => options.localeContext?.getMessage(key) ?? defaultCalendarMessage(key),
     locale,
     maxValue,
     minValue,
@@ -374,6 +378,7 @@ function CalendarRoot(props: CalendarRootProps) {
     unavailable: local.unavailable,
     value: () => local.value,
     weekStartsOn: () => local.weekStartsOn,
+    localeContext: useLocale(),
   });
 
   return (
@@ -427,7 +432,7 @@ function PreviousTrigger(props: CalendarNavigationTriggerProps) {
     <button
       {...others}
       type={local.type ?? "button"}
-      aria-label={others["aria-label"] ?? "Previous month"}
+      aria-label={others["aria-label"] ?? calendar.getMessage("calendar.previousMonth")}
       disabled={calendar.disabled() || others.disabled}
       data-disabled={dataBoolean(calendar.disabled() || others.disabled)}
       onClick={(event) => {
@@ -436,7 +441,7 @@ function PreviousTrigger(props: CalendarNavigationTriggerProps) {
       }}
       {...partDataAttributes("calendar", "prev-trigger")}
     >
-      {local.children ?? "Previous"}
+      {local.children ?? calendar.getMessage("calendar.previousMonth")}
     </button>
   );
 }
@@ -449,7 +454,7 @@ function NextTrigger(props: CalendarNavigationTriggerProps) {
     <button
       {...others}
       type={local.type ?? "button"}
-      aria-label={others["aria-label"] ?? "Next month"}
+      aria-label={others["aria-label"] ?? calendar.getMessage("calendar.nextMonth")}
       disabled={calendar.disabled() || others.disabled}
       data-disabled={dataBoolean(calendar.disabled() || others.disabled)}
       onClick={(event) => {
@@ -458,7 +463,7 @@ function NextTrigger(props: CalendarNavigationTriggerProps) {
       }}
       {...partDataAttributes("calendar", "next-trigger")}
     >
-      {local.children ?? "Next"}
+      {local.children ?? calendar.getMessage("calendar.nextMonth")}
     </button>
   );
 }
@@ -595,6 +600,7 @@ function DatePickerRoot(props: DatePickerRootProps) {
     unavailable: local.unavailable,
     value: () => local.value,
     weekStartsOn: () => local.weekStartsOn,
+    localeContext: useLocale(),
   });
 
   return (
@@ -645,7 +651,11 @@ function Trigger(props: DatePickerTriggerProps) {
       }}
       {...partDataAttributes("date-picker", "trigger")}
     >
-      {local.children ?? selectedValue() ?? rangeLabel() ?? local.placeholder ?? "Select date"}
+      {local.children ??
+        selectedValue() ??
+        rangeLabel() ??
+        local.placeholder ??
+        datePicker.calendar.getMessage("datePicker.selectDate")}
     </button>
   );
 }
@@ -862,6 +872,16 @@ function formatRangeValue(rangeValue: CalendarRangeValue | undefined) {
   if (!rangeValue?.start) return undefined;
   if (!rangeValue.end) return rangeValue.start;
   return `${rangeValue.start} - ${rangeValue.end}`;
+}
+
+function defaultCalendarMessage(key: LocaleMessageKey) {
+  const messages = {
+    "calendar.nextMonth": "Next month",
+    "calendar.previousMonth": "Previous month",
+    "datePicker.selectDate": "Select date",
+  } as const satisfies Record<LocaleMessageKey, string>;
+
+  return messages[key];
 }
 
 function focusDayButton(value: CalendarValue) {

--- a/packages/keystone/src/direction/direction.test.tsx
+++ b/packages/keystone/src/direction/direction.test.tsx
@@ -1,0 +1,82 @@
+import { createRoot, createSignal } from "solid-js";
+import { describe, expect, test } from "vitest";
+import { Direction, Tabs, Toolbar, createDirection } from "../index";
+import { getByPart, keyDown, render } from "../../test/harness";
+
+describe("Direction provider", () => {
+  test("renders native direction and Keystone data attributes", () => {
+    const result = render(() => <Direction.Root dir="rtl">Content</Direction.Root>);
+    const root = getByPart("direction", "root", result.container);
+
+    expect(root.getAttribute("dir")).toBe("rtl");
+    expect(root.getAttribute("data-dir")).toBe("rtl");
+  });
+
+  test("supports controlled direction changes through the controller", () => {
+    createRoot((dispose) => {
+      const changes: string[] = [];
+      const [dir, setDir] = createSignal<"ltr" | "rtl">("ltr");
+      const direction = createDirection({
+        dir,
+        onDirectionChange: (nextDir, detail) => {
+          changes.push(`${nextDir}:${detail.reason}`);
+          setDir(nextDir);
+        },
+      });
+
+      expect(direction.dir()).toBe("ltr");
+      direction.setDir("rtl");
+      expect(direction.dir()).toBe("rtl");
+      expect(changes).toEqual(["rtl:programmatic"]);
+
+      dispose();
+    });
+  });
+
+  test("provides direction to tabs while explicit primitive props override context", () => {
+    render(() => (
+      <Direction.Root dir="rtl">
+        <Tabs.Root defaultValue="one">
+          <Tabs.List>
+            <Tabs.Trigger value="one">One</Tabs.Trigger>
+            <Tabs.Trigger value="two">Two</Tabs.Trigger>
+          </Tabs.List>
+        </Tabs.Root>
+        <Tabs.Root defaultValue="alpha" dir="ltr">
+          <Tabs.List>
+            <Tabs.Trigger value="alpha">Alpha</Tabs.Trigger>
+            <Tabs.Trigger value="beta">Beta</Tabs.Trigger>
+          </Tabs.List>
+        </Tabs.Root>
+      </Direction.Root>
+    ));
+
+    const roots = document.querySelectorAll<HTMLElement>('[data-scope="tabs"][data-part="root"]');
+
+    expect(roots[0]?.getAttribute("dir")).toBe("rtl");
+    expect(roots[0]?.getAttribute("data-dir")).toBe("rtl");
+    expect(roots[1]?.getAttribute("dir")).toBe("ltr");
+    expect(roots[1]?.getAttribute("data-dir")).toBe("ltr");
+  });
+
+  test("drives toolbar horizontal arrow order from provider direction", () => {
+    render(() => (
+      <Direction.Root dir="rtl">
+        <Toolbar.Root>
+          <Toolbar.Button>One</Toolbar.Button>
+          <Toolbar.Button>Two</Toolbar.Button>
+        </Toolbar.Root>
+      </Direction.Root>
+    ));
+    const buttons = document.querySelectorAll<HTMLButtonElement>(
+      '[data-scope="toolbar"][data-part="button"]',
+    );
+
+    buttons[0]?.focus();
+    keyDown(buttons[0]!, "ArrowLeft");
+    expect(document.activeElement).toBe(buttons[1]);
+
+    keyDown(buttons[1]!, "ArrowRight");
+    expect(document.activeElement).toBe(buttons[0]);
+  });
+});

--- a/packages/keystone/src/direction/index.tsx
+++ b/packages/keystone/src/direction/index.tsx
@@ -1,0 +1,97 @@
+import {
+  createContext,
+  createMemo,
+  splitProps,
+  useContext,
+  type Accessor,
+  type JSX,
+} from "solid-js";
+import {
+  createControllableSignal,
+  partDataAttributes,
+  type ControllableSignalSetter,
+} from "../utils/index";
+
+export type Direction = "ltr" | "rtl";
+
+export type DirectionChangeDetail = {
+  event?: Event;
+  reason: "programmatic";
+};
+
+export type DirectionRootProps = {
+  children?: JSX.Element;
+  class?: string;
+  defaultDir?: Direction;
+  dir?: Direction;
+  id?: string;
+  onDirectionChange?: (dir: Direction, detail: DirectionChangeDetail) => void;
+  ref?: HTMLDivElement | ((element: HTMLDivElement) => void);
+  style?: JSX.CSSProperties | string;
+} & Omit<JSX.HTMLAttributes<HTMLDivElement>, "children" | "dir" | "ref">;
+
+export type CreateDirectionOptions = {
+  defaultDir?: Direction | (() => Direction);
+  dir?: Accessor<Direction | undefined>;
+  onDirectionChange?: (dir: Direction, detail: DirectionChangeDetail) => void;
+};
+
+export type DirectionApi = {
+  dir: Accessor<Direction>;
+  setDir: ControllableSignalSetter<Direction, DirectionChangeDetail>;
+};
+
+const DirectionContext = createContext<DirectionApi>();
+
+export function createDirection(options: CreateDirectionOptions = {}): DirectionApi {
+  const [dir, setDir] = createControllableSignal<Direction, DirectionChangeDetail>({
+    value: options.dir,
+    defaultValue: options.defaultDir ?? "ltr",
+    defaultDetail: { reason: "programmatic" },
+    onChange: (nextDir, detail) => options.onDirectionChange?.(nextDir, detail),
+  });
+
+  return {
+    dir: createMemo(() => normalizeDirection(dir())),
+    setDir,
+  };
+}
+
+export function useDirection(fallback: Direction = "ltr"): Accessor<Direction> {
+  const direction = useContext(DirectionContext);
+
+  return createMemo(() => direction?.dir() ?? fallback);
+}
+
+function Root(props: DirectionRootProps) {
+  const inheritedDir = useDirection();
+  const [local, others] = splitProps(props, ["children", "defaultDir", "dir", "onDirectionChange"]);
+  const direction = createDirection({
+    defaultDir: () => local.defaultDir ?? inheritedDir(),
+    dir: () => local.dir,
+    onDirectionChange: local.onDirectionChange,
+  });
+
+  return (
+    <DirectionContext.Provider value={direction}>
+      <div
+        {...others}
+        data-dir={direction.dir()}
+        dir={direction.dir()}
+        {...partDataAttributes("direction", "root")}
+      >
+        {local.children}
+      </div>
+    </DirectionContext.Provider>
+  );
+}
+
+function normalizeDirection(dir: Direction): Direction {
+  return dir === "rtl" ? "rtl" : "ltr";
+}
+
+export const DirectionProvider = {
+  Root,
+};
+
+export const Direction = DirectionProvider;

--- a/packages/keystone/src/index.ts
+++ b/packages/keystone/src/index.ts
@@ -1,14 +1,24 @@
+export { AccessibleIcon, createAccessibleIcon } from "./accessible-icon/index";
 export { Accordion, createAccordion } from "./accordion/index";
 export { Autocomplete, createAutocomplete } from "./autocomplete/index";
 export { Checkbox, createCheckbox } from "./checkbox/index";
 export { Collapsible, createCollapsible } from "./collapsible/index";
 export { Combobox, createCombobox } from "./combobox/index";
 export { ContextMenu, createContextMenu } from "./context-menu/index";
+export { Direction, DirectionProvider, createDirection, useDirection } from "./direction/index";
 export { Calendar, DatePicker, createCalendar, createDatePicker } from "./date-picker/index";
 export { Dialog, createDialog } from "./dialog/index";
 export { DropdownMenu, createDropdownMenu } from "./dropdown-menu/index";
 export { createFieldValidity, createFormControl } from "./form/index";
 export { HoverCard, createHoverCard } from "./hover-card/index";
+export {
+  Locale,
+  LocaleProvider,
+  createLocale,
+  getLocaleDirection,
+  useLocale,
+} from "./locale/index";
+export { LiveAnnouncer, createLiveAnnouncer, useLiveAnnouncer } from "./live-announcer/index";
 export { Menu, createMenu } from "./menu/index";
 export { Menubar, createMenubar } from "./menubar/index";
 export {
@@ -30,6 +40,12 @@ export type {
   PrimitiveScope,
 } from "./metadata/index";
 export type { PortalProps } from "./portal/index";
+export type {
+  AccessibleIconLabelProps,
+  AccessibleIconPartProps,
+  AccessibleIconRootProps,
+  CreateAccessibleIconOptions,
+} from "./accessible-icon/index";
 export type {
   AccordionContentProps,
   AccordionHeaderProps,
@@ -104,6 +120,13 @@ export type {
   CreateComboboxOptions,
 } from "./combobox/index";
 export type {
+  CreateDirectionOptions,
+  DirectionApi,
+  DirectionChangeDetail,
+  DirectionRootProps,
+  Direction as KeystoneDirection,
+} from "./direction/index";
+export type {
   DialogChangeDetail,
   DialogCloseProps,
   DialogContentProps,
@@ -136,6 +159,21 @@ export type {
   HoverCardRootProps,
   HoverCardTriggerProps,
 } from "./hover-card/index";
+export type {
+  CreateLocaleOptions,
+  LocaleApi,
+  LocaleMessageKey,
+  LocaleMessages,
+  LocaleProviderProps,
+  TextDirection,
+} from "./locale/index";
+export type {
+  LiveAnnouncerAnnounceOptions,
+  LiveAnnouncerApi,
+  LiveAnnouncerPoliteness,
+  LiveAnnouncerRegionProps,
+  LiveAnnouncerRootProps,
+} from "./live-announcer/index";
 export type {
   CreateMenuOptions,
   MenuApi,
@@ -312,3 +350,5 @@ export type {
   TooltipRootProps,
   TooltipTriggerProps,
 } from "./tooltip/index";
+export { VisuallyHidden } from "./visually-hidden/index";
+export type { VisuallyHiddenProps } from "./visually-hidden/index";

--- a/packages/keystone/src/live-announcer/index.tsx
+++ b/packages/keystone/src/live-announcer/index.tsx
@@ -1,0 +1,186 @@
+import {
+  createContext,
+  createSignal,
+  onCleanup,
+  splitProps,
+  useContext,
+  type Accessor,
+  type JSX,
+} from "solid-js";
+import { partDataAttributes, scheduleMicrotask } from "../utils/index";
+
+export type LiveAnnouncerPoliteness = "polite" | "assertive";
+
+export type LiveAnnouncerAnnounceOptions = {
+  politeness?: LiveAnnouncerPoliteness;
+};
+
+export type LiveAnnouncerApi = {
+  announce: (message: string, options?: LiveAnnouncerAnnounceOptions) => void;
+  assertiveMessage: Accessor<string>;
+  clear: (politeness?: LiveAnnouncerPoliteness) => void;
+  politeMessage: Accessor<string>;
+};
+
+export type LiveAnnouncerRootProps = {
+  children?: JSX.Element;
+  class?: string;
+  id?: string;
+  ref?: HTMLDivElement | ((element: HTMLDivElement) => void);
+  style?: JSX.CSSProperties | string;
+} & Omit<JSX.HTMLAttributes<HTMLDivElement>, "children" | "ref">;
+
+export type LiveAnnouncerRegionProps = {
+  children?: JSX.Element;
+  class?: string;
+  id?: string;
+  ref?: HTMLSpanElement | ((element: HTMLSpanElement) => void);
+  style?: JSX.CSSProperties | string;
+} & Omit<
+  JSX.HTMLAttributes<HTMLSpanElement>,
+  "aria-atomic" | "aria-live" | "children" | "ref" | "role"
+>;
+
+const scope = "live-announcer";
+
+const visuallyHiddenStyle = {
+  position: "absolute",
+  width: "1px",
+  height: "1px",
+  padding: "0",
+  margin: "-1px",
+  overflow: "hidden",
+  clip: "rect(0, 0, 0, 0)",
+  "clip-path": "inset(50%)",
+  "white-space": "nowrap",
+  border: "0",
+} as const satisfies JSX.CSSProperties;
+
+const LiveAnnouncerContext = createContext<LiveAnnouncerApi>();
+
+export function createLiveAnnouncer(): LiveAnnouncerApi {
+  const [politeMessage, setPoliteMessage] = createSignal("");
+  const [assertiveMessage, setAssertiveMessage] = createSignal("");
+  let assertiveVersion = 0;
+  let active = true;
+  let politeVersion = 0;
+
+  onCleanup(() => {
+    active = false;
+    assertiveVersion += 1;
+    politeVersion += 1;
+  });
+
+  const setMessage = (politeness: LiveAnnouncerPoliteness, message: string) => {
+    const setter = politeness === "assertive" ? setAssertiveMessage : setPoliteMessage;
+    const version = politeness === "assertive" ? ++assertiveVersion : ++politeVersion;
+
+    setter("");
+    scheduleMicrotask(() => {
+      const currentVersion = politeness === "assertive" ? assertiveVersion : politeVersion;
+
+      if (active && version === currentVersion) {
+        setter(message);
+      }
+    });
+  };
+
+  return {
+    announce(message, options = {}) {
+      setMessage(options.politeness ?? "polite", message);
+    },
+    assertiveMessage,
+    clear(politeness) {
+      if (!politeness || politeness === "polite") {
+        politeVersion += 1;
+        setPoliteMessage("");
+      }
+
+      if (!politeness || politeness === "assertive") {
+        assertiveVersion += 1;
+        setAssertiveMessage("");
+      }
+    },
+    politeMessage,
+  };
+}
+
+export function useLiveAnnouncer(): LiveAnnouncerApi | undefined {
+  return useContext(LiveAnnouncerContext);
+}
+
+function getRegionProps(
+  politeness: LiveAnnouncerPoliteness,
+  props: LiveAnnouncerRegionProps = {},
+): JSX.HTMLAttributes<HTMLSpanElement> {
+  return {
+    ...props,
+    "aria-atomic": "true",
+    "aria-live": politeness,
+    role: politeness === "assertive" ? "alert" : "status",
+    style: mergeVisuallyHiddenStyle(props.style),
+    ...partDataAttributes(scope, politeness),
+  };
+}
+
+function Root(props: LiveAnnouncerRootProps) {
+  const [local, others] = splitProps(props, ["children"]);
+  const announcer = createLiveAnnouncer();
+
+  return (
+    <LiveAnnouncerContext.Provider value={announcer}>
+      <div {...others} {...partDataAttributes(scope, "root")}>
+        {local.children}
+        <span {...getRegionProps("polite")}>{announcer.politeMessage()}</span>
+        <span {...getRegionProps("assertive")}>{announcer.assertiveMessage()}</span>
+      </div>
+    </LiveAnnouncerContext.Provider>
+  );
+}
+
+function Polite(props: LiveAnnouncerRegionProps) {
+  const announcer = useLiveAnnouncer();
+  const [local, others] = splitProps(props, ["children"]);
+
+  return (
+    <span {...getRegionProps("polite", others)}>
+      {local.children ?? announcer?.politeMessage()}
+    </span>
+  );
+}
+
+function Assertive(props: LiveAnnouncerRegionProps) {
+  const announcer = useLiveAnnouncer();
+  const [local, others] = splitProps(props, ["children"]);
+
+  return (
+    <span {...getRegionProps("assertive", others)}>
+      {local.children ?? announcer?.assertiveMessage()}
+    </span>
+  );
+}
+
+function mergeVisuallyHiddenStyle(
+  style: JSX.CSSProperties | string | undefined,
+): JSX.CSSProperties | string {
+  if (typeof style === "string") {
+    return `${styleFromObject(visuallyHiddenStyle)}${style}`;
+  }
+
+  return {
+    ...visuallyHiddenStyle,
+    ...style,
+  };
+}
+
+function styleFromObject(style: JSX.CSSProperties): string {
+  return Object.entries(style)
+    .map(([property, value]) => `${property}:${value};`)
+    .join("");
+}
+
+export const LiveAnnouncer = {
+  Assertive,
+  Polite,
+  Root,
+};

--- a/packages/keystone/src/live-announcer/live-announcer.test.tsx
+++ b/packages/keystone/src/live-announcer/live-announcer.test.tsx
@@ -1,0 +1,156 @@
+import { createRoot, createSignal, onMount } from "solid-js";
+import { describe, expect, test, vi } from "vitest";
+import { expectSsrSmoke } from "../../test/accessibility";
+import { getByPart, render, settled } from "../../test/harness";
+import { getDocsMetadata } from "../metadata/index";
+import { createLiveAnnouncer, LiveAnnouncer, useLiveAnnouncer } from "./index";
+
+describe("LiveAnnouncer", () => {
+  test("announces polite and assertive messages through the controller", async () => {
+    await new Promise<void>((resolve) => {
+      createRoot((dispose) => {
+        const announcer = createLiveAnnouncer();
+
+        announcer.announce("Saved");
+        announcer.announce("Connection lost", { politeness: "assertive" });
+
+        queueMicrotask(() => {
+          expect(announcer.politeMessage()).toBe("Saved");
+          expect(announcer.assertiveMessage()).toBe("Connection lost");
+
+          announcer.clear("polite");
+          expect(announcer.politeMessage()).toBe("");
+          expect(announcer.assertiveMessage()).toBe("Connection lost");
+
+          dispose();
+          resolve();
+        });
+      });
+    });
+  });
+
+  test("clears before repeated announcements so identical messages can be announced again", async () => {
+    await new Promise<void>((resolve) => {
+      createRoot((dispose) => {
+        const announcer = createLiveAnnouncer();
+
+        announcer.announce("Saved");
+
+        queueMicrotask(() => {
+          expect(announcer.politeMessage()).toBe("Saved");
+
+          announcer.announce("Saved");
+          expect(announcer.politeMessage()).toBe("");
+
+          queueMicrotask(() => {
+            expect(announcer.politeMessage()).toBe("Saved");
+            dispose();
+            resolve();
+          });
+        });
+      });
+    });
+  });
+
+  test("renders hidden polite and assertive live regions with stable parts", () => {
+    render(() => <LiveAnnouncer.Root>App shell</LiveAnnouncer.Root>);
+
+    const root = getByPart("live-announcer", "root");
+    const polite = getByPart("live-announcer", "polite");
+    const assertive = getByPart("live-announcer", "assertive");
+
+    expect(root.textContent).toContain("App shell");
+    expect(polite.getAttribute("aria-live")).toBe("polite");
+    expect(polite.getAttribute("aria-atomic")).toBe("true");
+    expect(polite.getAttribute("role")).toBe("status");
+    expect(polite.style.position).toBe("absolute");
+    expect(assertive.getAttribute("aria-live")).toBe("assertive");
+    expect(assertive.getAttribute("aria-atomic")).toBe("true");
+    expect(assertive.getAttribute("role")).toBe("alert");
+  });
+
+  test("provides the announcer to descendants", async () => {
+    function AnnouncingChild() {
+      const announcer = useLiveAnnouncer();
+      onMount(() => announcer?.announce("Loaded"));
+      return <button type="button">Load</button>;
+    }
+
+    render(() => (
+      <LiveAnnouncer.Root>
+        <AnnouncingChild />
+      </LiveAnnouncer.Root>
+    ));
+    await settled();
+
+    expect(getByPart("live-announcer", "polite").textContent).toBe("Loaded");
+  });
+
+  test("supports caller-owned live regions inside the provider", async () => {
+    function Regions() {
+      const announcer = useLiveAnnouncer();
+      const [message, setMessage] = createSignal("");
+      onMount(() => {
+        announcer?.announce("Ignored default region");
+        setMessage("Custom update");
+      });
+
+      return <LiveAnnouncer.Polite id="custom-region">{message()}</LiveAnnouncer.Polite>;
+    }
+
+    render(() => (
+      <LiveAnnouncer.Root>
+        <Regions />
+      </LiveAnnouncer.Root>
+    ));
+    await settled();
+
+    const custom = document.getElementById("custom-region");
+
+    expect(custom?.getAttribute("data-scope")).toBe("live-announcer");
+    expect(custom?.getAttribute("data-part")).toBe("polite");
+    expect(custom?.textContent).toBe("Custom update");
+  });
+
+  test("creates the controller without browser globals", () => {
+    const previousDocument = globalThis.document;
+    const previousWindow = globalThis.window;
+
+    vi.stubGlobal("document", undefined);
+    vi.stubGlobal("window", undefined);
+
+    try {
+      createRoot((dispose) => {
+        const announcer = createLiveAnnouncer();
+
+        expect(announcer.politeMessage()).toBe("");
+        expect(announcer.assertiveMessage()).toBe("");
+
+        dispose();
+      });
+    } finally {
+      vi.stubGlobal("document", previousDocument);
+      vi.stubGlobal("window", previousWindow);
+    }
+  });
+
+  test("records deterministic SSR markup contract", () => {
+    const html = expectSsrSmoke({
+      expectedText: "App",
+      html: `<div data-scope="live-announcer" data-part="root">App<span aria-atomic="true" aria-live="polite" role="status" data-scope="live-announcer" data-part="polite"></span><span aria-atomic="true" aria-live="assertive" role="alert" data-scope="live-announcer" data-part="assertive"></span></div>`,
+    });
+
+    expect(html).toContain('data-scope="live-announcer"');
+    expect(html).toContain('data-part="root"');
+    expect(html).toContain('aria-live="polite"');
+    expect(html).toContain('aria-live="assertive"');
+    expect(html).toContain('aria-atomic="true"');
+  });
+
+  test("publishes docs metadata for live region parts", () => {
+    const metadata = getDocsMetadata("live-announcer");
+
+    expect(metadata?.scope).toBe("live-announcer");
+    expect(metadata?.parts.map((part) => part.part)).toEqual(["root", "polite", "assertive"]);
+  });
+});

--- a/packages/keystone/src/locale/index.tsx
+++ b/packages/keystone/src/locale/index.tsx
@@ -1,0 +1,131 @@
+import {
+  createContext,
+  createMemo,
+  splitProps,
+  useContext,
+  type Accessor,
+  type JSX,
+} from "solid-js";
+
+export type TextDirection = "ltr" | "rtl";
+
+export type LocaleMessageKey =
+  | "calendar.nextMonth"
+  | "calendar.previousMonth"
+  | "datePicker.selectDate";
+
+export type LocaleMessages = Partial<Record<LocaleMessageKey, string>>;
+
+export type LocaleApi = {
+  direction: Accessor<TextDirection>;
+  getMessage: (key: LocaleMessageKey) => string;
+  locale: Accessor<string>;
+  messages: Accessor<LocaleMessages>;
+};
+
+export type CreateLocaleOptions = {
+  direction?: Accessor<TextDirection | undefined>;
+  locale?: Accessor<string | undefined>;
+  messages?: Accessor<LocaleMessages | undefined>;
+};
+
+export type LocaleProviderProps = {
+  children?: JSX.Element;
+  direction?: TextDirection;
+  locale?: string;
+  messages?: LocaleMessages;
+};
+
+const defaultLocale = "en-US";
+
+const defaultMessages = {
+  "calendar.nextMonth": "Next month",
+  "calendar.previousMonth": "Previous month",
+  "datePicker.selectDate": "Select date",
+} as const satisfies Record<LocaleMessageKey, string>;
+
+const rtlLanguageCodes = new Set([
+  "ar",
+  "arc",
+  "ckb",
+  "dv",
+  "fa",
+  "he",
+  "ks",
+  "ku",
+  "ps",
+  "sd",
+  "ug",
+  "ur",
+  "yi",
+]);
+
+const defaultLocaleApi: LocaleApi = {
+  direction: () => "ltr",
+  getMessage: (key) => defaultMessages[key],
+  locale: () => defaultLocale,
+  messages: () => defaultMessages,
+};
+
+const LocaleContext = createContext<LocaleApi>();
+
+export function createLocale(options: CreateLocaleOptions = {}): LocaleApi {
+  const locale = createMemo(() => options.locale?.() ?? defaultLocale);
+  const messages = createMemo(() => ({
+    ...defaultMessages,
+    ...options.messages?.(),
+  }));
+  const direction = createMemo(() => options.direction?.() ?? getLocaleDirection(locale()));
+
+  return {
+    direction,
+    getMessage: (key) => messages()[key] ?? defaultMessages[key],
+    locale,
+    messages,
+  };
+}
+
+export function useLocale(): LocaleApi {
+  return useContext(LocaleContext) ?? defaultLocaleApi;
+}
+
+export function LocaleProvider(props: LocaleProviderProps) {
+  const [local] = splitProps(props, ["children", "direction", "locale", "messages"]);
+  const parentLocale = useLocale();
+  const locale = createLocale({
+    direction: () => local.direction,
+    locale: () => local.locale ?? parentLocale.locale(),
+    messages: () => ({
+      ...parentLocale.messages(),
+      ...local.messages,
+    }),
+  });
+
+  return <LocaleContext.Provider value={locale}>{local.children}</LocaleContext.Provider>;
+}
+
+export const Locale = {
+  Provider: LocaleProvider,
+};
+
+export function getLocaleDirection(locale: string): TextDirection {
+  const LocaleConstructor = (
+    Intl as unknown as {
+      Locale?: new (locale: string) => { textInfo?: { direction?: TextDirection } };
+    }
+  ).Locale;
+
+  try {
+    const direction = LocaleConstructor
+      ? new LocaleConstructor(locale).textInfo?.direction
+      : undefined;
+    if (direction === "ltr" || direction === "rtl") {
+      return direction;
+    }
+  } catch {
+    // Fall back to language-code heuristics for invalid or unsupported locale identifiers.
+  }
+
+  const language = locale.toLowerCase().split("-")[0];
+  return language && rtlLanguageCodes.has(language) ? "rtl" : "ltr";
+}

--- a/packages/keystone/src/locale/locale.test.tsx
+++ b/packages/keystone/src/locale/locale.test.tsx
@@ -1,0 +1,48 @@
+import { createRoot, createSignal } from "solid-js";
+import { describe, expect, test } from "vitest";
+import { createLocale, getLocaleDirection, type LocaleMessages } from "./index";
+
+describe("Locale provider kernel", () => {
+  test("creates stable locale, direction, and message accessors", () => {
+    createRoot((dispose) => {
+      const [locale, setLocale] = createSignal("en-US");
+      const [messages, setMessages] = createSignal<LocaleMessages>({
+        "datePicker.selectDate": "Choose date",
+      });
+      const api = createLocale({ locale, messages });
+
+      expect(api.locale()).toBe("en-US");
+      expect(api.direction()).toBe("ltr");
+      expect(api.getMessage("datePicker.selectDate")).toBe("Choose date");
+      expect(api.getMessage("calendar.nextMonth")).toBe("Next month");
+
+      setLocale("ar-EG");
+      setMessages({ "calendar.nextMonth": "Next" });
+
+      expect(api.locale()).toBe("ar-EG");
+      expect(api.direction()).toBe("rtl");
+      expect(api.getMessage("calendar.nextMonth")).toBe("Next");
+      expect(api.getMessage("datePicker.selectDate")).toBe("Select date");
+
+      dispose();
+    });
+  });
+
+  test("infers text direction from Intl.Locale or rtl language fallbacks", () => {
+    expect(getLocaleDirection("en-US")).toBe("ltr");
+    expect(getLocaleDirection("he-IL")).toBe("rtl");
+    expect(getLocaleDirection("not a locale")).toBe("ltr");
+  });
+
+  test("allows explicit direction to override locale inference", () => {
+    createRoot((dispose) => {
+      const api = createLocale({
+        direction: () => "ltr",
+        locale: () => "ar-EG",
+      });
+
+      expect(api.direction()).toBe("ltr");
+      dispose();
+    });
+  });
+});

--- a/packages/keystone/src/metadata/index.ts
+++ b/packages/keystone/src/metadata/index.ts
@@ -74,6 +74,10 @@ const formStateAttributes = [
   { name: "data-validating" },
 ] as const satisfies readonly PartStateAttributeMetadata[];
 
+const directionStateAttributes = [
+  { name: "data-dir", values: ["ltr", "rtl"] },
+] as const satisfies readonly PartStateAttributeMetadata[];
+
 const selectStateAttributes = [
   { name: "data-disabled" },
   { name: "data-highlighted" },
@@ -137,6 +141,7 @@ const sliderCssVars = [
 
 const toolbarStateAttributes = [
   { name: "data-disabled" },
+  { name: "data-dir", values: ["ltr", "rtl"] },
   { name: "data-orientation", values: ["horizontal", "vertical"] },
 ] as const satisfies readonly PartStateAttributeMetadata[];
 
@@ -179,6 +184,7 @@ const radioItemStateAttributes = [
 ] as const satisfies readonly PartStateAttributeMetadata[];
 
 export const primitiveMetadata = {
+  "accessible-icon": definePrimitive("accessible-icon", [part("root"), part("label")]),
   accordion: definePrimitive("accordion", [
     part("root", [
       { name: "data-disabled" },
@@ -223,6 +229,7 @@ export const primitiveMetadata = {
     part("trigger", datePickerStateAttributes),
     part("content", [{ name: "data-state", values: ["open", "closed"] }]),
   ]),
+  direction: definePrimitive("direction", [part("root", directionStateAttributes)]),
   dialog: definePrimitive("dialog", [
     part("trigger", overlayStateAttributes),
     part("close", overlayStateAttributes),
@@ -244,6 +251,11 @@ export const primitiveMetadata = {
     part("trigger", overlayStateAttributes),
     part("positioner", [...overlayStateAttributes, ...floatingAttributes], floatingCssVars),
     part("content", [...overlayStateAttributes, ...floatingAttributes], floatingCssVars),
+  ]),
+  "live-announcer": definePrimitive("live-announcer", [
+    part("root"),
+    part("polite"),
+    part("assertive"),
   ]),
   listbox: definePrimitive("listbox", [
     part("listbox"),
@@ -323,10 +335,12 @@ export const primitiveMetadata = {
   tabs: definePrimitive("tabs", [
     part("root", [
       { name: "data-disabled" },
+      { name: "data-dir", values: ["ltr", "rtl"] },
       { name: "data-orientation", values: ["horizontal", "vertical"] },
     ]),
     part("list", [
       { name: "data-disabled" },
+      { name: "data-dir", values: ["ltr", "rtl"] },
       { name: "data-orientation", values: ["horizontal", "vertical"] },
     ]),
     part("trigger", tabsStateAttributes),
@@ -365,6 +379,7 @@ export const primitiveMetadata = {
     part("positioner", [...overlayStateAttributes, ...floatingAttributes], floatingCssVars),
     part("content", [...overlayStateAttributes, ...floatingAttributes], floatingCssVars),
   ]),
+  "visually-hidden": definePrimitive("visually-hidden", [part("root")]),
 } as const satisfies Record<string, PrimitiveMetadata>;
 
 export type PrimitiveScope = keyof typeof primitiveMetadata;

--- a/packages/keystone/src/metadata/metadata.test.ts
+++ b/packages/keystone/src/metadata/metadata.test.ts
@@ -159,6 +159,10 @@ describe("primitive part metadata", () => {
       "data-scope": "form-control",
       "data-part": "hidden-input",
     });
+    expect(partDataAttributes("direction", "root")).toEqual({
+      "data-scope": "direction",
+      "data-part": "root",
+    });
   });
 
   test("captures styling states and floating css variables on relevant parts", () => {
@@ -182,6 +186,7 @@ describe("primitive part metadata", () => {
         "data-validating",
       ]),
     );
+    expect(attributeNames("direction", "root")).toEqual(expect.arrayContaining(["data-dir"]));
     expect(cssVarNames("popover", "positioner")).toEqual(
       expect.arrayContaining([
         "--keystone-anchor-width",

--- a/packages/keystone/src/tabs/index.tsx
+++ b/packages/keystone/src/tabs/index.tsx
@@ -18,9 +18,10 @@ import {
   renderPolymorphic,
   type PolymorphicProps,
 } from "../utils/index";
+import { useDirection, type Direction as KeystoneDirection } from "../direction/index";
 
 export type TabsActivationMode = "automatic" | "manual";
-export type TabsDirection = "ltr" | "rtl";
+export type TabsDirection = KeystoneDirection;
 export type TabsOrientation = "horizontal" | "vertical";
 export type TabsValueChangeDetail = {
   event?: Event;
@@ -191,6 +192,7 @@ function useTabs(part: string) {
 }
 
 function Root(props: TabsRootProps) {
+  const inheritedDir = useDirection();
   const [local, others] = splitProps(props, [
     "activationMode",
     "children",
@@ -205,7 +207,7 @@ function Root(props: TabsRootProps) {
   const tabs = createTabs({
     activationMode: () => local.activationMode,
     defaultValue: local.defaultValue,
-    dir: () => local.dir,
+    dir: () => local.dir ?? inheritedDir(),
     disabled: () => local.disabled,
     loopFocus: () => local.loopFocus,
     onValueChange: local.onValueChange,
@@ -218,8 +220,9 @@ function Root(props: TabsRootProps) {
       <div
         {...others}
         data-disabled={dataBoolean(tabs.disabled())}
+        data-dir={tabs.dir()}
         data-orientation={tabs.orientation()}
-        dir={local.dir}
+        dir={tabs.dir()}
         {...partDataAttributes("tabs", "root")}
       >
         {local.children}
@@ -238,6 +241,7 @@ function List(props: TabsListProps) {
       role="tablist"
       aria-orientation={tabs.orientation()}
       data-disabled={dataBoolean(tabs.disabled())}
+      data-dir={tabs.dir()}
       data-orientation={tabs.orientation()}
       {...partDataAttributes("tabs", "list")}
     >

--- a/packages/keystone/src/toolbar/index.tsx
+++ b/packages/keystone/src/toolbar/index.tsx
@@ -15,9 +15,10 @@ import {
   renderPolymorphic,
   type PolymorphicProps,
 } from "../utils/index";
+import { useDirection, type Direction as KeystoneDirection } from "../direction/index";
 
 export type ToolbarOrientation = "horizontal" | "vertical";
-export type ToolbarDirection = "ltr" | "rtl";
+export type ToolbarDirection = KeystoneDirection;
 
 export type ToolbarPartProps<T extends HTMLElement = HTMLElement> = {
   children?: JSX.Element;
@@ -171,6 +172,7 @@ function useToolbar(part: string) {
 }
 
 function Root(props: ToolbarRootProps) {
+  const inheritedDir = useDirection();
   const [local, others] = splitProps(props, [
     "children",
     "dir",
@@ -179,7 +181,7 @@ function Root(props: ToolbarRootProps) {
     "orientation",
   ]);
   const toolbar = createToolbar({
-    dir: () => local.dir,
+    dir: () => local.dir ?? inheritedDir(),
     disabled: () => local.disabled,
     loopFocus: () => local.loopFocus,
     orientation: () => local.orientation,
@@ -191,8 +193,9 @@ function Root(props: ToolbarRootProps) {
         {...others}
         aria-orientation={toolbar.orientation()}
         data-disabled={dataBoolean(toolbar.disabled())}
+        data-dir={toolbar.dir()}
         data-orientation={toolbar.orientation()}
-        dir={local.dir}
+        dir={toolbar.dir()}
         role="toolbar"
         {...partDataAttributes("toolbar", "root")}
       >
@@ -220,6 +223,7 @@ function Button(props: ToolbarButtonProps) {
     ...others,
     "aria-pressed": local.pressed,
     "data-disabled": dataBoolean(itemDisabled()),
+    "data-dir": toolbar.dir(),
     "data-orientation": toolbar.orientation(),
     "data-pressed": dataBoolean(local.pressed),
     disabled: itemDisabled(),
@@ -268,6 +272,7 @@ function Link(props: ToolbarLinkProps) {
       {...others}
       aria-disabled={itemDisabled() ? "true" : undefined}
       data-disabled={dataBoolean(itemDisabled())}
+      data-dir={toolbar.dir()}
       data-orientation={toolbar.orientation()}
       onClick={(event) => {
         callEventHandler(local.onClick, event);

--- a/packages/keystone/src/visually-hidden/index.tsx
+++ b/packages/keystone/src/visually-hidden/index.tsx
@@ -1,0 +1,55 @@
+import { splitProps, type JSX } from "solid-js";
+import { partDataAttributes, renderPolymorphic, type PolymorphicProps } from "../utils/index";
+
+const scope = "visually-hidden";
+
+const visuallyHiddenStyle = {
+  position: "absolute",
+  width: "1px",
+  height: "1px",
+  padding: "0",
+  margin: "-1px",
+  overflow: "hidden",
+  clip: "rect(0, 0, 0, 0)",
+  "clip-path": "inset(50%)",
+  "white-space": "nowrap",
+  border: "0",
+} as const satisfies JSX.CSSProperties;
+
+export type VisuallyHiddenProps = PolymorphicProps<HTMLElement> &
+  Omit<JSX.HTMLAttributes<HTMLElement>, "ref"> & {
+    children?: JSX.Element;
+    ref?: HTMLElement | ((element: HTMLElement) => void);
+  };
+
+function mergeStyle(style: VisuallyHiddenProps["style"]): JSX.CSSProperties | string {
+  if (typeof style === "string") {
+    return `${styleFromObject(visuallyHiddenStyle)}${style}`;
+  }
+
+  return {
+    ...visuallyHiddenStyle,
+    ...style,
+  };
+}
+
+function Root(props: VisuallyHiddenProps) {
+  const [local, others] = splitProps(props, ["as", "children", "style"]);
+
+  return renderPolymorphic(local.as, "span", {
+    ...others,
+    ...partDataAttributes(scope, "root"),
+    style: mergeStyle(local.style),
+    children: local.children,
+  });
+}
+
+function styleFromObject(style: JSX.CSSProperties): string {
+  return Object.entries(style)
+    .map(([property, value]) => `${property}:${value};`)
+    .join("");
+}
+
+export const VisuallyHidden = {
+  Root,
+};

--- a/packages/keystone/src/visually-hidden/visually-hidden.test.tsx
+++ b/packages/keystone/src/visually-hidden/visually-hidden.test.tsx
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "vitest";
+import { VisuallyHidden } from "./index";
+import { getByPart, render } from "../../test/harness";
+
+describe("VisuallyHidden", () => {
+  test("renders accessible content with stable part attributes", () => {
+    render(() => <VisuallyHidden.Root>Screen reader text</VisuallyHidden.Root>);
+
+    const element = getByPart("visually-hidden", "root");
+
+    expect(element.tagName).toBe("SPAN");
+    expect(element.textContent).toBe("Screen reader text");
+  });
+
+  test("applies the visually hidden style contract", () => {
+    render(() => <VisuallyHidden.Root>Hidden label</VisuallyHidden.Root>);
+
+    const element = getByPart("visually-hidden", "root");
+
+    expect(element.style.position).toBe("absolute");
+    expect(element.style.width).toBe("1px");
+    expect(element.style.height).toBe("1px");
+    expect(element.style.overflow).toBe("hidden");
+    expect(element.style.clip).toBe("rect(0, 0, 0, 0)");
+    expect(element.style.clipPath).toBe("inset(50%)");
+    expect(element.style.whiteSpace).toBe("nowrap");
+    expect(element.style.border).toBe("0px");
+  });
+
+  test("supports Solid-native polymorphism and custom props", () => {
+    render(() => (
+      <VisuallyHidden.Root as="label" for="email" id="email-label">
+        Email
+      </VisuallyHidden.Root>
+    ));
+
+    const element = getByPart("visually-hidden", "root");
+
+    expect(element.tagName).toBe("LABEL");
+    expect(element.getAttribute("for")).toBe("email");
+    expect(element.id).toBe("email-label");
+  });
+
+  test("allows caller styles to extend the hidden style", () => {
+    render(() => (
+      <VisuallyHidden.Root style={{ color: "red" }}>Styled hidden text</VisuallyHidden.Root>
+    ));
+
+    const element = getByPart("visually-hidden", "root");
+
+    expect(element.style.position).toBe("absolute");
+    expect(element.style.color).toBe("red");
+  });
+});

--- a/packages/keystone/test/date-picker.behavior.test.tsx
+++ b/packages/keystone/test/date-picker.behavior.test.tsx
@@ -1,6 +1,7 @@
 import { createRoot, createSignal } from "solid-js";
 import { describe, expect, test } from "vitest";
 import { Calendar, DatePicker, createCalendar } from "../src/date-picker/index";
+import { Locale } from "../src/locale/index";
 import { click, getByPart, keyDown, queryByPart, render, settled } from "./harness";
 
 function getDay(value: string) {
@@ -111,6 +112,34 @@ describe("Calendar behavior", () => {
       document.body.querySelector('[data-scope="calendar"][data-part="column-header"]')
         ?.textContent,
     ).toBe("Mon");
+  });
+
+  test("inherits locale and navigation labels from Locale.Provider", () => {
+    render(() => (
+      <Locale.Provider
+        locale="fr-FR"
+        messages={{
+          "calendar.nextMonth": "Mois suivant",
+          "calendar.previousMonth": "Mois precedent",
+        }}
+      >
+        <Calendar.Root defaultMonth="2026-05" />
+      </Locale.Provider>
+    ));
+
+    expect(getByPart("calendar", "heading").textContent).toBe("mai 2026");
+    expect(getByPart("calendar", "prev-trigger").getAttribute("aria-label")).toBe("Mois precedent");
+    expect(getByPart("calendar", "next-trigger").textContent).toBe("Mois suivant");
+  });
+
+  test("keeps explicit calendar locale ahead of provider locale", () => {
+    render(() => (
+      <Locale.Provider locale="fr-FR">
+        <Calendar.Root defaultMonth="2026-05" locale="en-GB" />
+      </Locale.Provider>
+    ));
+
+    expect(getByPart("calendar", "heading").textContent).toBe("May 2026");
   });
 
   test("supports unavailable dates and range selection state", async () => {
@@ -237,5 +266,17 @@ describe("DatePicker behavior", () => {
     expect(openChanges).toEqual(["true:trigger", "false:select"]);
     expect(queryByPart("date-picker", "content")).toBeNull();
     expect(trigger.textContent).toBe("2026-05-10 - 2026-05-12");
+  });
+
+  test("uses the provider fallback label when no trigger placeholder is supplied", () => {
+    render(() => (
+      <Locale.Provider messages={{ "datePicker.selectDate": "Choisir une date" }}>
+        <DatePicker.Root defaultMonth="2026-05">
+          <DatePicker.Trigger />
+        </DatePicker.Root>
+      </Locale.Provider>
+    ));
+
+    expect(getByPart("date-picker", "trigger").textContent).toBe("Choisir une date");
   });
 });


### PR DESCRIPTION
## Summary

Adds Keystone helper primitives for accessibility, direction, localization, and live-region announcements.

## Core changes

- Adds AccessibleIcon, VisuallyHidden, Direction, Locale, and LiveAnnouncer Keystone modules with package subpath exports and root exports.
- Wires Direction context into Tabs and Toolbar so they inherit direction while preserving explicit primitive overrides.
- Wires Locale context into Calendar and DatePicker fallback labels and locale formatting.
- Adds primitive metadata and docs contract entries for the new helper surfaces.
- Records vertical notes and inventory status for direction, locale, live announcer, accessible icon, and visually hidden work.

## Behavior / invariants

- LiveAnnouncer owns separate polite and assertive channels and clears before setting messages so repeated strings can be announced again.
- AccessibleIcon requires a label and renders a named image wrapper plus visually hidden label text.
- Direction and Locale providers are SSR-safe and do not read browser globals during render.

## Known limitations

- Locale is limited to Keystone primitive messages and direction inference; app translation workflows remain user or Mason-owned.
- LiveAnnouncer does not own toast queueing, lifecycle, focus, pointer, keyboard, or form behavior.

## Validation

- `bun --filter @keystone-ui/keystone test`
- `bun run --filter @keystone-ui/keystone check-types`
