### PR TITLE
[codex] Close selected 0.1 kernel parity issues

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ This repository is the early Keystone UI monorepo. Treat `Keystone` and `Mason` 
 - [docs/adr/](docs/adr/): durable decisions.
 - [docs/agents/](docs/agents/): agent/work tracking conventions.
 - [docs/adr/0003-mason-tanstack-app-layer.md](docs/adr/0003-mason-tanstack-app-layer.md): TanStack app-layer decision for Mason.
+- [docs/adr/0004-keystone-kernel-api-boundary.md](docs/adr/0004-keystone-kernel-api-boundary.md): public/private Keystone kernel API boundary.
 - [docs/prd/keystone-mason-foundation.md](docs/prd/keystone-mason-foundation.md): foundation PRD and product flywheel.
 - [docs/prd/keystone-internals-inspiration-parity.md](docs/prd/keystone-internals-inspiration-parity.md): Keystone kernel parity PRD.
 - [docs/agents/issue-triage-spine.md](docs/agents/issue-triage-spine.md): GitHub issue milestones, labels, and 0.1 active spine.
@@ -41,6 +42,7 @@ This repository is the early Keystone UI monorepo. Treat `Keystone` and `Mason` 
 
 - Prefer Solid-native APIs over React-shaped translations.
 - Keystone primitives must be styling-agnostic and expose stable `data-scope` and `data-part` attributes.
+- Keystone kernels stay private by default; do not export generic `utils`, overlay, or collection internals without an ADR or accepted RFC.
 - Stateful primitives should support controlled and uncontrolled usage.
 - Event handlers should run user code first; internal handlers should skip when `event.defaultPrevented`.
 - Overlay work must account for focus management, dismissal, layering, portals, SSR, hydration, and accessibility testing.

--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -79,6 +79,7 @@ Keystone kernel
 - [apps/docs/package.json](apps/docs/package.json): Solid docs app dependencies.
 - [docs/adr/0001-keystone-mason-product-boundary.md](docs/adr/0001-keystone-mason-product-boundary.md): Keystone/Mason dependency and product boundary.
 - [docs/adr/0002-scope-names-license-governance.md](docs/adr/0002-scope-names-license-governance.md): provisional names, package scope, license intent, and governance.
+- [docs/adr/0004-keystone-kernel-api-boundary.md](docs/adr/0004-keystone-kernel-api-boundary.md): public/private Keystone kernel API boundary.
 - [docs/rfcs/keystone-api.md](docs/rfcs/keystone-api.md): Keystone compound API, low-level creators, state, polymorphism, styling contracts, SSR, and first primitives.
 - [docs/rfcs/mason-registry.md](docs/rfcs/mason-registry.md): Mason registry schema, CLI semantics, path safety, project detection, and first proving item.
 - [docs/adr/0003-mason-tanstack-app-layer.md](docs/adr/0003-mason-tanstack-app-layer.md): Mason's TanStack app-layer decision.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -76,7 +76,9 @@ Keystone internals -> Keystone primitives -> Mason components -> Mason blocks ->
 - Mason first-party app components should prefer TanStack libraries for app-grade behavior: `@tanstack/solid-form`, `@tanstack/solid-table`, TanStack Store, and `@tanstack/solid-hotkeys`.
 - Mason is the home for data-dense, keyboard-first workspace patterns. Keep domain-specific or finance-specific UI out of Keystone core unless it reduces to a general accessible primitive.
 - Keystone must not depend on TanStack app libraries. Keystone owns intrinsic primitive behavior; Mason owns app-level form/table/store/hotkey integration.
+- Keystone kernels stay private by default. Public API is promoted through primitive subpaths, primitive-specific creators, explicitly public utility primitives such as Portal/Popper/Direction/Locale/LiveAnnouncer, form support APIs, and metadata support APIs; generic `utils`, overlay, and collection kernels stay private until an ADR or accepted RFC promotes them.
 - Use [ADR 0003](docs/adr/0003-mason-tanstack-app-layer.md) and [End-State Primitive And Component Inventory](docs/agents/end-state-primitive-component-inventory.md) when deciding whether a new surface belongs in Keystone or Mason.
+- Use [ADR 0004](docs/adr/0004-keystone-kernel-api-boundary.md) before exporting a Keystone internal helper or letting Mason depend on anything below a public primitive or utility subpath.
 - Use [Do Not Reinvent Engines](docs/roadmap/do-not-reinvent.md) before adding table, virtualizer, form-state, query/cache, charting, validation, or date/i18n behavior.
 - The active design source of truth is the accepted ADRs, RFCs, PRDs, agent guidance, and end-state inventory in `docs/`.
 

--- a/apps/docs/src/components/header.tsx
+++ b/apps/docs/src/components/header.tsx
@@ -5,6 +5,7 @@ import { For } from "solid-js";
 export default function Header() {
   const links = [
     { to: "/", label: "Overview" },
+    { to: "/docs/preview", label: "Preview" },
     { to: "/#keystone", label: "Keystone" },
     { to: "/#mason", label: "Mason" },
     { to: "/#reference", label: "Reference" },

--- a/apps/docs/src/routeTree.gen.ts
+++ b/apps/docs/src/routeTree.gen.ts
@@ -8,215 +8,237 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from "./routes/__root";
-import { Route as IndexRouteImport } from "./routes/index";
-import { Route as DocsOverlayPopoverTooltipSheetRouteImport } from "./routes/docs.overlay.popover-tooltip-sheet";
-import { Route as DocsMasonTextFieldRouteImport } from "./routes/docs.mason.text-field";
-import { Route as DocsMasonSelectFieldRouteImport } from "./routes/docs.mason.select-field";
-import { Route as DocsMasonRegistryRouteImport } from "./routes/docs.mason.registry";
-import { Route as DocsMasonDialogRouteImport } from "./routes/docs.mason.dialog";
-import { Route as DocsMasonDataTableRouteImport } from "./routes/docs.mason.data-table";
-import { Route as DocsKeystoneDialogRouteImport } from "./routes/docs.keystone.dialog";
-import { Route as DocsKeystoneContractsRouteImport } from "./routes/docs.keystone.contracts";
+import { Route as rootRouteImport } from './routes/__root'
+import { Route as IndexRouteImport } from './routes/index'
+import { Route as DocsPreviewRouteImport } from './routes/docs.preview'
+import { Route as DocsOverlayPopoverTooltipSheetRouteImport } from './routes/docs.overlay.popover-tooltip-sheet'
+import { Route as DocsMasonTextFieldRouteImport } from './routes/docs.mason.text-field'
+import { Route as DocsMasonSelectFieldRouteImport } from './routes/docs.mason.select-field'
+import { Route as DocsMasonRegistryRouteImport } from './routes/docs.mason.registry'
+import { Route as DocsMasonDialogRouteImport } from './routes/docs.mason.dialog'
+import { Route as DocsMasonDataTableRouteImport } from './routes/docs.mason.data-table'
+import { Route as DocsKeystoneDialogRouteImport } from './routes/docs.keystone.dialog'
+import { Route as DocsKeystoneContractsRouteImport } from './routes/docs.keystone.contracts'
 
 const IndexRoute = IndexRouteImport.update({
-  id: "/",
-  path: "/",
+  id: '/',
+  path: '/',
   getParentRoute: () => rootRouteImport,
-} as any);
-const DocsOverlayPopoverTooltipSheetRoute = DocsOverlayPopoverTooltipSheetRouteImport.update({
-  id: "/docs/overlay/popover-tooltip-sheet",
-  path: "/docs/overlay/popover-tooltip-sheet",
+} as any)
+const DocsPreviewRoute = DocsPreviewRouteImport.update({
+  id: '/docs/preview',
+  path: '/docs/preview',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
+const DocsOverlayPopoverTooltipSheetRoute =
+  DocsOverlayPopoverTooltipSheetRouteImport.update({
+    id: '/docs/overlay/popover-tooltip-sheet',
+    path: '/docs/overlay/popover-tooltip-sheet',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const DocsMasonTextFieldRoute = DocsMasonTextFieldRouteImport.update({
-  id: "/docs/mason/text-field",
-  path: "/docs/mason/text-field",
+  id: '/docs/mason/text-field',
+  path: '/docs/mason/text-field',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const DocsMasonSelectFieldRoute = DocsMasonSelectFieldRouteImport.update({
-  id: "/docs/mason/select-field",
-  path: "/docs/mason/select-field",
+  id: '/docs/mason/select-field',
+  path: '/docs/mason/select-field',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const DocsMasonRegistryRoute = DocsMasonRegistryRouteImport.update({
-  id: "/docs/mason/registry",
-  path: "/docs/mason/registry",
+  id: '/docs/mason/registry',
+  path: '/docs/mason/registry',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const DocsMasonDialogRoute = DocsMasonDialogRouteImport.update({
-  id: "/docs/mason/dialog",
-  path: "/docs/mason/dialog",
+  id: '/docs/mason/dialog',
+  path: '/docs/mason/dialog',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const DocsMasonDataTableRoute = DocsMasonDataTableRouteImport.update({
-  id: "/docs/mason/data-table",
-  path: "/docs/mason/data-table",
+  id: '/docs/mason/data-table',
+  path: '/docs/mason/data-table',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const DocsKeystoneDialogRoute = DocsKeystoneDialogRouteImport.update({
-  id: "/docs/keystone/dialog",
-  path: "/docs/keystone/dialog",
+  id: '/docs/keystone/dialog',
+  path: '/docs/keystone/dialog',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const DocsKeystoneContractsRoute = DocsKeystoneContractsRouteImport.update({
-  id: "/docs/keystone/contracts",
-  path: "/docs/keystone/contracts",
+  id: '/docs/keystone/contracts',
+  path: '/docs/keystone/contracts',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 
 export interface FileRoutesByFullPath {
-  "/": typeof IndexRoute;
-  "/docs/keystone/contracts": typeof DocsKeystoneContractsRoute;
-  "/docs/keystone/dialog": typeof DocsKeystoneDialogRoute;
-  "/docs/mason/data-table": typeof DocsMasonDataTableRoute;
-  "/docs/mason/dialog": typeof DocsMasonDialogRoute;
-  "/docs/mason/registry": typeof DocsMasonRegistryRoute;
-  "/docs/mason/select-field": typeof DocsMasonSelectFieldRoute;
-  "/docs/mason/text-field": typeof DocsMasonTextFieldRoute;
-  "/docs/overlay/popover-tooltip-sheet": typeof DocsOverlayPopoverTooltipSheetRoute;
+  '/': typeof IndexRoute
+  '/docs/preview': typeof DocsPreviewRoute
+  '/docs/keystone/contracts': typeof DocsKeystoneContractsRoute
+  '/docs/keystone/dialog': typeof DocsKeystoneDialogRoute
+  '/docs/mason/data-table': typeof DocsMasonDataTableRoute
+  '/docs/mason/dialog': typeof DocsMasonDialogRoute
+  '/docs/mason/registry': typeof DocsMasonRegistryRoute
+  '/docs/mason/select-field': typeof DocsMasonSelectFieldRoute
+  '/docs/mason/text-field': typeof DocsMasonTextFieldRoute
+  '/docs/overlay/popover-tooltip-sheet': typeof DocsOverlayPopoverTooltipSheetRoute
 }
 export interface FileRoutesByTo {
-  "/": typeof IndexRoute;
-  "/docs/keystone/contracts": typeof DocsKeystoneContractsRoute;
-  "/docs/keystone/dialog": typeof DocsKeystoneDialogRoute;
-  "/docs/mason/data-table": typeof DocsMasonDataTableRoute;
-  "/docs/mason/dialog": typeof DocsMasonDialogRoute;
-  "/docs/mason/registry": typeof DocsMasonRegistryRoute;
-  "/docs/mason/select-field": typeof DocsMasonSelectFieldRoute;
-  "/docs/mason/text-field": typeof DocsMasonTextFieldRoute;
-  "/docs/overlay/popover-tooltip-sheet": typeof DocsOverlayPopoverTooltipSheetRoute;
+  '/': typeof IndexRoute
+  '/docs/preview': typeof DocsPreviewRoute
+  '/docs/keystone/contracts': typeof DocsKeystoneContractsRoute
+  '/docs/keystone/dialog': typeof DocsKeystoneDialogRoute
+  '/docs/mason/data-table': typeof DocsMasonDataTableRoute
+  '/docs/mason/dialog': typeof DocsMasonDialogRoute
+  '/docs/mason/registry': typeof DocsMasonRegistryRoute
+  '/docs/mason/select-field': typeof DocsMasonSelectFieldRoute
+  '/docs/mason/text-field': typeof DocsMasonTextFieldRoute
+  '/docs/overlay/popover-tooltip-sheet': typeof DocsOverlayPopoverTooltipSheetRoute
 }
 export interface FileRoutesById {
-  __root__: typeof rootRouteImport;
-  "/": typeof IndexRoute;
-  "/docs/keystone/contracts": typeof DocsKeystoneContractsRoute;
-  "/docs/keystone/dialog": typeof DocsKeystoneDialogRoute;
-  "/docs/mason/data-table": typeof DocsMasonDataTableRoute;
-  "/docs/mason/dialog": typeof DocsMasonDialogRoute;
-  "/docs/mason/registry": typeof DocsMasonRegistryRoute;
-  "/docs/mason/select-field": typeof DocsMasonSelectFieldRoute;
-  "/docs/mason/text-field": typeof DocsMasonTextFieldRoute;
-  "/docs/overlay/popover-tooltip-sheet": typeof DocsOverlayPopoverTooltipSheetRoute;
+  __root__: typeof rootRouteImport
+  '/': typeof IndexRoute
+  '/docs/preview': typeof DocsPreviewRoute
+  '/docs/keystone/contracts': typeof DocsKeystoneContractsRoute
+  '/docs/keystone/dialog': typeof DocsKeystoneDialogRoute
+  '/docs/mason/data-table': typeof DocsMasonDataTableRoute
+  '/docs/mason/dialog': typeof DocsMasonDialogRoute
+  '/docs/mason/registry': typeof DocsMasonRegistryRoute
+  '/docs/mason/select-field': typeof DocsMasonSelectFieldRoute
+  '/docs/mason/text-field': typeof DocsMasonTextFieldRoute
+  '/docs/overlay/popover-tooltip-sheet': typeof DocsOverlayPopoverTooltipSheetRoute
 }
 export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath;
+  fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
-    | "/"
-    | "/docs/keystone/contracts"
-    | "/docs/keystone/dialog"
-    | "/docs/mason/data-table"
-    | "/docs/mason/dialog"
-    | "/docs/mason/registry"
-    | "/docs/mason/select-field"
-    | "/docs/mason/text-field"
-    | "/docs/overlay/popover-tooltip-sheet";
-  fileRoutesByTo: FileRoutesByTo;
+    | '/'
+    | '/docs/preview'
+    | '/docs/keystone/contracts'
+    | '/docs/keystone/dialog'
+    | '/docs/mason/data-table'
+    | '/docs/mason/dialog'
+    | '/docs/mason/registry'
+    | '/docs/mason/select-field'
+    | '/docs/mason/text-field'
+    | '/docs/overlay/popover-tooltip-sheet'
+  fileRoutesByTo: FileRoutesByTo
   to:
-    | "/"
-    | "/docs/keystone/contracts"
-    | "/docs/keystone/dialog"
-    | "/docs/mason/data-table"
-    | "/docs/mason/dialog"
-    | "/docs/mason/registry"
-    | "/docs/mason/select-field"
-    | "/docs/mason/text-field"
-    | "/docs/overlay/popover-tooltip-sheet";
+    | '/'
+    | '/docs/preview'
+    | '/docs/keystone/contracts'
+    | '/docs/keystone/dialog'
+    | '/docs/mason/data-table'
+    | '/docs/mason/dialog'
+    | '/docs/mason/registry'
+    | '/docs/mason/select-field'
+    | '/docs/mason/text-field'
+    | '/docs/overlay/popover-tooltip-sheet'
   id:
-    | "__root__"
-    | "/"
-    | "/docs/keystone/contracts"
-    | "/docs/keystone/dialog"
-    | "/docs/mason/data-table"
-    | "/docs/mason/dialog"
-    | "/docs/mason/registry"
-    | "/docs/mason/select-field"
-    | "/docs/mason/text-field"
-    | "/docs/overlay/popover-tooltip-sheet";
-  fileRoutesById: FileRoutesById;
+    | '__root__'
+    | '/'
+    | '/docs/preview'
+    | '/docs/keystone/contracts'
+    | '/docs/keystone/dialog'
+    | '/docs/mason/data-table'
+    | '/docs/mason/dialog'
+    | '/docs/mason/registry'
+    | '/docs/mason/select-field'
+    | '/docs/mason/text-field'
+    | '/docs/overlay/popover-tooltip-sheet'
+  fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
-  IndexRoute: typeof IndexRoute;
-  DocsKeystoneContractsRoute: typeof DocsKeystoneContractsRoute;
-  DocsKeystoneDialogRoute: typeof DocsKeystoneDialogRoute;
-  DocsMasonDataTableRoute: typeof DocsMasonDataTableRoute;
-  DocsMasonDialogRoute: typeof DocsMasonDialogRoute;
-  DocsMasonRegistryRoute: typeof DocsMasonRegistryRoute;
-  DocsMasonSelectFieldRoute: typeof DocsMasonSelectFieldRoute;
-  DocsMasonTextFieldRoute: typeof DocsMasonTextFieldRoute;
-  DocsOverlayPopoverTooltipSheetRoute: typeof DocsOverlayPopoverTooltipSheetRoute;
+  IndexRoute: typeof IndexRoute
+  DocsPreviewRoute: typeof DocsPreviewRoute
+  DocsKeystoneContractsRoute: typeof DocsKeystoneContractsRoute
+  DocsKeystoneDialogRoute: typeof DocsKeystoneDialogRoute
+  DocsMasonDataTableRoute: typeof DocsMasonDataTableRoute
+  DocsMasonDialogRoute: typeof DocsMasonDialogRoute
+  DocsMasonRegistryRoute: typeof DocsMasonRegistryRoute
+  DocsMasonSelectFieldRoute: typeof DocsMasonSelectFieldRoute
+  DocsMasonTextFieldRoute: typeof DocsMasonTextFieldRoute
+  DocsOverlayPopoverTooltipSheetRoute: typeof DocsOverlayPopoverTooltipSheetRoute
 }
 
-declare module "@tanstack/solid-router" {
+declare module '@tanstack/solid-router' {
   interface FileRoutesByPath {
-    "/": {
-      id: "/";
-      path: "/";
-      fullPath: "/";
-      preLoaderRoute: typeof IndexRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/docs/overlay/popover-tooltip-sheet": {
-      id: "/docs/overlay/popover-tooltip-sheet";
-      path: "/docs/overlay/popover-tooltip-sheet";
-      fullPath: "/docs/overlay/popover-tooltip-sheet";
-      preLoaderRoute: typeof DocsOverlayPopoverTooltipSheetRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/docs/mason/text-field": {
-      id: "/docs/mason/text-field";
-      path: "/docs/mason/text-field";
-      fullPath: "/docs/mason/text-field";
-      preLoaderRoute: typeof DocsMasonTextFieldRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/docs/mason/select-field": {
-      id: "/docs/mason/select-field";
-      path: "/docs/mason/select-field";
-      fullPath: "/docs/mason/select-field";
-      preLoaderRoute: typeof DocsMasonSelectFieldRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/docs/mason/registry": {
-      id: "/docs/mason/registry";
-      path: "/docs/mason/registry";
-      fullPath: "/docs/mason/registry";
-      preLoaderRoute: typeof DocsMasonRegistryRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/docs/mason/dialog": {
-      id: "/docs/mason/dialog";
-      path: "/docs/mason/dialog";
-      fullPath: "/docs/mason/dialog";
-      preLoaderRoute: typeof DocsMasonDialogRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/docs/mason/data-table": {
-      id: "/docs/mason/data-table";
-      path: "/docs/mason/data-table";
-      fullPath: "/docs/mason/data-table";
-      preLoaderRoute: typeof DocsMasonDataTableRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/docs/keystone/dialog": {
-      id: "/docs/keystone/dialog";
-      path: "/docs/keystone/dialog";
-      fullPath: "/docs/keystone/dialog";
-      preLoaderRoute: typeof DocsKeystoneDialogRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/docs/keystone/contracts": {
-      id: "/docs/keystone/contracts";
-      path: "/docs/keystone/contracts";
-      fullPath: "/docs/keystone/contracts";
-      preLoaderRoute: typeof DocsKeystoneContractsRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/docs/preview': {
+      id: '/docs/preview'
+      path: '/docs/preview'
+      fullPath: '/docs/preview'
+      preLoaderRoute: typeof DocsPreviewRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/docs/overlay/popover-tooltip-sheet': {
+      id: '/docs/overlay/popover-tooltip-sheet'
+      path: '/docs/overlay/popover-tooltip-sheet'
+      fullPath: '/docs/overlay/popover-tooltip-sheet'
+      preLoaderRoute: typeof DocsOverlayPopoverTooltipSheetRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/docs/mason/text-field': {
+      id: '/docs/mason/text-field'
+      path: '/docs/mason/text-field'
+      fullPath: '/docs/mason/text-field'
+      preLoaderRoute: typeof DocsMasonTextFieldRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/docs/mason/select-field': {
+      id: '/docs/mason/select-field'
+      path: '/docs/mason/select-field'
+      fullPath: '/docs/mason/select-field'
+      preLoaderRoute: typeof DocsMasonSelectFieldRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/docs/mason/registry': {
+      id: '/docs/mason/registry'
+      path: '/docs/mason/registry'
+      fullPath: '/docs/mason/registry'
+      preLoaderRoute: typeof DocsMasonRegistryRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/docs/mason/dialog': {
+      id: '/docs/mason/dialog'
+      path: '/docs/mason/dialog'
+      fullPath: '/docs/mason/dialog'
+      preLoaderRoute: typeof DocsMasonDialogRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/docs/mason/data-table': {
+      id: '/docs/mason/data-table'
+      path: '/docs/mason/data-table'
+      fullPath: '/docs/mason/data-table'
+      preLoaderRoute: typeof DocsMasonDataTableRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/docs/keystone/dialog': {
+      id: '/docs/keystone/dialog'
+      path: '/docs/keystone/dialog'
+      fullPath: '/docs/keystone/dialog'
+      preLoaderRoute: typeof DocsKeystoneDialogRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/docs/keystone/contracts': {
+      id: '/docs/keystone/contracts'
+      path: '/docs/keystone/contracts'
+      fullPath: '/docs/keystone/contracts'
+      preLoaderRoute: typeof DocsKeystoneContractsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  DocsPreviewRoute: DocsPreviewRoute,
   DocsKeystoneContractsRoute: DocsKeystoneContractsRoute,
   DocsKeystoneDialogRoute: DocsKeystoneDialogRoute,
   DocsMasonDataTableRoute: DocsMasonDataTableRoute,
@@ -225,16 +247,16 @@ const rootRouteChildren: RootRouteChildren = {
   DocsMasonSelectFieldRoute: DocsMasonSelectFieldRoute,
   DocsMasonTextFieldRoute: DocsMasonTextFieldRoute,
   DocsOverlayPopoverTooltipSheetRoute: DocsOverlayPopoverTooltipSheetRoute,
-};
+}
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
-  ._addFileTypes<FileRouteTypes>();
+  ._addFileTypes<FileRouteTypes>()
 
-import type { getRouter } from "./router.tsx";
-import type { createStart } from "@tanstack/solid-start";
-declare module "@tanstack/solid-start" {
+import type { getRouter } from './router.tsx'
+import type { createStart } from '@tanstack/solid-start'
+declare module '@tanstack/solid-start' {
   interface Register {
-    ssr: true;
-    router: Awaited<ReturnType<typeof getRouter>>;
+    ssr: true
+    router: Awaited<ReturnType<typeof getRouter>>
   }
 }

--- a/apps/docs/src/routes/docs.preview.tsx
+++ b/apps/docs/src/routes/docs.preview.tsx
@@ -1,0 +1,178 @@
+import { createFileRoute, Link } from "@tanstack/solid-router";
+import {
+  ArrowLeft,
+  Boxes,
+  CheckCircle2,
+  FileJson2,
+  Layers,
+  ShieldCheck,
+  TriangleAlert,
+} from "lucide-solid";
+import { For } from "solid-js";
+
+export const Route = createFileRoute("/docs/preview")({
+  component: PreviewDocs,
+});
+
+const posture = [
+  {
+    label: "Audience",
+    value: "Private preview",
+    body: "Share with selected reviewers while release expectations, names, and publication posture stay explicit.",
+  },
+  {
+    label: "Names",
+    value: "Codenames retained",
+    body: "Keystone and Mason remain working product names until package, trademark, domain, and handle clearance are done.",
+  },
+  {
+    label: "Packages",
+    value: "Private 0.0.0",
+    body: "The provisional @keystone-ui scope remains internal; package manifests should not imply npm publication readiness.",
+  },
+];
+
+const noBreadth = [
+  "No new Keystone primitive surface area for 0.1.",
+  "No public kernel exports beyond deliberate primitive and utility APIs.",
+  "No hosted Mason registry promise until lifecycle behavior is ready.",
+  "No data-dense workspace buildout until after the 0.1 hardening spine.",
+];
+
+const nextChecks = [
+  {
+    title: "Surface Existing Docs",
+    body: "Keep boundary, maturity, styling contract, accessibility, and Mason lifecycle docs reachable from the docs app.",
+  },
+  {
+    title: "Manual Accessibility Evidence",
+    body: "Record assistive-technology evidence before calling any stable candidate truly stable.",
+  },
+  {
+    title: "Release Verification",
+    body: "Run the release gate and record the dated result in the preview notes before sharing.",
+  },
+];
+
+const docsLinks = [
+  {
+    icon: <Layers size={18} />,
+    title: "Keystone Contracts",
+    body: "Maturity labels, parts, data attributes, roles, keyboard behavior, ARIA notes, SSR notes, and examples.",
+    href: "/docs/keystone/contracts",
+  },
+  {
+    icon: <ShieldCheck size={18} />,
+    title: "Dialog Spec",
+    body: "The model stable-candidate primitive page for focus, dismissal, layering, and accessibility documentation.",
+    href: "/docs/keystone/dialog",
+  },
+  {
+    icon: <FileJson2 size={18} />,
+    title: "Mason Registry",
+    body: "Generated source files, dependency plans, customization notes, caveats, and parity metadata.",
+    href: "/docs/mason/registry",
+  },
+  {
+    icon: <Boxes size={18} />,
+    title: "Overlay Vertical",
+    body: "Popover, Tooltip, and Sheet documentation around shared overlay contracts and limits.",
+    href: "/docs/overlay/popover-tooltip-sheet",
+  },
+];
+
+function PreviewDocs() {
+  return (
+    <main class="doc-page">
+      <div class="doc-shell">
+        <Link to="/" class="back-link">
+          <ArrowLeft size={17} />
+          Overview
+        </Link>
+
+        <section class="doc-hero">
+          <div>
+            <p class="eyebrow">0.1 preview</p>
+            <h1>Private preview posture</h1>
+            <p class="doc-lede">
+              The next Keystone UI milestone is a private 0.1 preview: freeze breadth, keep
+              codenames, expose current limits, and harden the primitives, registry, docs, and
+              verification flow already in the repo.
+            </p>
+          </div>
+
+          <div class="doc-fact-panel" aria-label="Preview release facts">
+            <span>Release channel</span>
+            <strong>Private preview</strong>
+            <span>Package posture</span>
+            <strong>Private 0.0.0</strong>
+            <span>Naming posture</span>
+            <strong>Keystone / Mason codenames</strong>
+          </div>
+        </section>
+
+        <section class="doc-panel-grid">
+          <For each={posture}>
+            {(item) => (
+              <article class="doc-panel">
+                <div class="doc-section-title">
+                  <CheckCircle2 size={18} />
+                  <h2>{item.label}</h2>
+                </div>
+                <p>
+                  <strong>{item.value}.</strong> {item.body}
+                </p>
+              </article>
+            )}
+          </For>
+        </section>
+
+        <section class="doc-two-column">
+          <article class="doc-section">
+            <div class="doc-section-title">
+              <TriangleAlert size={19} />
+              <h2>Do Not Expand</h2>
+            </div>
+            <ul class="doc-list">
+              <For each={noBreadth}>{(item) => <li>{item}</li>}</For>
+            </ul>
+          </article>
+
+          <article class="doc-section">
+            <div class="doc-section-title">
+              <CheckCircle2 size={19} />
+              <h2>Next Checks</h2>
+            </div>
+            <ul class="doc-list">
+              <For each={nextChecks}>
+                {(item) => (
+                  <li>
+                    <strong>{item.title}</strong>: {item.body}
+                  </li>
+                )}
+              </For>
+            </ul>
+          </article>
+        </section>
+
+        <section class="doc-section">
+          <div class="doc-section-title">
+            <FileJson2 size={19} />
+            <h2>Preview Reading Path</h2>
+          </div>
+          <div class="preview-link-grid">
+            <For each={docsLinks}>
+              {(item) => (
+                <a class="preview-link" href={item.href}>
+                  <span>{item.icon}</span>
+                  <strong>{item.title}</strong>
+                  <small>{item.body}</small>
+                </a>
+              )}
+            </For>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/apps/docs/src/routes/index.tsx
+++ b/apps/docs/src/routes/index.tsx
@@ -9,6 +9,7 @@ import {
   FileJson2,
   Layers,
   PackageCheck,
+  ShieldCheck,
   RouteIcon,
   Sparkles,
 } from "lucide-solid";
@@ -32,6 +33,13 @@ const entryPoints = [
     body: "Install editable source for app UI. Inspect generated files, registry dependencies, target paths, caveats, and parity notes.",
     href: "/docs/mason/registry",
     action: "Browse registry contracts",
+  },
+  {
+    icon: <ShieldCheck size={19} />,
+    title: "Review the 0.1 preview",
+    body: "Private preview posture, codename limits, package posture, frozen breadth, release checks, and the first reading path.",
+    href: "/docs/preview",
+    action: "Open preview posture",
   },
   {
     icon: <BookOpen size={19} />,
@@ -297,6 +305,11 @@ function App() {
             <a class="issue-link issue-green" href="/docs/keystone/contracts">
               <span>Keystone</span>
               <strong>Primitive metadata reference</strong>
+              <ArrowRight size={17} />
+            </a>
+            <a class="issue-link issue-red" href="/docs/preview">
+              <span>Preview</span>
+              <strong>Private 0.1 release posture</strong>
               <ArrowRight size={17} />
             </a>
             <a class="issue-link issue-blue" href="/docs/mason/registry">

--- a/apps/docs/src/styles.css
+++ b/apps/docs/src/styles.css
@@ -635,6 +635,45 @@ a.doc-lane:focus-visible {
   border-left: 0.25rem solid #7c966d;
 }
 
+.issue-red {
+  border-left: 0.25rem solid #b96b62;
+}
+
+.preview-link-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: clamp(0.8rem, 2vw, 1rem);
+}
+
+.preview-link {
+  min-width: 0;
+  display: grid;
+  gap: 0.45rem;
+  border: 1px solid rgba(32, 39, 34, 0.12);
+  background: #fbfaf6;
+  padding: 0.95rem;
+}
+
+.preview-link:hover,
+.preview-link:focus-visible {
+  color: #8f4b42;
+}
+
+.preview-link span {
+  width: 2rem;
+  height: 2rem;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(32, 39, 34, 0.14);
+  background: #f7f4ec;
+}
+
+.preview-link small {
+  color: #4e5a53;
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
 .doc-page {
   padding-block: clamp(1.5rem, 4vw, 3.5rem) clamp(4rem, 7vw, 6rem);
 }
@@ -1027,7 +1066,8 @@ a.doc-lane:focus-visible {
   .doc-hero,
   .doc-two-column,
   .doc-panel-grid,
-  .contract-layout {
+  .contract-layout,
+  .preview-link-grid {
     grid-template-columns: 1fr;
   }
 

--- a/docs/adr/0004-keystone-kernel-api-boundary.md
+++ b/docs/adr/0004-keystone-kernel-api-boundary.md
@@ -1,0 +1,165 @@
+# ADR 0004: Keystone Kernel API Boundary
+
+## Status
+
+Accepted
+
+## Date
+
+2026-05-04
+
+## Context
+
+The Keystone internals parity work has moved the package beyond shallow primitive
+tracers. The shared kernel now covers controllable state, event composition,
+IDs, polymorphic rendering, state/data helpers, portal, overlay layering,
+focus, dismissal, outside hiding, scroll locking, presence, floating geometry,
+collection registration, active descendant state, roving focus, typeahead,
+selection, form-control ARIA, hidden inputs, and field validity.
+
+That depth creates an API boundary risk. If every proven internal helper becomes
+public API, Keystone freezes implementation detail too early and makes future
+primitive work harder. If too little is public, design-system authors and Mason
+components may have to duplicate behavior or depend on private source modules.
+
+The boundary must preserve the Keystone/Mason product split from ADR 0001:
+
+- Keystone owns intrinsic primitive behavior.
+- Mason owns styled source, registry workflow, blocks, templates, and app-level
+  integrations.
+- Keystone must not depend on Mason or TanStack app libraries.
+- Mason must build wrappers from Keystone public primitive behavior, not private
+  kernel imports.
+
+## Decision
+
+Keep Keystone kernels private by default. Public API is promoted only through
+primitive subpath exports, primitive-specific low-level creators, or explicitly
+named utility primitives.
+
+The end-state boundary is:
+
+1. Public primitive surface:
+   - Public subpath exports such as `@keystone-ui/keystone/dialog`,
+     `@keystone-ui/keystone/select`, `@keystone-ui/keystone/form`, and other
+     primitive subpaths.
+   - Namespace compound components such as `Dialog.Root` and `Select.Item`.
+   - Primitive-specific creators such as `createDialog`, `createSelect`,
+     `createPopover`, `createCombobox`, and `createFieldValidity`.
+   - Public primitive props, change details, part prop types, data attributes,
+     CSS variables, and ARIA/form behavior documented for those primitives.
+
+2. Public low-level utility primitives:
+   - `Portal` for DOM placement only.
+   - `Popper` and `createPopper` for low-level positioning without disclosure
+     state, dismissal, focus management, portals, roles, or overlay stack APIs.
+   - `Direction`, `Locale`, and `LiveAnnouncer` provider/creator surfaces.
+   - Metadata getters and metadata types used by docs and Mason registry
+     validation.
+
+3. Public low-level form support:
+   - `FormControl`, `Field`, `createFormControl`, `createFieldValidity`, and
+     `createHiddenInputDescriptors` are public through the form subpath.
+   - These APIs remain native-form and ARIA focused. They are not app-form
+     engines and must not depend on TanStack Form.
+
+4. Private implementation kernels:
+   - Generic utility kernels: controllable signal internals, event composition
+     helpers, stable ID stores, environment guards, polymorphic rendering
+     helpers, and data-attribute helpers.
+   - Overlay kernels: overlay controllers, layer stack, dismissable layer, focus
+     scope, outside hiding/inert behavior, prevent scroll, presence, floating
+     adapter internals, arrow positioning, dismissal policy, and DOM guards.
+   - Collection kernels: collection registry, collection manager, interaction
+     kernel, keyboard delegate, active descendant state, roving focus, typeahead,
+     selection manager, popup-field glue, and listbox facade.
+   - Primitive adapter kernels: disclosure controllers, selection-control
+     controllers, select controllers, slider controllers, menu context,
+     menu-family adapters, and similar shared implementation files.
+
+5. Deferred public surfaces:
+   - `@keystone-ui/keystone/utils`.
+   - Standalone public `Listbox`.
+   - Public overlay stack, dismissable layer, focus scope, scroll lock,
+     outside-hiding, presence, collection, typeahead, or Floating UI adapter
+     APIs.
+   - Public virtualization or large-list adapters.
+
+## Classification
+
+| Kernel capability                                                          | Boundary                                   | Notes                                                                                                                                             |
+| -------------------------------------------------------------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Controllable state                                                         | Private kernel                             | Public only through primitive state props, change handlers, and primitive creators. A generic `createControllableSignal` export remains deferred. |
+| Event composition                                                          | Private kernel                             | Public cancellation contract is DOM `preventDefault()` on documented events.                                                                      |
+| Stable IDs and SSR guards                                                  | Private kernel                             | Public proof is stable ARIA relationships and SSR-safe primitive output.                                                                          |
+| Polymorphic rendering                                                      | Public through parts, private helper       | `as` is public on parts; renderer internals are private.                                                                                          |
+| State/data attributes                                                      | Public contract, private helper            | Attribute names are public styling API; helper implementation is private.                                                                         |
+| Metadata                                                                   | Public support API                         | Metadata getters/types are public because docs and Mason validation consume them.                                                                 |
+| Portal                                                                     | Public utility primitive                   | DOM placement only. Focus, dismissal, and ARIA stay with content primitives.                                                                      |
+| Popper/floating                                                            | Public Popper, private floating adapter    | Popper is the stable low-level positioning primitive; direct Floating UI adapter internals stay private.                                          |
+| Overlay controller, layer stack, dismissal, focus, inert, scroll, presence | Private kernel                             | Exposed through Dialog, Sheet, Popover, Tooltip, HoverCard, Menu, Select, Combobox, and future overlay primitives.                                |
+| Collection registration, navigation, typeahead, selection, listbox facade  | Private kernel                             | Exposed through Select, Combobox, Menu, Tabs, Toolbar, RadioGroup, and future Listbox only after promotion.                                       |
+| Form-control ARIA, hidden input, validity                                  | Public form subpath plus private internals | Public form APIs stay native and library-agnostic; Mason owns TanStack Form integration.                                                          |
+| Direction, locale, live announcer                                          | Public utility primitives                  | Provider and creator APIs are stable-candidate cross-primitive support surfaces.                                                                  |
+| Primitive controllers and adapters                                         | Private kernel                             | Public wrapper authors use primitive creators and part components instead.                                                                        |
+
+## Promotion Criteria
+
+A private kernel capability can become public only when all of these are true:
+
+- There is a named external use case that cannot be met by compound parts,
+  primitive creators, Mason source wrappers, or a small new primitive.
+- At least two public primitives have proven the same internal contract without
+  primitive-specific leakage.
+- The API shape is Solid-native and does not expose React-specific clone,
+  render-snapshot, or store assumptions.
+- SSR, hydration, keyboard, focus, accessibility, and form behavior are covered
+  where relevant.
+- Public naming, types, and examples are documented in an RFC or ADR.
+- Semver and migration implications are explicit.
+
+Promotion should prefer a narrow utility primitive over exporting raw kernel
+objects. For example, Popper is the public positioning utility; the full floating
+adapter remains private.
+
+## Compatibility And Semver
+
+Before public package release:
+
+- Private kernel file paths, function names, and internal return shapes may
+  change without compatibility guarantees.
+- Public primitive subpaths, compound parts, creator inputs/outputs, exported
+  types, data attributes, CSS variables, and documented behavior are treated as
+  stable-candidate contracts.
+
+After public package release:
+
+- Breaking changes to public primitive subpaths, public creators, exported
+  types, data attributes, CSS variables, or documented behavior require normal
+  semver treatment.
+- Changes to private kernels do not require semver treatment unless they change
+  observable public behavior.
+- Adding a new public low-level kernel API requires an ADR or accepted RFC.
+
+## Consequences
+
+- Keystone can continue deepening internals without locking every helper into
+  public API.
+- Design-system authors get stable wrapper points through compound parts,
+  primitive creators, metadata, data attributes, and CSS variables.
+- Mason can style and compose Keystone primitives without importing private
+  internals or reimplementing behavior.
+- Public `utils`, public `Listbox`, and public overlay/collection kernel APIs
+  remain deliberate future decisions instead of accidental exports.
+- TanStack app libraries stay out of Keystone. Mason remains the app-layer home
+  for TanStack Form, Table, Store, Router, and Hotkeys integrations.
+
+## References
+
+- [ADR 0001: Keystone And Mason Product Boundary](0001-keystone-mason-product-boundary.md)
+- [ADR 0003: Mason TanStack App Layer](0003-mason-tanstack-app-layer.md)
+- [RFC: Keystone API](../rfcs/keystone-api.md)
+- [PRD: Keystone Internals Inspiration Parity](../prd/keystone-internals-inspiration-parity.md)
+- [Keystone Internal Kernel Guidance](../agents/keystone-internal-kernel-guidance.md)
+- [Overlay Kernel Boundary Note](../agents/overlay-kernel-boundary.md)
+- [Collection And Typeahead Kernel Boundary Note](../agents/collection-typeahead-kernel-boundary.md)

--- a/docs/agents/0.1-kernel-closure-audit.md
+++ b/docs/agents/0.1-kernel-closure-audit.md
@@ -1,0 +1,108 @@
+# 0.1 Kernel Closure Audit
+
+## Scope
+
+This note records closure status for the active 0.1 Keystone kernel issues reviewed on
+2026-05-04.
+
+## Ready To Close
+
+### #63 Decide end-state Keystone kernel API boundary
+
+Closure evidence:
+
+- `docs/adr/0004-keystone-kernel-api-boundary.md` classifies kernel capabilities as public
+  primitive surface, public utility primitive, public form support, private implementation kernel,
+  or deferred public surface.
+- The ADR records compatibility and semver implications, public promotion criteria, and the
+  Keystone/Mason/TanStack dependency boundary.
+- `docs/agents/keystone-internal-kernel-guidance.md`, overlay boundary notes, and collection
+  boundary notes align with the ADR.
+
+### #58 Reach end-state parity for Dialog and overlay interactions
+
+Closure evidence:
+
+- `packages/keystone/test/dialog.behavior.test.tsx` covers focus entry, focus trap, focus restore,
+  Escape/outside dismissal, preventable dismissal, inert outside content, pointer suppression,
+  force-mounted closed content, lifecycle completion, and nested top-layer dismissal.
+- `packages/keystone/src/overlay/layer-kernel.test.tsx` covers stack ordering, top-layer behavior,
+  pointer suppression, modal hiding, cleanup, and reactive modal/pointer option changes.
+- `docs/agents/dialog-vertical.md` records the public Dialog contract, parity references, known
+  follow-up, and verification evidence.
+
+### #59 Reach end-state parity for overlay presence and lifecycle
+
+Closure evidence:
+
+- `packages/keystone/src/overlay/presence.test.ts` covers immediate open/close completion and
+  force-mounted close behavior.
+- `packages/keystone/test/dialog.behavior.test.tsx` proves the public Dialog force-mount,
+  transition-delayed, hidden closed-content, and `onOpenChangeComplete` paths.
+- `docs/agents/dialog-vertical.md` records the presence lifecycle contract and remaining
+  follow-up as shared overlay internals.
+
+### #61 Reach end-state parity for modal environment management
+
+Closure evidence:
+
+- `packages/keystone/src/overlay/layer-kernel.tsx` coordinates outside hiding/inert, pointer-event
+  suppression, scroll locking, registered branch exceptions, and cleanup restoration.
+- `packages/keystone/src/overlay/layer-kernel.test.tsx` covers registered branch pointer
+  re-enabling, modal hiding, prevent-scroll acquisition, and restoration.
+- `docs/agents/outside-hiding-inert-vertical.md` and `docs/agents/layer-stack-vertical.md` record
+  the private-kernel contract and limitations.
+
+### #60 Reach end-state parity for Select collection and selection
+
+Closure evidence:
+
+- `packages/keystone/src/collection/*` covers registration, DOM order, enabled visible filtering,
+  keyboard delegation, typeahead, and selection.
+- `packages/keystone/test/select.behavior.test.tsx` covers selected/highlighted/disabled/hidden
+  state, duplicate value replacement, dynamic DOM order, form submission, reset, and external form
+  ownership.
+- `docs/agents/collection-selection-menu-closure.md` records Select/Listbox closure and documents
+  deferred public Listbox and virtualization hooks.
+
+### #62 Reach end-state parity for composite navigation and typeahead
+
+Closure evidence:
+
+- `packages/keystone/src/collection/typeahead.ts` handles repeated-key search, repeated-prefix
+  matching, disabled/hidden item skips, locale-aware matching, and reset timing.
+- `packages/keystone/src/collection/keyboard-delegate.ts` and public Select/Menu/Combobox behavior
+  tests cover Arrow/Home/End navigation and disabled/hidden item skipping.
+- `docs/agents/collection-selection-menu-closure.md` records the shared composite navigation,
+  typeahead, roving focus, and menu-family closure contract.
+
+### #54 Deepen selection controls and Slider parity
+
+Closure evidence:
+
+- `packages/keystone/src/selection-control/controller.ts` and selection-control tests cover
+  preventable interactions, read-only/disabled guards, hidden input state, reset, validation, and
+  external form ownership for Checkbox, Switch, and RadioGroup.
+- `packages/keystone/src/slider/*` covers min thumb distance, repeated hidden inputs, pointer
+  capture/fallback listeners, commit timing, active thumb state, RTL math, and read-only/disabled
+  semantics.
+- `docs/agents/selection-controls-vertical.md` and `docs/agents/slider-vertical.md` record the
+  Keystone and Mason contracts, parity choices, and deferred presentation/helper work.
+
+## Keep Open
+
+### #51 Deepen composite navigation primitive parity
+
+Reason:
+
+- `docs/agents/tabs-vertical.md`, `docs/agents/toolbar-vertical.md`, and
+  `docs/agents/navigation-menu-vertical.md` still list unresolved parity gaps.
+- The open gaps include measured Tabs indicator positioning, dynamic Tabs removal focus
+  restoration, Toolbar toggle/radio and nested overlay coordination, NavigationMenu root/list/
+  viewport anatomy, hover/touch behavior, routed-link focus restoration, and richer edge-case tests.
+
+Recommended issue handling:
+
+- Keep #51 open.
+- If needed, split #51 into narrower follow-up issues for Tabs, Toolbar, and NavigationMenu after
+  the private 0.1 preview closure set lands.

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -10,6 +10,7 @@ Start with:
 - [ADR 0001](../adr/0001-keystone-mason-product-boundary.md)
 - [ADR 0002](../adr/0002-scope-names-license-governance.md)
 - [ADR 0003](../adr/0003-mason-tanstack-app-layer.md)
+- [ADR 0004](../adr/0004-keystone-kernel-api-boundary.md)
 - [Canonical Roadmap](../roadmap/canonical-roadmap.md)
 - [Maturity Model](../roadmap/maturity-model.md)
 - [Do Not Reinvent Engines](../roadmap/do-not-reinvent.md)

--- a/docs/agents/collection-selection-menu-closure.md
+++ b/docs/agents/collection-selection-menu-closure.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-This note records the closure contract for GitHub issues #92, #93, #94, #96, #97, #98, #111, #112, #113, #116, #117, #118, and #119.
+This note records the closure contract for GitHub issues #60, #92, #93, #94, #96, #97, #98, #111, #112, #113, #116, #117, #118, and #119.
 
 The implemented Keystone layer is a shared collection/navigation kernel consumed by Select, Combobox, Menu, DropdownMenu, ContextMenu, and Menubar. Listbox remains an internal primitive facade for the 0.1 preview rather than a public subpath.
 

--- a/docs/agents/dialog-vertical.md
+++ b/docs/agents/dialog-vertical.md
@@ -30,7 +30,8 @@ Behavior:
 - User event handlers run before internal behavior; `preventDefault()` cancels Escape dismissal,
   outside dismissal, mount autofocus, and unmount autofocus.
 - Force-mounted content remains in the DOM for closed-state styling without registering as an
-  active modal layer.
+  active modal layer, and closed force-mounted backdrop, positioner, and content parts receive the
+  native `hidden` attribute so dialog semantics stay out of the accessibility tree.
 - Closing content remains mounted through exit transitions and reports transition completion.
 - Nested dialogs dismiss in top-layer order through the shared overlay stack.
 

--- a/docs/agents/keystone-internal-kernel-guidance.md
+++ b/docs/agents/keystone-internal-kernel-guidance.md
@@ -4,6 +4,8 @@
 
 Keystone internals should deepen shared primitive behavior before new component breadth. Dialog and Select are the proving primitives for the first kernel pass.
 
+The durable API boundary is [ADR 0004: Keystone Kernel API Boundary](../adr/0004-keystone-kernel-api-boundary.md). This note is operational guidance for contributors; ADR 0004 wins if the two documents conflict.
+
 ## Current Kernel Modules
 
 - `packages/keystone/src/utils/*`: controllable state, event composition, stable IDs, environment guards, polymorphic rendering, and state/data helpers.
@@ -12,18 +14,20 @@ Keystone internals should deepen shared primitive behavior before new component 
 - `packages/keystone/src/form/*`: form-control ARIA relationships, state data attributes, hidden input props, description/error registration, field validity, and form reset hooks.
 - `packages/keystone/src/i18n/*`: locale, message, text-direction inference, and direction provider internals used by primitives.
 
-These modules are implementation kernels for the 0.1.0 preview. They are used by public primitives but are not exported as public package subpaths.
+These modules are implementation kernels for the 0.1.0 preview. They are used by public primitives but are not exported as public package subpaths unless ADR 0004 explicitly classifies the surface as public.
 
-## 0.1.0 Public Surface
+## Public Surface Boundary
 
-The 0.1.0 preview exposes:
+The preview package exposes primitive and utility subpaths, including:
 
 - `@keystone-ui/keystone`
-- `@keystone-ui/keystone/dialog`
-- `@keystone-ui/keystone/form`
-- `@keystone-ui/keystone/select`
+- Primitive subpaths such as `@keystone-ui/keystone/dialog`, `@keystone-ui/keystone/select`, `@keystone-ui/keystone/combobox`, `@keystone-ui/keystone/menu`, `@keystone-ui/keystone/tabs`, and other current primitive exports.
+- Utility primitive subpaths such as `@keystone-ui/keystone/portal`, `@keystone-ui/keystone/popper`, `@keystone-ui/keystone/direction`, `@keystone-ui/keystone/locale`, and `@keystone-ui/keystone/live-announcer`.
+- `@keystone-ui/keystone/form` for native-form and ARIA-focused form-control support.
 
-The `./overlay` and `./utils` subpaths stay private until a later API decision promotes specific utilities. `./popper` is the public low-level positioning primitive; it wraps the private floating adapter without exposing the full overlay kernel. The goal is to let Dialog, Select, and Popper prove kernel behavior without freezing every helper as public API.
+The `./overlay`, `./collection`, and `./utils` subpaths stay private until a later ADR or accepted RFC promotes specific utilities. `./popper` is the public low-level positioning primitive; it wraps the private floating adapter without exposing the full overlay kernel. Metadata getters and types are public support APIs for docs and Mason validation, but metadata helper internals remain implementation detail.
+
+The goal is to let public primitives and narrow utility primitives prove kernel behavior without freezing every helper as public API.
 
 ## Implementation Rules
 
@@ -33,10 +37,12 @@ The `./overlay` and `./utils` subpaths stay private until a later API decision p
 - Keep reason details on the shared controllable-state setter path. Use `KeystoneChangeDetail`-shaped details and `defaultDetail` for programmatic changes instead of controller-local `lastDetail` or `pendingDetail` side channels.
 - Keep `data-scope` and `data-part` on every public primitive part. State attributes and floating CSS variables are styling contracts.
 - Do not add Mason dependencies to Keystone internals.
-- Avoid public subpath exports for private kernels until a later ADR/RFC explicitly promotes them.
+- Avoid public subpath exports for private kernels until a later ADR or accepted RFC explicitly promotes them.
+- Treat private kernel file paths, function names, and return shapes as non-contractual. Public contracts are primitive subpaths, namespace parts, creator APIs, exported types, data attributes, CSS variables, documented ARIA/form behavior, and explicitly public utility primitives.
 
 See also:
 
+- [ADR 0004: Keystone Kernel API Boundary](../adr/0004-keystone-kernel-api-boundary.md)
 - [Overlay Kernel Boundary Note](overlay-kernel-boundary.md)
 - [Collection And Typeahead Kernel Boundary Note](collection-typeahead-kernel-boundary.md)
 

--- a/docs/agents/layer-stack-vertical.md
+++ b/docs/agents/layer-stack-vertical.md
@@ -44,6 +44,8 @@ Gaps closed in this pass:
 - Outside hiding now uses the private hide-outside helper with `aria-hidden`, native `inert`,
   ref-counted cleanup, mutation handling for newly inserted outside DOM, and exceptions for layers
   registered above the active modal.
+- Pointer blocking now restores prior inline `pointer-events` values and re-enables registered
+  branch elements, not just layer roots, while body-level pointer suppression is active.
 - Cleanup now resyncs every document touched by a layer, including the fallback owner document and
   the eventual mounted element document.
 
@@ -74,6 +76,8 @@ Behavior:
 - Modal layers hide/inert outside elements, lock body scroll, and default to outside pointer-event
   blocking.
 - Non-modal layers may still opt into outside pointer-event blocking.
+- Body pointer-event blocking preserves existing inline body, layer, and branch pointer styles and
+  restores them when blocking is disabled or the layer unregisters.
 - Nested overlays share stack state through Solid context, including across portals.
 - Controlled option changes after mount update the stack's modal and pointer-blocking effects.
 - Cleanup restores body styles and outside element attributes to their prior values.
@@ -106,8 +110,8 @@ CSS variables:
 Focused coverage:
 
 - `packages/keystone/src/overlay/layer-kernel.test.tsx` verifies ordering, top-layer dismissal,
-  pointer-event blocking, modal hiding, prevent-scroll acquisition, cleanup restore, and reactive
-  modal/pointer option changes.
+  pointer-event blocking, registered branch pointer re-enabling, modal hiding, prevent-scroll
+  acquisition, cleanup restore, and reactive modal/pointer option changes.
 - `packages/keystone/src/overlay/prevent-scroll.test.ts` verifies scrollbar compensation,
   ref-counted nested locks, style restoration, and iOS touch edge blocking.
 - `packages/keystone/test/overlay-vertical.behavior.test.tsx` verifies Popover, Tooltip, and Sheet

--- a/docs/agents/outside-hiding-inert-vertical.md
+++ b/docs/agents/outside-hiding-inert-vertical.md
@@ -15,6 +15,9 @@ Reusable implementation:
   previous attributes/properties.
 - `packages/keystone/src/overlay/layer-kernel.tsx` applies outside hiding for the top active modal
   layer and treats layers registered above that modal as exceptions.
+- The same layer kernel coordinates outside hiding with body pointer suppression, scroll locking,
+  and registered branch exceptions so modal environment management is restored as one document-level
+  concern.
 - Dialog, Sheet, and other modal-capable overlays consume the behavior through the shared layer
   stack.
 

--- a/docs/agents/overlay-primitives-vertical.md
+++ b/docs/agents/overlay-primitives-vertical.md
@@ -14,6 +14,8 @@ Shared implementation:
 
 - Popover, HoverCard, Tooltip, and Sheet use `createOverlayController` for controlled/uncontrolled
   state, presence, stable IDs, trigger wiring, dismissal, and floating geometry where applicable.
+- Shared overlay presence exposes the closed force-mounted hidden state to overlay surfaces so
+  content can stay mounted for styling without remaining in the accessibility tree.
 - Modal Sheet uses the shared layer stack for focus trap, focus restore, outside hiding/inert,
   prevent scroll, and outside pointer blocking.
 - Popover, HoverCard, and Tooltip use the shared floating adapter and Arrow part contract.

--- a/docs/agents/selection-controls-vertical.md
+++ b/docs/agents/selection-controls-vertical.md
@@ -2,13 +2,13 @@
 
 ## Scope
 
-This vertical applies the current primitive delivery standard to Switch, Checkbox, and RadioGroup:
+This vertical applies the current primitive delivery standard to Switch, Checkbox, and RadioGroup and records closure for GitHub issue #54:
 
 - Compare the current Keystone and Mason state against Kobalte and Base UI.
 - Ship thin Keystone primitives over the shared selection-control controller first.
 - Add Mason copy-paste wrappers and registry metadata.
 - Add behavior tests for the core accessibility and state contract.
-- Record parity gaps before deepening.
+- Record intentional parity choices and deferred gaps.
 
 ## Current Keystone Contract
 
@@ -18,6 +18,8 @@ Switch:
 - `Switch.Control` exposes `role="switch"`, `aria-checked`, state data attributes, keyboard Space toggling, and user-handler-first click behavior.
 - `Switch.HiddenInput` mirrors checked state for form submission.
 - `Switch.HiddenInput` participates in native form reset and can sync checked state from input change events.
+- `Switch.Control` preserves user-owned `aria-labelledby` and `aria-describedby` composition for labels and descriptions.
+- Click and Space press semantics are preventable; disabled and read-only controls block internal toggles after user handlers run.
 
 Checkbox:
 
@@ -25,6 +27,9 @@ Checkbox:
 - `Checkbox.Control` exposes `role="checkbox"`, `aria-checked="mixed"` for indeterminate state, state data attributes, keyboard Space toggling, and preventable click behavior.
 - `Checkbox.HiddenInput` mirrors checked and `indeterminate` input state.
 - `Checkbox.HiddenInput` participates in native form reset and can sync checked state from input change events.
+- `Checkbox.HiddenInput` supports external form ownership and native required validation through the checkbox input.
+- `Checkbox.Control` preserves user-owned `aria-labelledby` and `aria-describedby` composition.
+- Control clicks, Space key presses, and hidden-input changes are preventable.
 
 RadioGroup:
 
@@ -33,7 +38,11 @@ RadioGroup:
 - `RadioGroup.Item` exposes `role="radio"`, roving `tabIndex`, checked data attributes, click selection, and arrow/Home/End keyboard selection.
 - `RadioGroup.HiddenInput` mirrors item selection as native radio inputs.
 - `RadioGroup.HiddenInput` participates in native form reset, including external form ownership through the root `form` prop.
+- `RadioGroup.Root` preserves user-owned `aria-labelledby` and `aria-describedby` composition.
+- Required radio validation delegates to the native radio inputs.
+- Item clicks, keyboard navigation, and hidden-input changes are preventable where native events are cancelable.
 - Checkbox, Switch, and RadioGroup hidden-input parts mirror stable checked, disabled, invalid, readonly, required, orientation, and direction data where applicable so generated source can style and test native form state without reaching into private controllers.
+- Selection-control SSR output is deterministic for root/control/input state; mount-only reset listeners do not require browser globals during server render.
 
 ## Mason Surface
 
@@ -44,4 +53,6 @@ RadioGroup:
 
 ## Parity Notes
 
-Kobalte and Base UI still go deeper than this first vertical. The next parity pass should add cursor/touch press behavior, richer label and description composition, nested or toolbar coordination decisions for radio groups, form validation edge cases, animation lifecycle data attributes, and broader SSR/hydration tests.
+Kobalte and Base UI still go deeper on full field primitives, press abstraction details, and nested composite coordination. Keystone intentionally keeps label and description ownership in userland or the form field layer for this milestone rather than adding selection-control-specific Label/Description parts. Cursor and touch semantics are native button/input semantics plus preventable click, keyboard, and change handlers; a dedicated press-state abstraction can be added later if Mason needs richer touch feedback without changing selection state contracts.
+
+Nested or toolbar coordination decisions for radio groups, animation lifecycle data attributes beyond current checked/unchecked state, and manual assistive-technology evidence remain deferred.

--- a/docs/agents/slider-vertical.md
+++ b/docs/agents/slider-vertical.md
@@ -2,24 +2,25 @@
 
 ## Scope
 
-This vertical applies the primitive delivery standard to Slider:
+This vertical applies the primitive delivery standard to Slider and records closure for GitHub issue #54:
 
 - Compare current Keystone and Mason state against Kobalte, Base UI, and TanStack Ranger.
 - Ship the thin Keystone primitive over a shared range controller.
 - Add Mason copy-paste wrappers and registry metadata.
 - Add behavior tests for the core accessibility and state contract.
-- Record parity gaps before deepening.
+- Record intentional parity choices and deferred gaps.
 
 ## Current Keystone Contract
 
 - `Slider.Root` supports `value`, `defaultValue`, `min`, `max`, `step`, `minStepsBetweenThumbs`, `orientation`, `dir`, `disabled`, `readOnly`, `invalid`, `required`, `name`, `form`, `onValueChange`, and `onValueCommit`.
 - `Slider.Track` owns pointer track selection and drag movement.
 - `Slider.Range` exposes range CSS variables for generated Mason styling.
-- `Slider.Thumb` exposes `role="slider"`, value ARIA, orientation ARIA, `data-scope`, `data-part`, `data-index`, `data-disabled`, and keyboard stepping.
+- `Slider.Thumb` exposes `role="slider"`, value ARIA, orientation ARIA, `data-scope`, `data-part`, `data-index`, `data-active`, `data-disabled`, and keyboard stepping.
 - Horizontal slider keyboard and pointer math is RTL-aware through explicit `dir` or the Keystone direction provider.
 - Multi-thumb sliders preserve the configured minimum step distance between thumbs.
-- `Slider.HiddenInput` serializes slider values for native forms, supports external form ownership, syncs input events back to slider state, and resets to `defaultValue`.
+- `Slider.HiddenInput` serializes single and multi-thumb slider values for native forms, supports external form ownership, syncs input events back to slider state, and resets to `defaultValue`.
 - User keyboard and pointer handlers run first; internal behavior skips when the event is default-prevented.
+- Pointer dragging uses pointer capture when the host implements it, keeps document-level move/up listeners as a fallback, exposes the active thumb lifecycle through `data-active`, and commits once on pointer release.
 
 ## Mason Surface
 
@@ -28,4 +29,6 @@ This vertical applies the primitive delivery standard to Slider:
 
 ## Parity Notes
 
-Kobalte and Base UI go deeper on field integration, validation semantics, and advanced pointer behavior. TanStack Ranger goes deeper on range-engine ergonomics, active handle lifecycle, tick helpers, interpolation, and commit timing. The next parity pass should add cursor/touch behavior, nested coordination, focus restoration, metadata docs examples, and edge-case tests.
+Kobalte and Base UI go deeper on field integration and validation semantics. TanStack Ranger goes deeper on range-engine ergonomics, tick helpers, interpolation, and helper APIs. Keystone intentionally defers origin and tooltip helpers for this milestone: Mason can compose visual labels/tooltips from public thumb value ARIA, range CSS variables, and `data-active` without adding slider-owned presentation primitives.
+
+Native constraint validation for hidden slider inputs is intentionally deferred because hidden inputs do not participate in browser validation UI. Field-level validity should live in Keystone Form or Mason/TanStack Form composition. Cursor/touch feedback beyond pointer capture and preventable pointer handlers, nested composite coordination, and focus restoration policy remain future deepening areas.

--- a/docs/prd/keystone-internals-inspiration-parity.md
+++ b/docs/prd/keystone-internals-inspiration-parity.md
@@ -71,7 +71,7 @@ Existing Dialog, Overlay, Form, and Select tracers should be refactored onto the
 - Keystone should not add broad new primitives until Dialog and Select are refactored onto shared internals.
 - Internal modules should be designed as deep modules: small stable interfaces, substantial encapsulated behavior, and focused tests.
 - Public primitive behavior should be the verification surface for internals whenever possible.
-- Private internals should not become public subpath exports until a deliberate API decision is made.
+- Private internals should not become public subpath exports until a deliberate API decision is made. [ADR 0004](../adr/0004-keystone-kernel-api-boundary.md) records the current boundary: primitive subpaths, primitive creators, selected utility primitives, form support, and metadata are public support surfaces; generic utilities, overlay kernels, and collection kernels remain private by default.
 - Existing utility and primitive files may be reorganized when it reduces duplication and improves testability.
 - Kernel modules must remain Keystone-only and must not depend on Mason.
 - Data attributes and CSS variables remain public styling contracts and should be documented when internals affect them.

--- a/docs/releases/0.1-preview-checklist.md
+++ b/docs/releases/0.1-preview-checklist.md
@@ -6,9 +6,9 @@ Draft checklist for private or public 0.1 preview readiness.
 
 ## Release Posture
 
-- [ ] Decide whether the preview is private or public.
-- [ ] Decide final package scope, names, and version posture.
-- [ ] Confirm Keystone and Mason codename posture for release materials.
+- [x] Decide whether the preview is private or public.
+- [x] Decide package scope, names, and version posture for private preview.
+- [x] Confirm Keystone and Mason codename posture for release materials.
 - [ ] Confirm MIT license copyright wording.
 - [ ] Keep primitive breadth frozen for the preview.
 
@@ -30,16 +30,17 @@ Draft checklist for private or public 0.1 preview readiness.
 - [x] Mason registry lifecycle docs exist.
 - [x] Default local-registry preview behavior is documented.
 - [x] Registry parity metadata is documented.
+- [x] Surface private preview posture in the docs app.
 - [ ] Surface lifecycle docs in the docs app before public preview.
 - [ ] Decide hosted default registry timing.
 
 ## Verification
 
-- [ ] Run `bun install` if lockfile or dependencies changed.
-- [ ] Run `bun run check`.
-- [ ] Run `bun run check-types`.
-- [ ] Run `bun run verify:release`.
-- [ ] Record command results and date in release notes.
+- [x] Run `bun install` if lockfile or dependencies changed.
+- [x] Run `bun run check`.
+- [x] Run `bun run check-types`.
+- [x] Run `bun run verify:release`.
+- [x] Record command results and date in release notes.
 
 ## Before Tagging Or Sharing
 

--- a/docs/releases/0.1.0-preview.md
+++ b/docs/releases/0.1.0-preview.md
@@ -2,15 +2,15 @@
 
 ## Status
 
-Draft preview notes. Generated 2026-05-04 from the current repo state.
+Draft private preview notes. Generated 2026-05-04 from the current repo state.
 
-This preview is for Keystone/Mason convergence and early evaluation. It is not a stable public release.
+This private preview is for Keystone/Mason convergence and selected early evaluation. It is not a stable public release.
 
 ## Release Posture
 
-- Packages remain private `0.0.0` until the maintainer decides the public package scope, names, and publication plan.
+- Packages remain private `0.0.0` for this preview.
 - `Keystone` and `Mason` remain working product names until naming, trademark, domain, and handle clearance are complete.
-- `@keystone-ui` remains the provisional internal package scope.
+- `@keystone-ui` remains the provisional internal package scope for private preview work.
 - Source is licensed under MIT via the root `LICENSE` file.
 - Primitive breadth is frozen for the preview. New work should harden existing kernels, docs, specs, accessibility evidence, and Mason lifecycle behavior.
 
@@ -43,6 +43,7 @@ This preview is for Keystone/Mason convergence and early evaluation. It is not a
 - Mason registry contract docs.
 - Mason registry lifecycle/default-registry docs.
 - Mason Dialog, TextField, SelectField, and DataTable docs.
+- Private preview posture docs page.
 - Internal reports:
   - `docs/reports/status-parity-end-state-report.md`
   - `docs/reports/0.1-preview-readiness-tracker.md`
@@ -58,13 +59,13 @@ bun run verify:release
 
 The release gate currently includes formatting/lint, typecheck, Keystone tests, docs tests, Mason CLI tests, Mason Registry tests, generated example app verification, and docs build.
 
-Last local verification snapshot recorded in the status report:
+Current local verification recorded on 2026-05-04 after private preview posture docs were added:
 
 - `bun run verify:release` passed on 2026-05-04.
 - Keystone tests passed: 39 files, 218 tests.
-- Docs tests passed.
-- Mason CLI tests passed.
-- Mason Registry tests passed.
+- Docs tests passed: 1 file, 4 tests.
+- Mason CLI tests passed: 1 file, 21 tests.
+- Mason Registry tests passed: 1 file, 30 tests.
 - Docs client/SSR build passed.
 
 ## Known Preview Limitations
@@ -96,8 +97,8 @@ Do not start RealtimeTable, Watchlist, TerminalLayout, ConditionBuilder, EventFe
 
 ## Next Work After This Draft
 
-1. Decide whether the preview stays private or becomes public.
-2. Decide package scope/name posture.
-3. Add keyboard matrices and manual accessibility evidence summaries.
-4. Surface boundary, styling contract, specs, and Mason lifecycle docs in the docs app.
-5. Decide hosted default registry timing.
+1. Add keyboard matrices and manual accessibility evidence summaries.
+2. Keep boundary, styling contract, specs, and Mason lifecycle docs surfaced in the docs app.
+3. Keep `bun run verify:release` green immediately before sharing.
+4. Decide hosted default registry timing.
+5. Revisit public package scope, final names, and publication posture after the private preview.

--- a/packages/keystone/src/collection/collection-manager.ts
+++ b/packages/keystone/src/collection/collection-manager.ts
@@ -7,6 +7,7 @@ import {
 } from "./collection-registry";
 import {
   firstEnabledItem,
+  isCollectionItemEnabled,
   lastEnabledItem,
   nextEnabledFromEnabledItems,
   type ListInteractionNavigationIntent,
@@ -51,9 +52,7 @@ export function createListCollectionManager<T extends CollectionItem>(
 
     return map;
   });
-  const enabledItems = createMemo(() =>
-    itemList().filter((item) => !item.disabled && !item.hidden),
-  );
+  const enabledItems = createMemo(() => itemList().filter(isCollectionItemEnabled));
   const itemByValue = (candidateValue: string | undefined) =>
     candidateValue === undefined ? undefined : itemByValueMap().get(candidateValue);
   const activeDescendant = createActiveDescendant({ itemByValue });
@@ -86,7 +85,7 @@ export function createListCollectionManager<T extends CollectionItem>(
 
     if (intent === "selected-or-first") {
       return highlightItem(
-        selected && !selected.disabled ? selected : firstEnabledItem(enabledItems()),
+        selected && isCollectionItemEnabled(selected) ? selected : firstEnabledItem(enabledItems()),
       );
     }
 

--- a/packages/keystone/src/collection/collection.test.tsx
+++ b/packages/keystone/src/collection/collection.test.tsx
@@ -153,6 +153,84 @@ describe("Listbox interaction module", () => {
     });
   });
 
+  test("typeahead keeps cycling repeated keys when repeated-prefix items are not enabled", () => {
+    createRoot((dispose) => {
+      const listbox = createListboxInteraction<
+        { disabled?: boolean; hidden?: boolean; label: string; value: string },
+        { reason: string }
+      >({
+        id: () => "project-listbox",
+        labelledBy: () => "project-trigger",
+        optionId: (value) => `project-option-${value}`,
+        optionSelectDetail: () => ({ reason: "item" }),
+        programmaticDetail: { reason: "programmatic" },
+        scope: "test-listbox",
+      });
+
+      listbox.getOptionProps({ label: "Alpha", value: "alpha" });
+      listbox.getOptionProps({ label: "Alpine", value: "alpine" });
+      listbox.getOptionProps({ hidden: true, label: "Aardvark", value: "aardvark" });
+      listbox.getOptionProps({ disabled: true, label: "Aaron", value: "aaron" });
+      const props = listbox.getListboxProps(
+        {},
+        {
+          selectDetail: () => ({ reason: "keyboard" }),
+        },
+      );
+
+      for (const key of ["a", "a", "a"]) {
+        (props.onKeyDown as (event: KeyboardEvent) => void)(
+          new KeyboardEvent("keydown", { cancelable: true, key }),
+        );
+      }
+
+      expect(listbox.activeDescendant.highlightedValue()).toBe("alpha");
+      dispose();
+    });
+  });
+
+  test("typeahead allows enabled repeated-prefix items without blocking later cycling", () => {
+    createRoot((dispose) => {
+      const listbox = createListboxInteraction<
+        { disabled?: boolean; label: string; value: string },
+        { reason: string }
+      >({
+        id: () => "project-listbox",
+        labelledBy: () => "project-trigger",
+        optionId: (value) => `project-option-${value}`,
+        optionSelectDetail: () => ({ reason: "item" }),
+        programmaticDetail: { reason: "programmatic" },
+        scope: "test-listbox",
+      });
+
+      listbox.getOptionProps({ label: "Aardvark", value: "aardvark" });
+      listbox.getOptionProps({ label: "Alpha", value: "alpha" });
+      listbox.getOptionProps({ label: "Alpine", value: "alpine" });
+      const props = listbox.getListboxProps(
+        {},
+        {
+          selectDetail: () => ({ reason: "keyboard" }),
+        },
+      );
+
+      (props.onKeyDown as (event: KeyboardEvent) => void)(
+        new KeyboardEvent("keydown", { cancelable: true, key: "a" }),
+      );
+      expect(listbox.activeDescendant.highlightedValue()).toBe("aardvark");
+
+      (props.onKeyDown as (event: KeyboardEvent) => void)(
+        new KeyboardEvent("keydown", { cancelable: true, key: "a" }),
+      );
+      expect(listbox.activeDescendant.highlightedValue()).toBe("aardvark");
+
+      (props.onKeyDown as (event: KeyboardEvent) => void)(
+        new KeyboardEvent("keydown", { cancelable: true, key: "a" }),
+      );
+      expect(listbox.activeDescendant.highlightedValue()).toBe("alpha");
+      dispose();
+    });
+  });
+
   test("navigation and typeahead skip hidden options while preserving collection lookup", () => {
     createRoot((dispose) => {
       const listbox = createListboxInteraction<
@@ -190,6 +268,31 @@ describe("Listbox interaction module", () => {
         new KeyboardEvent("keydown", { cancelable: true, key: "ArrowDown" }),
       );
       expect(listbox.activeDescendant.highlightedValue()).toBe("beta");
+      dispose();
+    });
+  });
+
+  test("selected-or-first falls back when the selected option is hidden", () => {
+    createRoot((dispose) => {
+      const listbox = createListboxInteraction<
+        { disabled?: boolean; hidden?: boolean; label: string; value: string },
+        { reason: string }
+      >({
+        defaultValue: "alpha",
+        id: () => "project-listbox",
+        labelledBy: () => "project-trigger",
+        optionId: (value) => `project-option-${value}`,
+        optionSelectDetail: () => ({ reason: "item" }),
+        programmaticDetail: { reason: "programmatic" },
+        scope: "test-listbox",
+      });
+
+      listbox.getOptionProps({ hidden: true, label: "Alpha", value: "alpha" });
+      listbox.getOptionProps({ label: "Bravo", value: "bravo" });
+
+      listbox.keyboard.highlight("selected-or-first");
+
+      expect(listbox.activeDescendant.highlightedValue()).toBe("bravo");
       dispose();
     });
   });

--- a/packages/keystone/src/collection/keyboard-delegate.ts
+++ b/packages/keystone/src/collection/keyboard-delegate.ts
@@ -20,18 +20,22 @@ export type ListKeyboardDelegate<T extends CollectionItem> = {
   previous?: (options: CollectionNavigationOptions<T>) => T | undefined;
 };
 
+export function isCollectionItemEnabled(item: CollectionItem): boolean {
+  return !item.disabled && !item.hidden;
+}
+
 export function firstEnabledItem<T extends CollectionItem>(items: readonly T[]): T | undefined {
-  return items.find((item) => !item.disabled);
+  return items.find(isCollectionItemEnabled);
 }
 
 export function lastEnabledItem<T extends CollectionItem>(items: readonly T[]): T | undefined {
-  return items.findLast((item) => !item.disabled);
+  return items.findLast(isCollectionItemEnabled);
 }
 
 export function nextEnabledItem<T extends CollectionItem>(
   options: CollectionNavigationOptions<T> & { direction: 1 | -1 },
 ): T | undefined {
-  const enabled = options.items.filter((item) => !item.disabled);
+  const enabled = options.items.filter(isCollectionItemEnabled);
 
   return nextEnabledFromEnabledItems({
     ...options,

--- a/packages/keystone/src/collection/roving-focus.ts
+++ b/packages/keystone/src/collection/roving-focus.ts
@@ -1,6 +1,7 @@
 import { createMemo, type Accessor } from "solid-js";
 import type { CollectionItem } from "./collection-registry";
 import {
+  isCollectionItemEnabled,
   nextEnabledFromEnabledItems,
   type ListInteractionNavigationIntent,
 } from "./keyboard-delegate";
@@ -29,9 +30,7 @@ export function createRovingFocus<T extends RovingFocusItem>(
   options: RovingFocusOptions<T>,
 ): RovingFocusApi<T> {
   let fallbackCurrent: string | undefined;
-  const enabledItems = createMemo(() =>
-    options.items().filter((item) => !item.disabled && !item.hidden),
-  );
+  const enabledItems = createMemo(() => options.items().filter(isCollectionItemEnabled));
   const currentValue = () => options.current?.() ?? fallbackCurrent ?? enabledItems()[0]?.value;
   const currentItem = createMemo(() =>
     enabledItems().find((item) => item.value === currentValue()),

--- a/packages/keystone/src/collection/typeahead.ts
+++ b/packages/keystone/src/collection/typeahead.ts
@@ -1,5 +1,6 @@
 import { createSignal, onCleanup, type Accessor } from "solid-js";
 import type { CollectionItem } from "./collection-registry";
+import { isCollectionItemEnabled } from "./keyboard-delegate";
 
 export type TypeaheadOptions<T extends CollectionItem> = {
   collator?: Intl.Collator;
@@ -88,13 +89,24 @@ function normalizeTypeaheadSearch<T extends CollectionItem>(
   items: readonly T[],
   locale?: string,
 ) {
-  const repeatedCharacter = currentSearch.length === 1 && currentSearch === key;
-  const canCycleRepeatedCharacter = items.every((item) => {
-    const normalized = normalizeTypeaheadText(item.label, locale);
-    return !normalized || normalized[0] !== normalized[1];
-  });
+  const nextSearch = currentSearch + key;
+  const isRepeatedSearch = Array.from(nextSearch).every((character) => character === key);
 
-  return repeatedCharacter && canCycleRepeatedCharacter ? key : currentSearch + key;
+  if (!isRepeatedSearch) {
+    return nextSearch;
+  }
+
+  const hasRepeatedPrefixMatch = items
+    .filter(isCollectionItemEnabled)
+    .some((item) =>
+      startsWithTypeahead(
+        normalizeTypeaheadText(item.label, locale),
+        normalizeTypeaheadSearchText(nextSearch, locale),
+        undefined,
+      ),
+    );
+
+  return hasRepeatedPrefixMatch ? nextSearch : key;
 }
 
 function findTypeaheadMatch<T extends CollectionItem>(options: {

--- a/packages/keystone/src/dialog/index.tsx
+++ b/packages/keystone/src/dialog/index.tsx
@@ -74,6 +74,7 @@ export type DialogApi = {
   modal: () => boolean;
   open: () => boolean;
   setOpen: (open: boolean, detail: DialogChangeDetail) => void;
+  hidden: (forceMount?: boolean) => boolean;
   shouldMount: (forceMount?: boolean) => boolean;
   titleId: string;
 };
@@ -103,6 +104,9 @@ export function createDialog(options: CreateDialogOptions = {}): DialogApi {
     descriptionId: overlay.descriptionId,
     getBackdropProps: (props) => ({
       ...props,
+      get hidden() {
+        return overlay.hidden();
+      },
       ...overlay.getPartProps("backdrop"),
     }),
     getCloseProps: (props) => overlay.getCloseProps(props, "close") as Record<string, unknown>,
@@ -139,6 +143,9 @@ export function createDialog(options: CreateDialogOptions = {}): DialogApi {
         ...others,
         ...layerProps,
         id: overlay.contentId,
+        get hidden() {
+          return overlay.hidden();
+        },
         tabIndex: -1,
         role: "dialog",
         "aria-modal": overlay.modal() ? "true" : undefined,
@@ -154,6 +161,9 @@ export function createDialog(options: CreateDialogOptions = {}): DialogApi {
     }),
     getPositionerProps: (props) => ({
       ...props,
+      get hidden() {
+        return overlay.hidden();
+      },
       ...overlay.getPartProps("positioner"),
     }),
     getTitleProps: (props) => ({
@@ -169,6 +179,7 @@ export function createDialog(options: CreateDialogOptions = {}): DialogApi {
     modal: overlay.modal,
     open: overlay.open,
     setOpen: overlay.setOpen,
+    hidden: overlay.hidden,
     shouldMount: overlay.shouldMount,
     titleId: overlay.titleId,
   };

--- a/packages/keystone/src/hover-card/index.tsx
+++ b/packages/keystone/src/hover-card/index.tsx
@@ -190,6 +190,9 @@ export function createHoverCard(options: CreateHoverCardOptions = {}): HoverCard
         ...layerProps,
         ...floatingProps,
         id: overlay.contentId,
+        get hidden() {
+          return overlay.hidden();
+        },
         "aria-hidden": "true",
         tabindex: -1,
         ...partProps("content"),
@@ -199,6 +202,9 @@ export function createHoverCard(options: CreateHoverCardOptions = {}): HoverCard
       const floatingProps = overlay.getFloatingPositionerProps<HTMLDivElement>(props);
       return {
         ...floatingProps,
+        get hidden() {
+          return overlay.hidden();
+        },
         ...partProps("positioner"),
       };
     },

--- a/packages/keystone/src/menu/interaction.ts
+++ b/packages/keystone/src/menu/interaction.ts
@@ -152,6 +152,9 @@ export function createScopedMenu(
         ...layerProps,
         ...floatingProps,
         id: overlay.contentId,
+        get hidden() {
+          return overlay.hidden();
+        },
         role: rootRole,
         tabindex: -1,
         get "aria-activedescendant"() {
@@ -278,6 +281,9 @@ export function createScopedMenu(
     },
     getPositionerProps: (props) => ({
       ...overlay.getFloatingPositionerProps<HTMLDivElement>(props),
+      get hidden() {
+        return overlay.hidden();
+      },
       ...floatingPartProps("positioner"),
     }),
     getSeparatorProps: (props) => ({

--- a/packages/keystone/src/overlay/controller.ts
+++ b/packages/keystone/src/overlay/controller.ts
@@ -129,6 +129,7 @@ export type OverlayController<Reason extends string> = {
   modal: Accessor<boolean>;
   open: Accessor<boolean>;
   presence: OverlayPresenceApi;
+  hidden: (forceMount?: boolean) => boolean;
   setOpen: (open: boolean, detail: OverlayControllerChangeDetail<Reason>) => void;
   setVirtualAnchor: (anchor: FloatingReferenceElement | undefined) => void;
   shouldMount: (forceMount?: boolean) => boolean;
@@ -392,6 +393,7 @@ export function createOverlayController<Reason extends string>(
     modal,
     open,
     presence,
+    hidden: presence.hidden,
     setOpen,
     setVirtualAnchor: (anchor) => setVirtualAnchor(() => anchor),
     shouldMount,

--- a/packages/keystone/src/overlay/layer-kernel.test.tsx
+++ b/packages/keystone/src/overlay/layer-kernel.test.tsx
@@ -34,6 +34,42 @@ function TestLayer(props: {
   );
 }
 
+function TestLayerWithBranch(props: {
+  id: string;
+  branchPointerEvents?: string;
+  layerPointerEvents?: string;
+  modal?: boolean;
+}) {
+  const [element, setElement] = createSignal<HTMLDivElement>();
+  const [branch, setBranch] = createSignal<HTMLDivElement>();
+  const layer = createOverlayLayer({
+    id: props.id,
+    element,
+    branchElements: () => {
+      const current = branch();
+      return current ? [current] : [];
+    },
+    modal: () => props.modal ?? false,
+    disableOutsidePointerEvents: () => props.modal ?? false,
+  });
+
+  return (
+    <>
+      <div
+        data-testid={props.id}
+        data-layer-index={layer.index()}
+        ref={setElement}
+        style={{ "pointer-events": props.layerPointerEvents }}
+      />
+      <div
+        data-testid={`${props.id}-branch`}
+        ref={setBranch}
+        style={{ "pointer-events": props.branchPointerEvents }}
+      />
+    </>
+  );
+}
+
 describe("Overlay layer kernel", () => {
   test("orders layers, blocks pointer events, and dismisses only the top layer through one stack", async () => {
     let stack!: ReturnType<typeof createOverlayLayerStack>;
@@ -198,6 +234,49 @@ describe("Overlay layer kernel", () => {
 
     expect(document.body.style.pointerEvents).toBe("none");
     expect(outside.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  test("re-enables registered branches during pointer suppression and restores inline styles", async () => {
+    let setModal!: (modal: boolean) => void;
+
+    render(() => {
+      const [modal, updateModal] = createSignal(true);
+      setModal = updateModal;
+
+      return (
+        <OverlayLayerProvider stack={createOverlayLayerStack()}>
+          <button data-testid="outside">Outside</button>
+          <TestLayerWithBranch
+            id="layer"
+            modal={modal()}
+            branchPointerEvents="none"
+            layerPointerEvents="none"
+          />
+        </OverlayLayerProvider>
+      );
+    });
+    await settled();
+
+    const layer = document.querySelector<HTMLElement>("[data-testid='layer']")!;
+    const branch = document.querySelector<HTMLElement>("[data-testid='layer-branch']")!;
+
+    expect(document.body.style.pointerEvents).toBe("none");
+    expect(layer.style.pointerEvents).toBe("auto");
+    expect(branch.style.pointerEvents).toBe("auto");
+
+    setModal(false);
+    await settled();
+
+    expect(document.body.style.pointerEvents).toBe("");
+    expect(layer.style.pointerEvents).toBe("none");
+    expect(branch.style.pointerEvents).toBe("none");
+
+    setModal(true);
+    await settled();
+
+    expect(document.body.style.pointerEvents).toBe("none");
+    expect(layer.style.pointerEvents).toBe("auto");
+    expect(branch.style.pointerEvents).toBe("auto");
   });
 
   test("hides outside content added while a modal layer is open and restores it on close", async () => {

--- a/packages/keystone/src/overlay/layer-kernel.tsx
+++ b/packages/keystone/src/overlay/layer-kernel.tsx
@@ -85,6 +85,7 @@ export type OverlayLayerProps = Omit<JSX.HTMLAttributes<HTMLDivElement>, "childr
 
 type PointerEventsState = {
   disabled: boolean;
+  elementStates: Map<HTMLElement, string>;
   originalBodyPointerEvents: string;
 };
 
@@ -112,15 +113,21 @@ export function createOverlayLayerStack(): OverlayLayerStack {
   const syncPointerEvents = (ownerDocument: Document) => {
     const state = pointerEventsByDocument.get(ownerDocument) ?? {
       disabled: false,
+      elementStates: new Map<HTMLElement, string>(),
       originalBodyPointerEvents: "",
     };
     const current = registrations();
     const hasBlockingLayer = current.some((layer) => layer.disableOutsidePointerEvents());
+    const unblockedElements = new Set(
+      current.flatMap((layer) => getRegistrationElements(layer, ownerDocument)),
+    );
 
-    for (const layer of current) {
-      const element = untrack(() => layer.getElement?.() ?? layer.element);
+    if (hasBlockingLayer) {
+      for (const element of unblockedElements) {
+        if (!state.elementStates.has(element)) {
+          state.elementStates.set(element, element.style.pointerEvents);
+        }
 
-      if (element) {
         element.style.pointerEvents = "auto";
       }
     }
@@ -130,6 +137,19 @@ export function createOverlayLayerStack(): OverlayLayerStack {
       ownerDocument.body.style.pointerEvents = "none";
       state.disabled = true;
       pointerEventsByDocument.set(ownerDocument, state);
+    }
+
+    for (const [element, pointerEvents] of state.elementStates) {
+      if (hasBlockingLayer && unblockedElements.has(element)) {
+        continue;
+      }
+
+      element.style.pointerEvents = pointerEvents;
+      state.elementStates.delete(element);
+
+      if (!element.getAttribute("style")) {
+        element.removeAttribute("style");
+      }
     }
 
     if (!hasBlockingLayer && state.disabled) {

--- a/packages/keystone/src/overlay/presence.test.ts
+++ b/packages/keystone/src/overlay/presence.test.ts
@@ -74,6 +74,45 @@ describe("overlay presence", () => {
     dispose();
   });
 
+  test("completes immediate open and close paths when no transition is present", async () => {
+    let dispose!: () => void;
+    let presence!: OverlayPresenceApi;
+    let setOpen!: (open: boolean) => boolean;
+    const complete: string[] = [];
+    const element = document.createElement("div");
+
+    createRoot((rootDispose) => {
+      dispose = rootDispose;
+      const [open, nextOpen] = createSignal(false);
+      setOpen = nextOpen;
+      presence = createOverlayPresence({
+        open,
+        onOpenChangeComplete: (open, detail) =>
+          complete.push(`${open ? "open" : "closed"}:${detail.preventedUnmount}`),
+      });
+      presence.setElement(element);
+    });
+
+    setOpen(true);
+    await animationFrame();
+    await settled();
+
+    expect(presence.mounted()).toBe(true);
+    expect(presence.transitionStatus()).toBe("open");
+    expect(complete).toEqual(["open:false"]);
+
+    setOpen(false);
+    await animationFrame();
+    await settled();
+
+    expect(presence.mounted()).toBe(false);
+    expect(presence.shouldMount()).toBe(false);
+    expect(presence.transitionStatus()).toBe("closed");
+    expect(complete).toEqual(["open:false", "closed:false"]);
+
+    dispose();
+  });
+
   test("keeps force-mounted content present and hidden after close completion", async () => {
     let dispose!: () => void;
     let presence!: OverlayPresenceApi;

--- a/packages/keystone/src/popover/index.tsx
+++ b/packages/keystone/src/popover/index.tsx
@@ -163,6 +163,9 @@ export function createPopover(options: CreatePopoverOptions = {}): PopoverApi {
         ...layerProps,
         ...floatingProps,
         id: overlay.contentId,
+        get hidden() {
+          return overlay.hidden();
+        },
         role: "dialog",
         tabindex: -1,
         ...partProps("content"),
@@ -172,6 +175,9 @@ export function createPopover(options: CreatePopoverOptions = {}): PopoverApi {
       const floatingProps = overlay.getFloatingPositionerProps<HTMLDivElement>(props);
       return {
         ...floatingProps,
+        get hidden() {
+          return overlay.hidden();
+        },
         ...partProps("positioner"),
       };
     },

--- a/packages/keystone/src/selection-control/selection-control.test.tsx
+++ b/packages/keystone/src/selection-control/selection-control.test.tsx
@@ -65,6 +65,22 @@ describe("Selection controls", () => {
     expect(new FormData(form).get("notifications")).toBe("on");
   });
 
+  test("switch supports user-owned label and description composition", () => {
+    render(() => (
+      <Switch.Root>
+        <span id="switch-label">Notifications</span>
+        <span id="switch-description">Send activity updates.</span>
+        <Switch.Control aria-describedby="switch-description" aria-labelledby="switch-label" />
+        <Switch.HiddenInput />
+      </Switch.Root>
+    ));
+
+    const control = getByPart("switch", "control");
+
+    expect(control.getAttribute("aria-labelledby")).toBe("switch-label");
+    expect(control.getAttribute("aria-describedby")).toBe("switch-description");
+  });
+
   test("checkbox supports indeterminate state and keyboard toggling", () => {
     const changes: Array<boolean | "indeterminate"> = [];
 
@@ -147,6 +163,59 @@ describe("Selection controls", () => {
 
     expect(getByPart("checkbox", "control").getAttribute("aria-checked")).toBe("true");
     expect(new FormData(form).get("terms")).toBe("on");
+  });
+
+  test("checkbox required validation and external form reset use the native input", async () => {
+    render(() => (
+      <>
+        <form id="legal" />
+        <Checkbox.Root form="legal" name="terms" required>
+          <span id="terms-label">Terms</span>
+          <span id="terms-description">Required before continuing.</span>
+          <Checkbox.Control aria-describedby="terms-description" aria-labelledby="terms-label" />
+          <Checkbox.HiddenInput />
+        </Checkbox.Root>
+      </>
+    ));
+
+    const form = document.querySelector<HTMLFormElement>("#legal")!;
+    const control = getByPart("checkbox", "control");
+    const input = getByPart("checkbox", "hidden-input") as HTMLInputElement;
+
+    expect(control.getAttribute("aria-labelledby")).toBe("terms-label");
+    expect(control.getAttribute("aria-describedby")).toBe("terms-description");
+    expect(input.form).toBe(form);
+    expect(input.required).toBe(true);
+    expect(input.checkValidity()).toBe(false);
+
+    click(control);
+    expect(input.checkValidity()).toBe(true);
+    expect(new FormData(form).get("terms")).toBe("on");
+
+    form.reset();
+    await settled();
+
+    expect(input.checkValidity()).toBe(false);
+    expect(new FormData(form).get("terms")).toBeNull();
+  });
+
+  test("checkbox native input changes are preventable", async () => {
+    const changes: Array<boolean | "indeterminate"> = [];
+
+    render(() => (
+      <Checkbox.Root onCheckedChange={(checked) => changes.push(checked)}>
+        <Checkbox.Control />
+        <Checkbox.HiddenInput onChange={(event) => event.preventDefault()} />
+      </Checkbox.Root>
+    ));
+
+    const input = getByPart("checkbox", "hidden-input") as HTMLInputElement;
+    input.checked = true;
+    input.dispatchEvent(new Event("change", { bubbles: true, cancelable: true }));
+    await settled();
+
+    expect(getByPart("checkbox", "control").getAttribute("aria-checked")).toBe("false");
+    expect(changes).toEqual([]);
   });
 
   test("radio group roves focus and selects with keyboard while skipping disabled items", () => {
@@ -241,5 +310,56 @@ describe("Selection controls", () => {
 
     expect(new FormData(form).get("size")).toBe("small");
     expect(parts("radio-group", "item")[0].getAttribute("aria-checked")).toBe("true");
+  });
+
+  test("radio group exposes label composition, required validation, and preventable item input", async () => {
+    const changes: string[] = [];
+
+    render(() => (
+      <>
+        <form id="profile" />
+        <RadioGroup.Root
+          aria-describedby="size-description"
+          aria-labelledby="size-label"
+          form="profile"
+          name="size"
+          required
+          onValueChange={(value) => changes.push(value ?? "")}
+        >
+          <span id="size-label">Size</span>
+          <span id="size-description">Choose one size.</span>
+          <RadioGroup.Item value="small">
+            Small
+            <RadioGroup.HiddenInput onChange={(event) => event.preventDefault()} />
+          </RadioGroup.Item>
+          <RadioGroup.Item value="large">
+            Large
+            <RadioGroup.HiddenInput />
+          </RadioGroup.Item>
+        </RadioGroup.Root>
+      </>
+    ));
+
+    const form = document.querySelector<HTMLFormElement>("#profile")!;
+    const root = getByPart("radio-group", "root");
+    const [smallInput, largeInput] = parts("radio-group", "hidden-input") as HTMLInputElement[];
+
+    expect(root.getAttribute("aria-labelledby")).toBe("size-label");
+    expect(root.getAttribute("aria-describedby")).toBe("size-description");
+    expect(smallInput?.form).toBe(form);
+    expect(smallInput?.required).toBe(true);
+    expect(largeInput?.required).toBe(true);
+    expect(smallInput?.checkValidity()).toBe(false);
+
+    smallInput!.checked = true;
+    smallInput!.dispatchEvent(new Event("change", { bubbles: true, cancelable: true }));
+    await settled();
+    expect(parts("radio-group", "item")[0]?.getAttribute("aria-checked")).toBe("false");
+    expect(changes).toEqual([]);
+
+    click(parts("radio-group", "item")[1]!);
+    expect(new FormData(form).get("size")).toBe("large");
+    expect(largeInput?.checkValidity()).toBe(true);
+    expect(changes).toEqual(["large"]);
   });
 });

--- a/packages/keystone/src/sheet/index.tsx
+++ b/packages/keystone/src/sheet/index.tsx
@@ -84,6 +84,7 @@ type SheetApi = {
   modal: () => boolean;
   open: () => boolean;
   setOpen: (open: boolean, detail: SheetChangeDetail) => void;
+  hidden: (forceMount?: boolean) => boolean;
   shouldMount: (forceMount?: boolean) => boolean;
   side: () => SheetSide;
   titleId: string;
@@ -120,6 +121,9 @@ export function createSheet(options: CreateSheetOptions = {}): SheetApi {
     descriptionId: overlay.descriptionId,
     getBackdropProps: (props) => ({
       ...props,
+      get hidden() {
+        return overlay.hidden();
+      },
       ...partProps("backdrop"),
     }),
     getCloseProps: (props) => ({
@@ -159,6 +163,9 @@ export function createSheet(options: CreateSheetOptions = {}): SheetApi {
         ...others,
         ...layerProps,
         id: overlay.contentId,
+        get hidden() {
+          return overlay.hidden();
+        },
         tabIndex: -1,
         role: "dialog",
         "aria-modal": overlay.modal() ? "true" : undefined,
@@ -174,6 +181,9 @@ export function createSheet(options: CreateSheetOptions = {}): SheetApi {
     }),
     getPositionerProps: (props) => ({
       ...props,
+      get hidden() {
+        return overlay.hidden();
+      },
       ...partProps("positioner"),
     }),
     getTitleProps: (props) => ({
@@ -191,6 +201,7 @@ export function createSheet(options: CreateSheetOptions = {}): SheetApi {
     modal: overlay.modal,
     open: overlay.open,
     setOpen: overlay.setOpen,
+    hidden: overlay.hidden,
     shouldMount: overlay.shouldMount,
     side,
     titleId: overlay.titleId,

--- a/packages/keystone/src/slider/controller.ts
+++ b/packages/keystone/src/slider/controller.ts
@@ -1,4 +1,4 @@
-import { createMemo, untrack, type Accessor, type JSX } from "solid-js";
+import { createMemo, createSignal, onCleanup, untrack, type Accessor, type JSX } from "solid-js";
 import {
   callEventHandler,
   createControllableSignal,
@@ -74,6 +74,7 @@ export type SliderHiddenInputContractProps = Omit<
 };
 
 export type SliderApi = {
+  activeThumbIndex: Accessor<number | undefined>;
   dir: Accessor<Direction>;
   disabled: Accessor<boolean>;
   form: Accessor<string | undefined>;
@@ -117,7 +118,8 @@ export function createSliderController(options: SliderControllerOptions = {}): S
   const readOnly = createMemo(() => options.readOnly?.() ?? false);
   const required = createMemo(() => options.required?.() ?? false);
   let trackElement: HTMLDivElement | undefined;
-  let activeThumbIndex: number | undefined;
+  const [activeThumbIndex, setActiveThumbIndex] = createSignal<number>();
+  let captureElement: HTMLElement | undefined;
   const [value, setValueState] = createControllableSignal<
     readonly number[],
     SliderValueChangeDetail
@@ -177,18 +179,21 @@ export function createSliderController(options: SliderControllerOptions = {}): S
       orientation(),
       dir(),
     );
-    const thumbIndex = activeThumbIndex ?? getClosestThumbIndex(normalizedValue(), valueFromPoint);
-    activeThumbIndex = thumbIndex;
+    const thumbIndex =
+      activeThumbIndex() ?? getClosestThumbIndex(normalizedValue(), valueFromPoint);
+    setActiveThumbIndex(thumbIndex);
     setThumbValue(thumbIndex, valueFromPoint, { event, reason });
   };
 
   const stopDragging = (event: PointerEvent) => {
-    if (activeThumbIndex === undefined) return;
+    if (activeThumbIndex() === undefined) return;
 
-    const thumbIndex = activeThumbIndex;
-    activeThumbIndex = undefined;
+    const thumbIndex = activeThumbIndex();
+    setActiveThumbIndex(undefined);
     document.removeEventListener("pointermove", moveDragging);
     document.removeEventListener("pointerup", stopDragging);
+    releasePointerCapture(captureElement, event.pointerId);
+    captureElement = undefined;
     commitValue({ event, reason: "pointer", thumbIndex });
   };
 
@@ -200,13 +205,21 @@ export function createSliderController(options: SliderControllerOptions = {}): S
   const startDragging = (event: PointerEvent, thumbIndex?: number) => {
     if (disabled() || readOnly()) return;
 
-    activeThumbIndex = thumbIndex;
+    setActiveThumbIndex(thumbIndex);
+    captureElement = event.currentTarget instanceof HTMLElement ? event.currentTarget : undefined;
+    setPointerCapture(captureElement, event.pointerId);
     setValueFromPoint(event, thumbIndex === undefined ? "track" : "pointer");
     document.addEventListener("pointermove", moveDragging);
     document.addEventListener("pointerup", stopDragging);
   };
 
+  onCleanup(() => {
+    document.removeEventListener("pointermove", moveDragging);
+    document.removeEventListener("pointerup", stopDragging);
+  });
+
   return {
+    activeThumbIndex,
     dir,
     disabled,
     form,
@@ -234,6 +247,9 @@ export function createSliderController(options: SliderControllerOptions = {}): S
         },
         get "data-disabled"() {
           return dataBoolean(disabled());
+        },
+        get "data-active"() {
+          return dataBoolean(activeThumbIndex() === index);
         },
         get "data-invalid"() {
           return dataBoolean(invalid());
@@ -514,6 +530,18 @@ function getClosestThumbIndex(values: readonly number[], nextValue: number) {
   });
 
   return closestIndex;
+}
+
+function setPointerCapture(element: HTMLElement | undefined, pointerId: number) {
+  if (element && "setPointerCapture" in element) {
+    element.setPointerCapture(pointerId);
+  }
+}
+
+function releasePointerCapture(element: HTMLElement | undefined, pointerId: number) {
+  if (element && "releasePointerCapture" in element) {
+    element.releasePointerCapture(pointerId);
+  }
 }
 
 function getValueFromPointer(

--- a/packages/keystone/src/slider/index.tsx
+++ b/packages/keystone/src/slider/index.tsx
@@ -144,9 +144,14 @@ function Range(props: SliderRangeProps) {
 function Thumb(props: SliderThumbProps) {
   const slider = useSlider("Thumb");
   const [local, others] = splitProps(props, ["children", "index"]);
-  const thumbProps = slider.getThumbProps({ ...others, index: local.index ?? 0 });
+  const index = () => local.index ?? 0;
+  const thumbProps = slider.getThumbProps({ ...others, index: index() });
 
-  return <button {...thumbProps}>{local.children}</button>;
+  return (
+    <button {...thumbProps} data-active={slider.activeThumbIndex() === index() ? "" : undefined}>
+      {local.children}
+    </button>
+  );
 }
 
 function HiddenInput(props: SliderHiddenInputProps) {

--- a/packages/keystone/src/slider/slider.test.tsx
+++ b/packages/keystone/src/slider/slider.test.tsx
@@ -170,13 +170,15 @@ describe("Slider", () => {
     expect(thumb.getAttribute("aria-valuenow")).toBe("30");
   });
 
-  test("updates the closest thumb from track pointer input and commits on release", () => {
+  test("updates the closest thumb from track pointer input, captures pointer, and commits on release", async () => {
     const changes: Array<{ reason: string; value: readonly number[] }> = [];
     const commits: Array<{
       reason: string;
       thumbIndex: number | undefined;
       value: readonly number[];
     }> = [];
+    const captures: number[] = [];
+    const releases: number[] = [];
 
     render(() => (
       <Slider.Root
@@ -200,13 +202,23 @@ describe("Slider", () => {
     const track = getByPart("slider", "track");
     track.getBoundingClientRect = () =>
       ({ bottom: 20, height: 20, left: 0, right: 100, top: 0, width: 100 }) as DOMRect;
+    track.setPointerCapture = (pointerId: number) => captures.push(pointerId);
+    track.releasePointerCapture = (pointerId: number) => releases.push(pointerId);
 
     pointerDown(track, { clientX: 70, clientY: 10 });
+    await settled();
+    const [, activeThumb] = parts("thumb");
+    expect(activeThumb?.getAttribute("data-active")).toBe("");
+
     pointerMove({ clientX: 60, clientY: 10 });
     pointerUp({ clientX: 60, clientY: 10 });
+    await settled();
 
     const [, secondThumb] = parts("thumb");
     expect(secondThumb?.getAttribute("aria-valuenow")).toBe("60");
+    expect(secondThumb?.hasAttribute("data-active")).toBe(false);
+    expect(captures).toEqual([1]);
+    expect(releases).toEqual([1]);
     expect(changes.map((change) => change.reason)).toEqual(["track", "pointer"]);
     expect(commits).toEqual([{ reason: "pointer", thumbIndex: 1, value: [20, 60] }]);
   });
@@ -272,6 +284,25 @@ describe("Slider", () => {
 
     expect(thumb.getAttribute("aria-valuenow")).toBe("20");
     expect(new FormData(form).get("price")).toBe("20");
+  });
+
+  test("serializes multi-thumb values as repeated hidden inputs", () => {
+    render(() => (
+      <form>
+        <Slider.Root defaultValue={[20, 80]} name="price" min={0} max={100} step={10}>
+          <Slider.Track>
+            <Slider.Range />
+            <Slider.Thumb index={0} />
+            <Slider.Thumb index={1} />
+          </Slider.Track>
+          <Slider.HiddenInput index={0} />
+          <Slider.HiddenInput index={1} />
+        </Slider.Root>
+      </form>
+    ));
+
+    const form = document.querySelector<HTMLFormElement>("form")!;
+    expect(new FormData(form).getAll("price")).toEqual(["20", "80"]);
   });
 
   test("read-only slider exposes state and blocks keyboard and pointer changes", () => {

--- a/packages/keystone/src/tooltip/index.tsx
+++ b/packages/keystone/src/tooltip/index.tsx
@@ -207,6 +207,9 @@ export function createTooltip(options: CreateTooltipOptions = {}): TooltipApi {
       return {
         ...floatingProps,
         id: overlay.contentId,
+        get hidden() {
+          return overlay.hidden();
+        },
         role: "tooltip",
         ...partProps("content"),
         onKeyDown: (event: KeyboardEvent) => {
@@ -225,6 +228,9 @@ export function createTooltip(options: CreateTooltipOptions = {}): TooltipApi {
       const floatingProps = overlay.getFloatingPositionerProps<HTMLDivElement>(props);
       return {
         ...floatingProps,
+        get hidden() {
+          return overlay.hidden();
+        },
         ...partProps("positioner"),
       };
     },

--- a/packages/keystone/test/dialog.behavior.test.tsx
+++ b/packages/keystone/test/dialog.behavior.test.tsx
@@ -133,6 +133,41 @@ describe("Dialog behavior harness", () => {
     expect(outsideRoot.hasAttribute("inert")).toBe(false);
   });
 
+  test("suppresses outside pointer events while keeping dialog content interactive", async () => {
+    document.body.style.pointerEvents = "all";
+    const outsideRoot = document.createElement("main");
+    outsideRoot.setAttribute("data-testid", "outside-root");
+    document.body.append(outsideRoot);
+
+    render(() => (
+      <Dialog.Root>
+        <Dialog.Trigger>Open dialog</Dialog.Trigger>
+        <Dialog.Portal>
+          <Dialog.Content>
+            <Dialog.Title>Project settings</Dialog.Title>
+            <Dialog.Description>Change project metadata.</Dialog.Description>
+            <Dialog.Close>Close</Dialog.Close>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
+    ));
+
+    click(getByPart("dialog", "trigger"));
+    await settled();
+
+    const content = getByPart("dialog", "content");
+
+    expect(document.body.style.pointerEvents).toBe("none");
+    expect(content.style.pointerEvents).toBe("auto");
+    expect(outsideRoot.getAttribute("aria-hidden")).toBe("true");
+    expect(outsideRoot.inert).toBe(true);
+
+    click(getByPart("dialog", "close"));
+    await settled();
+
+    expect(document.body.style.pointerEvents).toBe("all");
+  });
+
   test("marks outside body content added after opening inert and restores it on close", async () => {
     render(() => (
       <Dialog.Root>
@@ -286,6 +321,40 @@ describe("Dialog behavior harness", () => {
     expect(complete).toEqual(["open:false", "closed:false"]);
   });
 
+  test("reports open-change completion for immediate lifecycle paths", async () => {
+    const complete: string[] = [];
+
+    render(() => (
+      <Dialog.Root
+        onOpenChangeComplete={(open, detail) =>
+          complete.push(`${open ? "open" : "closed"}:${detail.preventedUnmount}`)
+        }
+      >
+        <Dialog.Trigger>Open dialog</Dialog.Trigger>
+        <Dialog.Portal>
+          <Dialog.Content>
+            <Dialog.Title>Project settings</Dialog.Title>
+            <Dialog.Description>Change project metadata.</Dialog.Description>
+            <Dialog.Close>Close</Dialog.Close>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
+    ));
+
+    click(getByPart("dialog", "trigger"));
+    await animationFrame();
+    await settled();
+
+    expect(complete).toEqual(["open:false"]);
+
+    click(getByPart("dialog", "close"));
+    await animationFrame();
+    await settled();
+
+    expect(queryByPart("dialog", "content")).toBeNull();
+    expect(complete).toEqual(["open:false", "closed:false"]);
+  });
+
   test("keeps force-mounted content present across the closed presence lifecycle", async () => {
     const complete: string[] = [];
     const outsideRoot = document.createElement("main");
@@ -305,11 +374,14 @@ describe("Dialog behavior harness", () => {
         >
           <Dialog.Trigger>Open dialog</Dialog.Trigger>
           <Dialog.Portal forceMount>
-            <Dialog.Content style="transition-duration: 100ms;">
-              <Dialog.Title>Project settings</Dialog.Title>
-              <Dialog.Description>Change project metadata.</Dialog.Description>
-              <Dialog.Close>Close</Dialog.Close>
-            </Dialog.Content>
+            <Dialog.Backdrop />
+            <Dialog.Positioner>
+              <Dialog.Content style="transition-duration: 100ms;">
+                <Dialog.Title>Project settings</Dialog.Title>
+                <Dialog.Description>Change project metadata.</Dialog.Description>
+                <Dialog.Close>Close</Dialog.Close>
+              </Dialog.Content>
+            </Dialog.Positioner>
           </Dialog.Portal>
         </Dialog.Root>
       );
@@ -318,8 +390,13 @@ describe("Dialog behavior harness", () => {
     await settled();
 
     const content = getByPart("dialog", "content");
+    const backdrop = getByPart("dialog", "backdrop");
+    const positioner = getByPart("dialog", "positioner");
     expect(content.getAttribute("data-state")).toBe("closed");
     expect(content.getAttribute("data-transition-status")).toBe("closed");
+    expect(content.hidden).toBe(true);
+    expect(backdrop.hidden).toBe(true);
+    expect(positioner.hidden).toBe(true);
     expect(outsideRoot.getAttribute("aria-hidden")).toBeNull();
     expect(outsideRoot.inert).toBe(false);
 
@@ -328,6 +405,9 @@ describe("Dialog behavior harness", () => {
 
     expect(content.getAttribute("data-state")).toBe("open");
     expect(content.getAttribute("data-transition-status")).toBe("opening");
+    expect(content.hidden).toBe(false);
+    expect(backdrop.hidden).toBe(false);
+    expect(positioner.hidden).toBe(false);
     expect(outsideRoot.getAttribute("aria-hidden")).toBe("true");
     expect(outsideRoot.inert).toBe(true);
 
@@ -343,6 +423,7 @@ describe("Dialog behavior harness", () => {
 
     expect(content.getAttribute("data-state")).toBe("closed");
     expect(content.getAttribute("data-transition-status")).toBe("closing");
+    expect(content.hidden).toBe(false);
 
     await animationFrame();
     content.dispatchEvent(new Event("transitionend"));
@@ -350,6 +431,9 @@ describe("Dialog behavior harness", () => {
 
     expect(getByPart("dialog", "content")).toBe(content);
     expect(content.getAttribute("data-transition-status")).toBe("closed");
+    expect(content.hidden).toBe(true);
+    expect(backdrop.hidden).toBe(true);
+    expect(positioner.hidden).toBe(true);
     expect(outsideRoot.getAttribute("aria-hidden")).toBeNull();
     expect(outsideRoot.inert).toBe(false);
     expect(complete).toEqual(["open:false", "closed:true"]);

--- a/packages/keystone/test/select.behavior.test.tsx
+++ b/packages/keystone/test/select.behavior.test.tsx
@@ -237,6 +237,109 @@ describe("Select behavior harness", () => {
     expect(getByPart("select", "listbox").getAttribute("aria-multiselectable")).toBeNull();
   });
 
+  test("exposes selected state and protects disabled and hidden options", async () => {
+    const changes: string[] = [];
+
+    render(() => (
+      <Select.Root
+        defaultOpen
+        defaultValue="alpha"
+        onValueChange={(value) => changes.push(value ?? "")}
+      >
+        <Select.Trigger>Choose project</Select.Trigger>
+        <Select.Value />
+        <Select.Content>
+          <Select.Listbox>
+            <Select.Item value="alpha">Alpha</Select.Item>
+            <Select.Item value="beta" disabled>
+              Beta
+            </Select.Item>
+            <Select.Item value="bravo" hidden>
+              Bravo
+            </Select.Item>
+            <Select.Item value="charlie">Charlie</Select.Item>
+          </Select.Listbox>
+        </Select.Content>
+      </Select.Root>
+    ));
+
+    const items = Array.from(document.querySelectorAll<HTMLElement>('[data-part="item"]'));
+    const alpha = items.find((item) => item.textContent === "Alpha")!;
+    const beta = items.find((item) => item.textContent === "Beta")!;
+    const bravo = items.find((item) => item.textContent === "Bravo")!;
+    const charlie = items.find((item) => item.textContent === "Charlie")!;
+
+    expect(alpha.getAttribute("aria-selected")).toBe("true");
+    expect(alpha.getAttribute("data-selected")).toBe("");
+    expect(beta.getAttribute("aria-disabled")).toBe("true");
+    expect(beta.getAttribute("data-disabled")).toBe("");
+    expect(bravo.hidden).toBe(true);
+    expect(bravo.getAttribute("data-hidden")).toBe("");
+
+    click(beta);
+    await settled();
+    expect(getByPart("select", "value").textContent).toBe("Alpha");
+    expect(changes).toEqual([]);
+
+    const listbox = getByPart("select", "listbox");
+    keyDown(listbox, "ArrowDown");
+    expect(document.querySelector('[data-part="item"][data-highlighted]')?.textContent).toBe(
+      "Alpha",
+    );
+
+    keyDown(listbox, "b");
+    expect(document.querySelector('[data-part="item"][data-highlighted]')?.textContent).toBe(
+      "Alpha",
+    );
+
+    keyDown(listbox, "ArrowDown");
+    expect(document.querySelector('[data-part="item"][data-highlighted]')?.textContent).toBe(
+      "Charlie",
+    );
+
+    keyDown(listbox, "Enter");
+    await settled();
+
+    expect(charlie.getAttribute("aria-selected")).toBe("true");
+    expect(charlie.getAttribute("data-selected")).toBe("");
+    expect(getByPart("select", "value").textContent).toBe("Charlie");
+    expect(changes).toEqual(["charlie"]);
+  });
+
+  test("keeps duplicate value replacements after stale option cleanup", async () => {
+    let setShowOldAlpha!: Setter<boolean>;
+
+    render(() => {
+      const [showOldAlpha, setShowOldAlphaSignal] = createSignal(true);
+      setShowOldAlpha = setShowOldAlphaSignal;
+
+      return (
+        <Select.Root defaultValue="alpha">
+          <Select.Trigger>Choose project</Select.Trigger>
+          <Select.Value />
+          <Select.Content>
+            <Select.Listbox>
+              <Show when={showOldAlpha()}>
+                <Select.Item value="alpha">Old Alpha</Select.Item>
+              </Show>
+              <Select.Item value="alpha">Updated Alpha</Select.Item>
+              <Select.Item value="bravo">Bravo</Select.Item>
+            </Select.Listbox>
+          </Select.Content>
+        </Select.Root>
+      );
+    });
+
+    await settled();
+
+    expect(getByPart("select", "value").textContent).toBe("Updated Alpha");
+
+    setShowOldAlpha(false);
+    await settled();
+
+    expect(getByPart("select", "value").textContent).toBe("Updated Alpha");
+  });
+
   test("keeps dynamic options in DOM order and removes stale unmounted items", async () => {
     let setShowAlpha!: Setter<boolean>;
     const changes: string[] = [];


### PR DESCRIPTION
## Summary

Closes the selected 0.1 Keystone kernel parity issues that now have implementation, test, and documentation evidence.

Closes #63.
Closes #58.
Closes #59.
Closes #61.
Closes #60.
Closes #62.
Closes #54.

Refs #51. The closure audit keeps #51 open because Tabs, Toolbar, and NavigationMenu still list unresolved primitive-specific parity gaps.

## Core changes

- Adds ADR 0004 to define the Keystone kernel API boundary, public promotion criteria, and semver implications.
- Deepens overlay behavior for Dialog, presence lifecycle, pointer-event suppression, outside hiding/inert handling, and layer stack restoration.
- Deepens collection/typeahead/select behavior for enabled visible filtering, repeated-key search, duplicate value replacement, hidden item skipping, and public selected/highlighted state proof.
- Deepens selection-control and Slider coverage around preventable interactions, hidden inputs, reset/form behavior, active thumb state, pointer capture, and multi-thumb serialization.
- Adds a private preview docs route and updates release notes/checklist for the private 0.1 posture.
- Adds a 0.1 kernel closure audit documenting which issues can close and why #51 should remain open.

## Behavior / invariants

- Keystone kernels remain private by default; public behavior is exposed through primitive subpaths, primitive creators, documented parts, data attributes, CSS variables, metadata, and selected utility primitives.
- Mason wrappers should continue using public Keystone primitive behavior and must not import private Keystone kernels.
- #51 remains open until Tabs, Toolbar, and NavigationMenu parity gaps are split or completed.

## Known limitations

- Public Listbox, public overlay stack/focus/dismissal kernels, public collection/typeahead APIs, and generic `utils` exports remain deferred.
- Manual assistive-technology evidence is still required before stable public claims.
- NavigationMenu, Toolbar, and Tabs still need additional parity work tracked by #51.

## Validation

- `bun run check`
- `bun run verify:release`
