### PR TITLE
[codex] Add dashboard registry endstate

### DIFF
--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -8,61 +8,61 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from './routes/__root'
-import { Route as IndexRouteImport } from './routes/index'
+import { Route as rootRouteImport } from "./routes/__root";
+import { Route as IndexRouteImport } from "./routes/index";
 
 const IndexRoute = IndexRouteImport.update({
-  id: '/',
-  path: '/',
+  id: "/",
+  path: "/",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 
 export interface FileRoutesByFullPath {
-  '/': typeof IndexRoute
+  "/": typeof IndexRoute;
 }
 export interface FileRoutesByTo {
-  '/': typeof IndexRoute
+  "/": typeof IndexRoute;
 }
 export interface FileRoutesById {
-  __root__: typeof rootRouteImport
-  '/': typeof IndexRoute
+  __root__: typeof rootRouteImport;
+  "/": typeof IndexRoute;
 }
 export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/'
-  fileRoutesByTo: FileRoutesByTo
-  to: '/'
-  id: '__root__' | '/'
-  fileRoutesById: FileRoutesById
+  fileRoutesByFullPath: FileRoutesByFullPath;
+  fullPaths: "/";
+  fileRoutesByTo: FileRoutesByTo;
+  to: "/";
+  id: "__root__" | "/";
+  fileRoutesById: FileRoutesById;
 }
 export interface RootRouteChildren {
-  IndexRoute: typeof IndexRoute
+  IndexRoute: typeof IndexRoute;
 }
 
-declare module '@tanstack/solid-router' {
+declare module "@tanstack/solid-router" {
   interface FileRoutesByPath {
-    '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof IndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+    "/": {
+      id: "/";
+      path: "/";
+      fullPath: "/";
+      preLoaderRoute: typeof IndexRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
   }
 }
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
-}
+};
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
-  ._addFileTypes<FileRouteTypes>()
+  ._addFileTypes<FileRouteTypes>();
 
-import type { getRouter } from './router.tsx'
-import type { createStart } from '@tanstack/solid-start'
-declare module '@tanstack/solid-start' {
+import type { getRouter } from "./router.tsx";
+import type { createStart } from "@tanstack/solid-start";
+declare module "@tanstack/solid-start" {
   interface Register {
-    ssr: true
-    router: Awaited<ReturnType<typeof getRouter>>
+    ssr: true;
+    router: Awaited<ReturnType<typeof getRouter>>;
   }
 }

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -20,6 +20,7 @@ Start with:
 - [Core internal kernel guidance](./core-internal-kernel-guidance.md)
 - [Issue triage spine](./issue-triage-spine.md)
 - [Data-dense workspace verticals](./data-dense-workspace-verticals.md)
+- [UI DataTable vertical](./ui-data-table-vertical.md)
 - [UI CommandMenu vertical](./ui-command-menu-vertical.md)
 - [Core layer stack vertical](./layer-stack-vertical.md)
 - [Controllable state vertical](./controllable-state-vertical.md)

--- a/docs/agents/data-dense-workspace-verticals.md
+++ b/docs/agents/data-dense-workspace-verticals.md
@@ -20,6 +20,7 @@ Parent PRD: [Keystone Core And UI Foundation](../prd/keystone-foundation.md)
 2. **Realtime Data Table Pattern Tracer** ([#272](https://github.com/erik-kroon/core-ui/issues/272))
    - Type: AFK
    - Blocked by: [#271](https://github.com/erik-kroon/core-ui/issues/271)
+   - Foundation: [UI DataTable vertical](./ui-data-table-vertical.md) proves the base TanStack Table source kit for [#233](https://github.com/erik-kroon/core-ui/issues/233); realtime/domain blocks should build on it instead of re-solving the base table contract.
    - User stories covered: 8, 10, 15, 49, 52
    - Acceptance criteria:
      - A Mason registry item demonstrates a TanStack-backed data table pattern for frequent row/cell updates.

--- a/docs/agents/end-state-primitive-component-inventory.md
+++ b/docs/agents/end-state-primitive-component-inventory.md
@@ -208,7 +208,7 @@ Core owns headless accessible primitives and shared primitive helpers. UI owns s
 - ContextMenu
 - Menubar
 - NavigationMenu
-- Toast
+- Toast (`proven`; see [ui-toast-vertical.md](ui-toast-vertical.md))
 - Select
 - Combobox
 - Command
@@ -221,15 +221,15 @@ Core owns headless accessible primitives and shared primitive helpers. UI owns s
 
 ### TanStack Table UI
 
-- DataTable
-- DataTableToolbar
-- DataTablePagination
-- DataTableColumnHeader
-- DataTableFacetedFilter
-- DataTableViewOptions
-- DataTableRowActions
-- DataTableEmpty
-- DataTableSkeleton
+- DataTable (`proven`; TanStack Table source kit with controlled/uncontrolled state, native table semantics, stable data parts, and Mason registry metadata; see [ui-data-table-vertical.md](ui-data-table-vertical.md))
+- DataTableToolbar (`proven`; see [ui-data-table-vertical.md](ui-data-table-vertical.md))
+- DataTablePagination (`proven`; see [ui-data-table-vertical.md](ui-data-table-vertical.md))
+- DataTableColumnHeader (`proven`; see [ui-data-table-vertical.md](ui-data-table-vertical.md))
+- DataTableFacetedFilter (`proven`; see [ui-data-table-vertical.md](ui-data-table-vertical.md))
+- DataTableViewOptions (`proven`; see [ui-data-table-vertical.md](ui-data-table-vertical.md))
+- DataTableRowActions (`proven`; see [ui-data-table-vertical.md](ui-data-table-vertical.md))
+- DataTableEmpty (`proven`; see [ui-data-table-vertical.md](ui-data-table-vertical.md))
+- DataTableSkeleton (`proven`; see [ui-data-table-vertical.md](ui-data-table-vertical.md))
 
 ### TanStack Store And Hotkeys UI
 

--- a/docs/agents/issue-triage-spine.md
+++ b/docs/agents/issue-triage-spine.md
@@ -31,7 +31,7 @@ Keep the active board near 12-15 issues:
 - [#52](https://github.com/erik-kroon/core-ui/issues/52): registry parity metadata contract.
 - [#233](https://github.com/erik-kroon/core-ui/issues/233): UI DataTable.
 - [#246](https://github.com/erik-kroon/core-ui/issues/246): UI CommandMenu.
-- [#197](https://github.com/erik-kroon/core-ui/issues/197) and [#198](https://github.com/erik-kroon/core-ui/issues/198): TanStack Form proof.
+- [#197](https://github.com/erik-kroon/core-ui/issues/197), [#198](https://github.com/erik-kroon/core-ui/issues/198), and [#201](https://github.com/erik-kroon/core-ui/issues/201): TanStack Form proof.
 
 ## 0.1 Hardening Checklist
 
@@ -51,10 +51,10 @@ Keep the active board near 12-15 issues:
 - [ ] Menu/DropdownMenu.
 - [ ] Select.
 - [ ] Combobox.
-- [ ] Tabs.
+- [x] Tabs.
 - [ ] Checkbox/Switch/RadioGroup.
 - [ ] Field/FormControl.
-- [ ] Toast.
+- [x] Toast.
 
 ### UI
 

--- a/docs/agents/tabs-vertical.md
+++ b/docs/agents/tabs-vertical.md
@@ -16,19 +16,22 @@ This vertical applies the primitive delivery standard to Tabs:
 - `Tabs.List` renders the `tablist` role and orientation attributes.
 - `Tabs.Trigger` renders a button with `role="tab"`, `aria-selected`, `aria-controls`, roving `tabIndex`, disabled state, and stable `data-scope="tabs"` / `data-part="trigger"` hooks.
 - `Tabs.Content` renders the active `tabpanel`, links back to its trigger with `aria-labelledby`, and supports `forceMount` for user-owned animation.
+- `Tabs.Indicator` measures the active trigger relative to its list container and exposes `--keystone-tabs-indicator-x`, `--keystone-tabs-indicator-y`, `--keystone-tabs-indicator-width`, and `--keystone-tabs-indicator-height` for styled UI source.
+- Dynamic trigger removal moves uncontrolled selection to the nearest enabled successor and restores focus when the removed selected trigger held focus.
+- Panel focus follows the ARIA tabs pattern: panels receive `tabIndex=0` only when they do not already contain focusable content.
 - User click, focus, and keydown handlers run before internal behavior; internal selection/focus work skips when the event is default-prevented.
 
 ## UI Surface
 
-- `registry/default/ui/tabs.tsx` wraps Keystone Tabs with `ui-tabs-*` styling hooks.
-- `registry/default/items/tabs.json` records dependencies, parts, install command, source files, customization notes, and parity gaps.
+- `packages/ui/src/default/ui/tabs.tsx` wraps Keystone Tabs with `ui-tabs-*` styling hooks, default horizontal/vertical styling, focus rings, selected trigger state styling, and a measured indicator transform driven by Core CSS variables.
+- `registry/default/items/tabs.json` records dependencies, anatomy, CSS variables, parts, install command, source files, customization notes, and parity status.
 - `registry/default/registry.json` exposes `tabs` as a first-party Mason registry item.
 
 ## Kobalte And Base UI Comparison
 
 - Kobalte Tabs documents the same anatomy: root, list, trigger, indicator, and content. It also calls out controlled/uncontrolled value, disabled tabs, horizontal/vertical orientation, automatic/manual activation, RTL keyboard navigation, focus management for panels, and `forceMount`.
 - Base UI Tabs exposes root, list, tab, indicator, and panel, with controlled/uncontrolled value, orientation, disabled tabs, `keepMounted`, and measured indicator CSS variables.
-- Core now covers the shared core contract: value state, orientation, disabled triggers, activation mode, roving focus, trigger/panel ARIA, `forceMount`, data parts, and UI metadata.
+- Core now covers the shared core contract: value state, orientation, disabled triggers, activation mode, roving focus, trigger/panel ARIA, measured indicator variables, dynamic removal selection/focus fallback, panel focus heuristics, `forceMount`, data parts, and UI metadata.
 - The #51 parity pass adds explicit `dir="rtl"` handling for horizontal arrow keys so `ArrowLeft` moves forward and `ArrowRight` moves backward in RTL tablists.
 
 References checked on 2026-05-03:
@@ -36,6 +39,6 @@ References checked on 2026-05-03:
 - https://kobalte.dev/docs/core/components/tabs/
 - https://base-ui.com/react/components/tabs
 
-## Parity Notes
+## Final Status
 
-The next Tabs parity pass should add measured indicator positioning and CSS variables, dynamic removal focus restoration, closable/deleteable tab coordination, activation latency policy, panel focus heuristics that omit `tabIndex` when content already has focusable children, and broader touch/cursor edge-case tests.
+Tabs is a stable-candidate UI item for 0.1. The remaining intentional gaps are delete/closable tab coordination, an explicit activation latency policy for heavy panels, and broader touch/cursor edge-case tests. These stay out of the default UI component because closable tabs require application-owned collection mutation and activation latency depends on panel workload.

--- a/docs/agents/ui-data-table-vertical.md
+++ b/docs/agents/ui-data-table-vertical.md
@@ -1,0 +1,64 @@
+# UI DataTable Vertical
+
+## Status
+
+Proven for the first-party UI registry item tracked by [#233](https://github.com/erik-kroon/core-ui/issues/233).
+
+## Audit
+
+Existing reusable pieces:
+
+- `packages/ui/src/default/components/data-table/data-table.tsx`: native table renderer around a TanStack Table instance.
+- `packages/ui/src/default/components/data-table/use-data-table.ts`: Solid Table setup with sorting, filtering, pagination, column visibility, row selection, faceting, and stable row ID support.
+- `packages/ui/src/default/components/data-table/data-table-toolbar.tsx`: filter/search toolbar driven by TanStack column metadata.
+- `packages/ui/src/default/components/data-table/data-table-column-header.tsx`: sortable/hideable header controls.
+- `packages/ui/src/default/components/data-table/data-table-faceted-filter.tsx`: native checkbox/radio filter controls.
+- `packages/ui/src/default/components/data-table/data-table-pagination.tsx`: native pagination controls and page size select.
+- `packages/ui/src/default/components/data-table/data-table-view-options.tsx`: column visibility controls.
+- `packages/ui/src/default/components/data-table/data-table-row-actions.tsx`: source-owned action slot helper.
+- `packages/ui/src/default/components/data-table/data-table-search.ts` and `use-data-table-router.ts`: TanStack Router search-param adapter.
+- `registry/default/items/data-table.json` and `data-table-tanstack-router.json`: Mason multi-file registry metadata.
+
+Missing before this vertical:
+
+- Explicit DataTable API and state ownership notes in registry metadata.
+- Controlled-state callbacks for local DataTable usage outside the router adapter.
+- Reactive data/column accessors for frequent row updates.
+- Explicit table accessibility/data-attribute contract beyond native implicit semantics.
+- Source-contract tests for generated DataTable ARIA, native-control, state, and metadata guarantees.
+
+## End-State Contract
+
+DataTable is a UI-owned TanStack Table source kit. It does not implement a table engine, virtualizer, fetcher, or persistence layer. App behavior comes from `@tanstack/solid-table`; Keystone UI owns readable composition, native controls, styling hooks, and registry metadata.
+
+API:
+
+- `DataTable` receives a TanStack `Table<TData>` instance plus optional `caption`, toolbar/header slot, `empty`, `loading`, `skeletonRows`, `pageSizeOptions`, and `pagination`.
+- `useDataTable` accepts `data` and `columns` as values or Solid accessors, `getRowId`, `initialState`, optional controlled `state` slices, matching `on*Change` callbacks, `manualSorting`, `manualFiltering`, `manualPagination`, and `pageCount`.
+- `useDataTableRouter` maps TanStack Router search params to pagination, sorting, filters, and visibility while leaving row selection local.
+
+Anatomy and attributes:
+
+- Stable `data-scope="ui-data-table"` appears on all public parts.
+- Stable parts include `root`, `header-slot`, `viewport`, `table`, `caption`, `header`, `header-row`, `head`, `body`, `row`, `cell`, `empty-row`, `empty`, `skeleton-row`, `skeleton-cell`, `column-header`, `sort-trigger`, `sort-clear`, `column-hide`, `toolbar`, `search`, `reset`, `toolbar-actions`, `faceted-filter`, `faceted-option`, `faceted-count`, `faceted-clear`, `view-options`, `view-options-search`, `view-option`, `row-actions`, `pagination`, `selected-summary`, `page-summary`, `page-size`, and `page-buttons`.
+- Root exposes `data-loading` and `data-empty`.
+- Header cells expose `data-sort` and `aria-sort`.
+- Selected rows expose `data-selected`, `data-state="selected"`, and `aria-selected`.
+
+Accessibility:
+
+- Native table semantics are preferred over ARIA table reimplementation.
+- Caption, table, header, body, row, cell, button, search input, checkbox, radio, select, fieldset, legend, and label semantics are used directly.
+- Loading sets `aria-busy` on the root.
+- Pagination is a labelled navigation region with live page/selection summaries.
+- Sorting, clearing, hiding, searching, pagination, and row-action controls are keyboard reachable through native elements.
+
+SSR and hydration:
+
+- Source renders deterministic native markup and does not read browser globals during render.
+- Apps should pass `getRowId` when rows can reorder or update frequently so selection and hydration-sensitive row identity do not depend on array index.
+
+Known limitations:
+
+- Virtualization, server fetching orchestration, persisted views, drag column sizing/ordering, and advanced query builders remain future app-code or companion-item work.
+- The router adapter validates basic search-param shape but does not own loader integration or debounced URL writes.

--- a/docs/agents/ui-tanstack-form-vertical.md
+++ b/docs/agents/ui-tanstack-form-vertical.md
@@ -41,14 +41,26 @@ SelectField:
   `field.handleBlur()`.
 - It preserves Core Select listbox behavior, hidden form value, typeahead, disabled options,
   and popup geometry instead of copying primitive internals.
+- The end-state API supports flat or grouped string options, disabled groups/options,
+  `textValue` for JSX labels, an empty listbox state, `selectProps`, and per-part class/prop
+  escape hatches for trigger, content, listbox, group, group label, and item source.
+- SelectField forwards disabled, readonly, required, and form ownership to Core Select,
+  treats the empty string as the no-selection value for placeholder display, and wires
+  trigger `aria-labelledby`/`aria-describedby` to TanStackField label, description, and
+  error IDs.
 
 ## Registry Status
 
 - `tanstack-form`, `tanstack-field`, and `select-field` carry `meta.api`,
-  `meta.accessibility`, `meta.anatomy`, `meta.cssVariables`, `meta.limitations`, and
-  `meta.parity` notes.
+  `meta.accessibility`, `meta.anatomy`, `meta.cssVariables`, `meta.state`,
+  `meta.dataAttributes`, `meta.ssr`, `meta.limitations`, and `meta.parity` notes where
+  relevant to the item.
 - `select-field` depends on `select` and `tanstack-field`, so installed source reuses the
   same UI Select and TanStack field contracts.
+- Issue #201 final status: implemented as the string-first, single-select TanStack adapter.
+  Known limitations are intentional: empty string means no selection, and multi-select,
+  object adapters, async loading, filtering, virtualization, and schema-specific validation
+  helpers remain app-owned composition.
 
 ## Verification
 

--- a/docs/agents/ui-toast-vertical.md
+++ b/docs/agents/ui-toast-vertical.md
@@ -1,0 +1,44 @@
+# UI Toast Vertical
+
+Issue: #223
+
+## Audit
+
+Core already provides the reusable Toast behavior floor: provider, viewport, root, title,
+description, action, close, manager shortcuts, id-based update/dismiss, live-region roles, viewport
+limits, duration timers, and hover/focus pause behavior. The previous UI source only passed classes
+through to Core parts and exported a minimal `Toaster`, so generated apps received little source-owned
+presentation or Sonner-style ergonomics.
+
+Reusable pieces were the Core Toast contract, `toaster` manager export, `cn` registry dependency,
+stable Core `data-scope`/`data-part` attributes, and the existing registry parity metadata.
+
+## End-State Contract
+
+- API: `Toaster`, `toaster`, `ToastProvider`, `ToastViewport`, `Toast`, `ToastIcon`, `ToastTitle`,
+  `ToastDescription`, `ToastAction`, `ToastClose`, and `ToastPrimitive`.
+- Anatomy: Core parts stay `viewport`, `root`, `title`, `description`, `action`, and `close`; UI adds
+  a decorative `toast-icon` slot plus stable `data-slot` hooks for source customization.
+- Presentation: default `Toaster` renders responsive Sonner-inspired notification cards with tone
+  icons, close button, action styling, position presets, and `--toast-offset`, `--toast-gap`, and
+  `--toast-width` customization variables.
+- Accessibility: Core owns the labeled region, status/alert roles, title/description relationships,
+  action callbacks, close labeling, timer scheduling, pause/resume, and visible limit. UI icons are
+  decorative and `aria-hidden`.
+- State: UI does not own toast state. Controlled/uncontrolled behavior remains the Core manager
+  contract through `manager`, `toaster`, `add`, `update`, `dismiss`, `clear`, and subscriptions.
+- SSR/hydration: UI source has no browser-only effects; server and client markup are determined by
+  props and Core context.
+
+## Intentional Limits
+
+Swipe gestures, measured stacking/expand mode, promise helper lifecycle, cancel action, rich custom
+renderer presets, and window-blur timer pausing remain explicit follow-up work for Core or a future
+UI helper. Toast does not participate in focus trapping, outside hiding, inerting, prevent-scroll, or
+overlay layer behavior.
+
+## Verification
+
+- `packages/core/test/toast.behavior.test.tsx` covers the user-visible behavior floor.
+- `packages/mason-registry/src/registry-validation.test.ts` covers the generated UI source contract,
+  registry anatomy, accessibility metadata, CSS variables, limitations, and parity notes.

--- a/packages/core/src/tabs/index.tsx
+++ b/packages/core/src/tabs/index.tsx
@@ -1,6 +1,7 @@
 import {
   Show,
   createContext,
+  createEffect,
   createMemo,
   createSignal,
   createUniqueId,
@@ -25,7 +26,7 @@ export type TabsDirection = CoreDirection;
 export type TabsOrientation = "horizontal" | "vertical";
 export type TabsValueChangeDetail = {
   event?: Event;
-  reason: "trigger" | "programmatic";
+  reason: "dynamic-removal" | "trigger" | "programmatic";
 };
 
 export type TabsPartProps<T extends HTMLElement = HTMLElement> = {
@@ -68,6 +69,16 @@ type TriggerRecord = {
   element: HTMLButtonElement;
   value: string;
 };
+
+const FOCUSABLE_PANEL_CONTENT = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  "[contenteditable]",
+  '[tabindex]:not([tabindex="-1"])',
+].join(",");
 
 export type CreateTabsOptions = {
   activationMode?: () => TabsActivationMode | undefined;
@@ -130,7 +141,19 @@ export function createTabs(options: CreateTabsOptions = {}): TabsApi {
     registryVersion();
     return triggerRecords.find((record) => !record.disabled())?.value;
   });
-  const selectedValue = createMemo(() => value() ?? firstEnabledValue());
+  const selectedValue = createMemo(() => {
+    registryVersion();
+    const currentValue = value();
+    if (currentValue !== undefined && triggerRecords.length === 0) return currentValue;
+    if (
+      currentValue !== undefined &&
+      triggerRecords.some((record) => record.value === currentValue && !record.disabled())
+    ) {
+      return currentValue;
+    }
+
+    return firstEnabledValue();
+  });
 
   const getTriggerId = (triggerValue: string) => {
     const current = triggerIds.get(triggerValue);
@@ -170,9 +193,20 @@ export function createTabs(options: CreateTabsOptions = {}): TabsApi {
       setRegistryVersion((version) => version + 1);
 
       return () => {
+        const wasActive = element === element.ownerDocument.activeElement;
+        const wasSelected = selectedValue() === triggerValue;
         const index = triggerRecords.indexOf(record);
         if (index >= 0) triggerRecords.splice(index, 1);
         setRegistryVersion((version) => version + 1);
+        if (!wasActive && !wasSelected) return;
+
+        queueMicrotask(() => {
+          const enabledTriggers = triggerRecords.filter((candidate) => !candidate.disabled());
+          const fallback = enabledTriggers[Math.min(index, enabledTriggers.length - 1)];
+          if (!fallback) return;
+          if (wasSelected) setValueState(fallback.value, { reason: "dynamic-removal" });
+          if (wasActive) fallback.element.focus();
+        });
       };
     },
     selectValue,
@@ -331,14 +365,72 @@ function Trigger(props: TabsTriggerProps) {
 
 function Indicator(props: TabsIndicatorProps) {
   const tabs = useTabs("Indicator");
-  const [local, others] = splitProps(props, ["children"]);
+  const [local, others] = splitProps(props, ["children", "ref"]);
+  const [indicatorElement, setIndicatorElement] = createSignal<HTMLDivElement>();
+  let cleanupMeasurement: (() => void) | undefined;
+
+  const updateIndicator = () => {
+    const element = indicatorElement();
+    const selectedTrigger = tabs.triggers().find((record) => record.value === tabs.selectedValue());
+    const container = element?.parentElement;
+    if (!element || !selectedTrigger || !container) return;
+
+    const triggerRect = selectedTrigger.element.getBoundingClientRect();
+    const containerRect = container.getBoundingClientRect();
+    const x = triggerRect.left - containerRect.left + container.scrollLeft;
+    const y = triggerRect.top - containerRect.top + container.scrollTop;
+
+    element.style.setProperty("--keystone-tabs-indicator-x", `${x}px`);
+    element.style.setProperty("--keystone-tabs-indicator-y", `${y}px`);
+    element.style.setProperty("--keystone-tabs-indicator-width", `${triggerRect.width}px`);
+    element.style.setProperty("--keystone-tabs-indicator-height", `${triggerRect.height}px`);
+  };
+
+  createEffect(() => {
+    indicatorElement();
+    tabs.selectedValue();
+    tabs.orientation();
+    tabs.triggers();
+    queueMicrotask(updateIndicator);
+  });
+
+  createEffect(() => {
+    const element = indicatorElement();
+    cleanupMeasurement?.();
+    cleanupMeasurement = undefined;
+    if (!element) return;
+
+    const selectedTrigger = tabs.triggers().find((record) => record.value === tabs.selectedValue());
+    const resizeObserver = globalThis.ResizeObserver
+      ? new ResizeObserver(updateIndicator)
+      : undefined;
+    if (resizeObserver) {
+      resizeObserver.observe(element);
+      if (element.parentElement) resizeObserver.observe(element.parentElement);
+      if (selectedTrigger) resizeObserver.observe(selectedTrigger.element);
+    }
+
+    globalThis.addEventListener?.("resize", updateIndicator);
+    cleanupMeasurement = () => {
+      resizeObserver?.disconnect();
+      globalThis.removeEventListener?.("resize", updateIndicator);
+    };
+  });
+
+  onCleanup(() => cleanupMeasurement?.());
 
   return (
     <div
       {...others}
       data-disabled={dataBoolean(tabs.disabled())}
       data-orientation={tabs.orientation()}
+      data-state={tabs.selectedValue() ? "measured" : "idle"}
       {...partDataAttributes("tabs", "indicator")}
+      ref={(element) => {
+        setIndicatorElement(element);
+        if (typeof local.ref === "function") local.ref(element);
+        queueMicrotask(updateIndicator);
+      }}
     >
       {local.children}
     </div>
@@ -347,8 +439,40 @@ function Indicator(props: TabsIndicatorProps) {
 
 function Content(props: TabsContentProps) {
   const tabs = useTabs("Content");
-  const [local, others] = splitProps(props, ["children", "forceMount", "value"]);
+  const [local, others] = splitProps(props, ["children", "forceMount", "ref", "value"]);
   const selected = createMemo(() => tabs.selectedValue() === local.value);
+  const [tabIndex, setTabIndex] = createSignal<number | undefined>(0);
+  const [panelElement, setPanelElement] = createSignal<HTMLDivElement>();
+  let cleanupPanelObserver: (() => void) | undefined;
+
+  const updatePanelTabIndex = () => {
+    const element = panelElement();
+    if (!element) return;
+    setTabIndex(element.querySelector(FOCUSABLE_PANEL_CONTENT) ? undefined : 0);
+  };
+
+  createEffect(() => {
+    panelElement();
+    selected();
+    queueMicrotask(updatePanelTabIndex);
+  });
+
+  createEffect(() => {
+    const element = panelElement();
+    cleanupPanelObserver?.();
+    cleanupPanelObserver = undefined;
+    if (!element || !globalThis.MutationObserver) return;
+
+    const observer = new MutationObserver(updatePanelTabIndex);
+    observer.observe(element, {
+      attributes: true,
+      childList: true,
+      subtree: true,
+    });
+    cleanupPanelObserver = () => observer.disconnect();
+  });
+
+  onCleanup(() => cleanupPanelObserver?.());
 
   return (
     <Show when={local.forceMount || selected()}>
@@ -356,13 +480,18 @@ function Content(props: TabsContentProps) {
         {...others}
         id={tabs.getContentId(local.value)}
         role="tabpanel"
-        tabIndex={0}
+        tabIndex={tabIndex()}
         hidden={selected() ? undefined : true}
         aria-labelledby={tabs.getTriggerId(local.value)}
         data-disabled={dataBoolean(tabs.disabled())}
         data-orientation={tabs.orientation()}
         data-selected={dataBoolean(selected())}
         {...partDataAttributes("tabs", "content")}
+        ref={(element) => {
+          setPanelElement(element);
+          if (typeof local.ref === "function") local.ref(element);
+          queueMicrotask(updatePanelTabIndex);
+        }}
       >
         {local.children}
       </div>

--- a/packages/core/test/tabs.behavior.test.tsx
+++ b/packages/core/test/tabs.behavior.test.tsx
@@ -1,4 +1,4 @@
-import { createRoot, createSignal } from "solid-js";
+import { For, createRoot, createSignal } from "solid-js";
 import { describe, expect, test } from "vitest";
 import { Tabs, createTabs } from "../src/tabs/index";
 import { click, keyDown, render, settled } from "./harness";
@@ -135,7 +135,113 @@ describe("Tabs behavior", () => {
     expect(triggers[0].getAttribute("aria-selected")).toBe("true");
     expect(triggers[1].getAttribute("aria-selected")).toBe("false");
   });
+
+  test("measures the active trigger for indicator CSS variables", async () => {
+    render(() => (
+      <Tabs.Root defaultValue="alpha">
+        <Tabs.List>
+          <Tabs.Trigger value="alpha">Alpha</Tabs.Trigger>
+          <Tabs.Trigger value="beta">Beta</Tabs.Trigger>
+          <Tabs.Indicator />
+        </Tabs.List>
+        <Tabs.Content value="alpha">Alpha panel</Tabs.Content>
+        <Tabs.Content value="beta">Beta panel</Tabs.Content>
+      </Tabs.Root>
+    ));
+
+    const list = getList();
+    const triggers = getTriggers();
+    const indicator = document.body.querySelector<HTMLElement>(
+      '[data-scope="tabs"][data-part="indicator"]',
+    );
+    if (!indicator) throw new Error("Unable to find tabs indicator");
+
+    setRect(list, { height: 40, left: 10, top: 20, width: 240 });
+    setRect(triggers[1], { height: 32, left: 90, top: 24, width: 72 });
+
+    click(triggers[1]);
+    await settled();
+
+    expect(indicator.style.getPropertyValue("--keystone-tabs-indicator-x")).toBe("80px");
+    expect(indicator.style.getPropertyValue("--keystone-tabs-indicator-y")).toBe("4px");
+    expect(indicator.style.getPropertyValue("--keystone-tabs-indicator-width")).toBe("72px");
+    expect(indicator.style.getPropertyValue("--keystone-tabs-indicator-height")).toBe("32px");
+    expect(indicator.getAttribute("data-state")).toBe("measured");
+  });
+
+  test("moves selection and focus when the active trigger is removed", async () => {
+    const [items, setItems] = createSignal([
+      { label: "One", value: "one" },
+      { label: "Two", value: "two" },
+      { label: "Three", value: "three" },
+    ]);
+    const changes: Array<{ reason: string; value: string }> = [];
+
+    render(() => (
+      <Tabs.Root
+        defaultValue="two"
+        onValueChange={(value, detail) => changes.push({ reason: detail.reason, value })}
+      >
+        <Tabs.List>
+          <For each={items()}>
+            {(item) => <Tabs.Trigger value={item.value}>{item.label}</Tabs.Trigger>}
+          </For>
+        </Tabs.List>
+        <For each={items()}>
+          {(item) => <Tabs.Content value={item.value}>{item.label} panel</Tabs.Content>}
+        </For>
+      </Tabs.Root>
+    ));
+
+    getTriggers()[1].focus();
+    setItems((current) => current.filter((item) => item.value !== "two"));
+    await settled();
+
+    const triggers = getTriggers();
+    expect(document.activeElement).toBe(triggers[1]);
+    expect(triggers[1].getAttribute("aria-selected")).toBe("true");
+    expect(getPanel("three").textContent).toBe("Three panel");
+    expect(changes).toContainEqual({ reason: "dynamic-removal", value: "three" });
+  });
+
+  test("omits panel tabIndex when the active panel has focusable content", async () => {
+    render(() => (
+      <Tabs.Root defaultValue="plain">
+        <Tabs.List>
+          <Tabs.Trigger value="plain">Plain</Tabs.Trigger>
+          <Tabs.Trigger value="interactive">Interactive</Tabs.Trigger>
+        </Tabs.List>
+        <Tabs.Content value="plain">Plain panel</Tabs.Content>
+        <Tabs.Content value="interactive">
+          Interactive panel
+          <button type="button">Focusable action</button>
+        </Tabs.Content>
+      </Tabs.Root>
+    ));
+
+    expect(getPanel("plain").getAttribute("tabindex")).toBe("0");
+
+    click(getTriggers()[1]);
+    await settled();
+
+    expect(getPanel("interactive").hasAttribute("tabindex")).toBe(false);
+  });
 });
+
+function setRect(element: HTMLElement, rect: Pick<DOMRect, "height" | "left" | "top" | "width">) {
+  element.getBoundingClientRect = () =>
+    ({
+      bottom: rect.top + rect.height,
+      height: rect.height,
+      left: rect.left,
+      right: rect.left + rect.width,
+      top: rect.top,
+      width: rect.width,
+      x: rect.left,
+      y: rect.top,
+      toJSON: () => ({}),
+    }) as DOMRect;
+}
 
 function getList() {
   const list = document.body.querySelector<HTMLElement>('[data-scope="tabs"][data-part="list"]');

--- a/packages/mason-registry/src/registry-validation.test.ts
+++ b/packages/mason-registry/src/registry-validation.test.ts
@@ -161,6 +161,7 @@ describe("Mason registry validation tracer", () => {
       "field",
       "hover-card",
       "input",
+      "invoice-dashboard",
       "label",
       "menu",
       "menubar",
@@ -176,6 +177,7 @@ describe("Mason registry validation tracer", () => {
       "tabs",
       "tanstack-field",
       "tanstack-form",
+      "tanstack-start-dashboard",
       "text-field",
       "textarea",
       "toast",
@@ -226,12 +228,79 @@ describe("Mason registry validation tracer", () => {
         result.value.files.length,
       );
       expect(result.value.meta?.columns).toBeString();
+      expect(result.value.meta?.api).toContain("accessors");
       expect(result.value.meta?.sorting).toBeString();
       expect(result.value.meta?.filtering).toBeString();
       expect(result.value.meta?.pagination).toBeString();
+      expect(result.value.meta?.state).toContain("controlled");
+      expect(result.value.meta?.accessibility).toContain("aria-sort");
+      expect(result.value.meta?.dataAttributes).toContain('data-scope="ui-data-table"');
+      expect(result.value.meta?.ssr).toContain("getRowId");
       expect(result.value.meta?.rowActions).toBeString();
       expect(result.value.meta?.limitations).toBeString();
     }
+  });
+
+  test("captures the real default data-table generated source contract", async () => {
+    const sourceRoot = resolve(uiPackageSourceRoot, "components/data-table");
+    const [
+      table,
+      useTable,
+      columnHeader,
+      toolbar,
+      facetedFilter,
+      pagination,
+      viewOptions,
+      rowActions,
+    ] = await Promise.all([
+      readFile(resolve(sourceRoot, "data-table.tsx"), "utf8"),
+      readFile(resolve(sourceRoot, "use-data-table.ts"), "utf8"),
+      readFile(resolve(sourceRoot, "data-table-column-header.tsx"), "utf8"),
+      readFile(resolve(sourceRoot, "data-table-toolbar.tsx"), "utf8"),
+      readFile(resolve(sourceRoot, "data-table-faceted-filter.tsx"), "utf8"),
+      readFile(resolve(sourceRoot, "data-table-pagination.tsx"), "utf8"),
+      readFile(resolve(sourceRoot, "data-table-view-options.tsx"), "utf8"),
+      readFile(resolve(sourceRoot, "data-table-row-actions.tsx"), "utf8"),
+    ]);
+
+    expect(table).toContain('data-scope="ui-data-table"');
+    expect(table).toContain('data-part="caption"');
+    expect(table).toContain("aria-busy={local.loading || undefined}");
+    expect(table).toContain('scope="col"');
+    expect(table).toContain("aria-sort={getAriaSort(header.column.getIsSorted())}");
+    expect(table).toContain("aria-selected={row.getIsSelected() || undefined}");
+    expect(table).toContain('data-selected={row.getIsSelected() ? "" : undefined}');
+    expect(table).toContain("function getAriaSort");
+
+    expect(useTable).toContain("type MaybeAccessor");
+    expect(useTable).toContain("state?: {");
+    expect(useTable).toContain("onSortingChange?: OnChangeFn<SortingState>");
+    expect(useTable).toContain("manualPagination?: boolean");
+    expect(useTable).toContain("resolveDataTableOption(options.data)");
+
+    expect(columnHeader).toContain("aria-label={`Sort ${label()}`}");
+    expect(columnHeader).toContain('data-part="sort-trigger"');
+    expect(columnHeader).toContain('data-part="sort-clear"');
+    expect(columnHeader).toContain('data-part="column-hide"');
+
+    expect(toolbar).toContain('type="search"');
+    expect(toolbar).toContain("aria-label={meta?.placeholder ?? `Search ${label}`}");
+    expect(toolbar).toContain("Reset table filters and column visibility");
+
+    expect(facetedFilter).toContain("<fieldset");
+    expect(facetedFilter).toContain("<legend>{props.title}</legend>");
+    expect(facetedFilter).toContain('type={props.multiple === false ? "radio" : "checkbox"}');
+    expect(facetedFilter).toContain("props.table.setPageIndex(0)");
+
+    expect(pagination).toContain('role="navigation"');
+    expect(pagination).toContain('aria-label="Table pagination"');
+    expect(pagination).toContain('aria-live="polite"');
+    expect(pagination).toContain('aria-label="Go to next page"');
+
+    expect(viewOptions).toContain('role="group"');
+    expect(viewOptions).toContain('aria-label="Column visibility"');
+    expect(rowActions).toContain('role="group"');
+    expect(rowActions).toContain('aria-label="Row actions"');
   });
 
   test("validates docs-ready metadata on the real default data-table router adapter item", async () => {
@@ -246,6 +315,111 @@ describe("Mason registry validation tracer", () => {
       expect(result.value.meta?.stateMapping).toBeString();
       expect(result.value.meta?.limitations).toBeString();
     }
+  });
+
+  test("validates docs-ready metadata on the real default invoice-dashboard block", async () => {
+    const item = await import("../../../registry/default/items/invoice-dashboard.json");
+    const result = validateItem(item.default, { registryRoot: repoRoot });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.type).toBe("registry:block");
+      expect(result.value.dependencies).toContain("@tanstack/solid-form@^1.29.1");
+      expect(result.value.dependencies).toContain("@tanstack/solid-table@^8.21.3");
+      expect(result.value.registryDependencies).toContain("data-table");
+      expect(result.value.registryDependencies).toContain("text-field");
+      expect(result.value.registryDependencies).toContain("toast");
+      expect(result.value.files).toHaveLength(3);
+      expect(
+        result.value.files.every((file) =>
+          file.target?.startsWith("src/components/blocks/invoice-dashboard/"),
+        ),
+      ).toBe(true);
+      expect(result.value.meta?.fileTree).toContain("invoice-dashboard-columns.tsx");
+      expect(result.value.meta?.frameworkAssumptions).toContain("Solid");
+      expect(result.value.meta?.interactions).toContain("table sorting");
+      expect(result.value.meta?.parity).toMatchObject({
+        shadcn: expect.any(String),
+        tanstackForm: expect.any(String),
+        tanstackTable: expect.any(String),
+        sonner: expect.any(String),
+      });
+    }
+  });
+
+  test("captures the real default invoice-dashboard generated source contract", async () => {
+    const sourceRoot = resolve(uiPackageSourceRoot, "blocks/invoice-dashboard");
+    const [block, columns, data] = await Promise.all([
+      readFile(resolve(sourceRoot, "invoice-dashboard.tsx"), "utf8"),
+      readFile(resolve(sourceRoot, "invoice-dashboard-columns.tsx"), "utf8"),
+      readFile(resolve(sourceRoot, "invoice-dashboard-data.ts"), "utf8"),
+    ]);
+
+    expect(block).toContain('data-part="invoice-dashboard"');
+    expect(block).toContain("createForm");
+    expect(block).toContain("CommandMenu");
+    expect(block).toContain("DataTableToolbar");
+    expect(block).toContain("TanStackFormSubmit");
+    expect(block).toContain("Toaster");
+    expect(columns).toContain("DataTableColumnHeader");
+    expect(columns).toContain("DataTableRowActions");
+    expect(columns).toContain("dataTableFacetedFilter");
+    expect(data).toContain("invoiceDashboardRows");
+    expect(data).toContain("invoiceDashboardStatusOptions");
+  });
+
+  test("validates docs-ready metadata on the real default TanStack Start dashboard template", async () => {
+    const item = await import("../../../registry/default/items/tanstack-start-dashboard.json");
+    const result = validateItem(item.default, { registryRoot: repoRoot });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.type).toBe("registry:template");
+      expect(result.value.registryDependencies).toEqual(["invoice-dashboard"]);
+      expect(result.value.dependencies).toContain("@tanstack/solid-start@^1.167.58");
+      expect(result.value.dependencies).toContain("@tanstack/solid-router@^1.168.20");
+      expect(result.value.files.length).toBeGreaterThanOrEqual(8);
+      expect(result.value.meta?.fileTree).toContain("src/routes/index.tsx");
+      expect(result.value.meta?.frameworkAssumptions).toContain("TanStack Start");
+      expect(result.value.meta?.verification).toContain("invoice-dashboard block is installed");
+      expect(result.value.meta?.parity).toMatchObject({
+        tanstackStart: expect.any(String),
+        shadcn: expect.any(String),
+        mason: expect.any(String),
+      });
+    }
+  });
+
+  test("captures the real default tabs generated source contract", async () => {
+    const item = await import("../../../registry/default/items/tabs.json");
+    const result = validateItem(item.default, { registryRoot: repoRoot });
+    const source = await readFile(resolve(uiPackageSourceRoot, "ui/tabs.tsx"), "utf8");
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.meta?.anatomy).toEqual([
+        "Tabs",
+        "TabsList",
+        "TabsTrigger",
+        "TabsIndicator",
+        "TabsContent",
+      ]);
+      expect(result.value.meta?.cssVariables).toEqual([
+        "--keystone-tabs-indicator-x",
+        "--keystone-tabs-indicator-y",
+        "--keystone-tabs-indicator-width",
+        "--keystone-tabs-indicator-height",
+      ]);
+      expect(result.value.meta?.accessibility).toContain("role=tablist/tab/tabpanel");
+    }
+
+    expect(source).toContain("tabsRootClass");
+    expect(source).toContain("tabsIndicatorClass");
+    expect(source).toContain("--keystone-tabs-indicator-x");
+    expect(source).toContain("--keystone-tabs-indicator-width");
+    expect(source).toContain("data-[orientation=vertical]:flex-col");
+    expect(source).toContain("focus-visible:ring-2");
+    expect(source).toContain("data-selected:text-foreground");
   });
 
   test("validates docs-ready metadata on the real default command-menu item", async () => {
@@ -597,7 +771,9 @@ describe("Mason registry validation tracer", () => {
       expect(result.value.dependencies).toContain("@keystone-ui/core@^0.0.0");
       expect(result.value.dependencies).toContain("@tanstack/solid-form@^1.29.1");
       expect(result.value.registryDependencies).toEqual(["cn", "select", "tanstack-field"]);
-      expect(result.value.meta?.api).toContain("TanStackField");
+      expect(result.value.meta?.api).toContain("SelectFieldOptionGroup");
+      expect(result.value.meta?.api).toContain("textValue");
+      expect(result.value.meta?.accessibility).toContain("aria-labelledby");
       expect(result.value.meta?.accessibility).toContain("hidden form value");
       expect(result.value.meta?.anatomy).toEqual([
         "field-root",
@@ -606,13 +782,20 @@ describe("Mason registry validation tracer", () => {
         "value",
         "content",
         "listbox",
+        "group",
+        "group-label",
         "item",
         "item-text",
         "item-indicator",
+        "empty",
         "field-description",
         "field-error",
       ]);
       expect(result.value.meta?.limitations).toContain("single-value");
+      expect(result.value.meta?.limitations).toContain("empty string");
+      expect(result.value.meta?.state).toContain("field.handleBlur");
+      expect(result.value.meta?.dataAttributes).toContain('data-slot="select-field-empty"');
+      expect(result.value.meta?.ssr).toContain("deterministic");
       expect(result.value.meta?.parity).toMatchObject({
         tanstackForm: expect.any(String),
         baseUi: expect.any(String),
@@ -623,12 +806,25 @@ describe("Mason registry validation tracer", () => {
     expect(source).toContain('from "@/components/ui/select"');
     expect(source).toContain('from "@/components/ui/tanstack-field"');
     expect(source).toContain("export function SelectField");
+    expect(source).toContain("export type SelectFieldOptionGroup");
     expect(source).toContain("<TanStackField<string, HTMLButtonElement>");
+    expect(source).toContain("aria-describedby={props.describedBy || undefined}");
+    expect(source).toContain("aria-labelledby={props.labelledBy}");
+    expect(source).toContain("disabled={props.disabled}");
+    expect(source).toContain("readOnly={props.readOnly}");
+    expect(source).toContain("required={props.required}");
+    expect(source).toContain("form={props.formId}");
+    expect(source).toContain("props.value.length > 0 ? props.value : undefined");
     expect(source).toContain("field().handleBlur()");
     expect(source).toContain('field().handleChange(next ?? "")');
+    expect(source).toContain("props.selectProps?.onOpenChange?.(open, detail)");
+    expect(source).toContain("label={optionText(props.option)}");
     expect(source).toContain('data-slot="select-field-trigger"');
     expect(source).toContain('data-slot="select-field-content"');
+    expect(source).toContain('data-slot="select-field-group"');
+    expect(source).toContain('data-slot="select-field-group-label"');
     expect(source).toContain('data-slot="select-field-item"');
+    expect(source).toContain('data-slot="select-field-empty"');
   });
 
   test("captures Combobox parity metadata and generated source contract", async () => {
@@ -921,17 +1117,42 @@ describe("Mason registry validation tracer", () => {
       expect(result.value.meta?.parts).toEqual([
         "viewport",
         "root",
+        "icon",
         "title",
         "description",
         "action",
         "close",
       ]);
+      expect(result.value.meta?.api).toContain("ToastPrimitive");
+      expect(result.value.meta?.anatomy).toMatchObject({
+        coreParts: expect.arrayContaining(["viewport", "root", "title", "description"]),
+        uiSlots: expect.arrayContaining(["toast-viewport", "toast-icon", "toast-close"]),
+      });
+      expect(result.value.meta?.accessibility).toEqual(
+        expect.arrayContaining([expect.any(String)]),
+      );
+      expect(result.value.meta?.cssVariables).toEqual([
+        "--toast-offset",
+        "--toast-gap",
+        "--toast-width",
+      ]);
+      expect(result.value.meta?.limitations).toEqual(expect.arrayContaining([expect.any(String)]));
       expect(result.value.meta?.parity).toMatchObject({
         baseUi: expect.any(String),
         kobalte: expect.any(String),
         sonner: expect.any(String),
       });
     }
+
+    const source = await Bun.file(join(repoRoot, "packages/ui/src/default/ui/toast.tsx")).text();
+
+    expect(source).toContain('from "@keystone-ui/core/toast"');
+    expect(source).toContain("export function ToastIcon");
+    expect(source).toContain("export const ToastPrimitive = CoreToast");
+    expect(source).toContain('data-slot="toast-viewport"');
+    expect(source).toContain('data-slot="toast-icon"');
+    expect(source).toContain("[--toast-width:24rem]");
+    expect(source).toContain("renderToast?: (toast: ToastData) => JSX.Element");
   });
 
   test("resolves dialog registry dependencies deterministically", () => {

--- a/packages/ui/src/default/blocks/invoice-dashboard/invoice-dashboard-columns.tsx
+++ b/packages/ui/src/default/blocks/invoice-dashboard/invoice-dashboard-columns.tsx
@@ -1,0 +1,86 @@
+import type { ColumnDef } from "@tanstack/solid-table";
+import { Badge } from "@/components/ui/badge";
+import { DataTableColumnHeader } from "@/components/data-table/data-table-column-header";
+import { DataTableRowActions } from "@/components/data-table/data-table-row-actions";
+import { dataTableFacetedFilter } from "@/components/data-table/use-data-table";
+import {
+  invoiceDashboardStatusOptions,
+  type InvoiceDashboardRow,
+  type InvoiceDashboardStatus,
+} from "./invoice-dashboard-data";
+
+const statusVariant: Record<InvoiceDashboardStatus, "muted" | "outline" | "solid"> = {
+  draft: "muted",
+  open: "outline",
+  paid: "solid",
+};
+
+function formatCurrency(value: number) {
+  return new Intl.NumberFormat("en-US", {
+    currency: "USD",
+    maximumFractionDigits: 0,
+    style: "currency",
+  }).format(value);
+}
+
+export const invoiceDashboardColumns: ColumnDef<InvoiceDashboardRow, unknown>[] = [
+  {
+    accessorKey: "customer",
+    header: ({ column }) => <DataTableColumnHeader column={column} title="Customer" />,
+    cell: ({ row }) => (
+      <div class="ui-block-invoice-dashboard-customer">
+        <span>{row.original.customer}</span>
+        <small>{row.original.id}</small>
+      </div>
+    ),
+    meta: {
+      label: "Customer",
+      placeholder: "Search customers",
+      variant: "text",
+    },
+  },
+  {
+    accessorKey: "status",
+    header: "Status",
+    cell: ({ row }) => (
+      <Badge variant={statusVariant[row.original.status]}>{row.original.status}</Badge>
+    ),
+    filterFn: dataTableFacetedFilter,
+    meta: {
+      label: "Status",
+      options: invoiceDashboardStatusOptions,
+      variant: "multiSelect",
+    },
+  },
+  {
+    accessorKey: "owner",
+    header: "Owner",
+    meta: {
+      label: "Owner",
+      placeholder: "Search owner",
+      variant: "text",
+    },
+  },
+  {
+    accessorKey: "total",
+    header: ({ column }) => <DataTableColumnHeader column={column} title="Total" />,
+    cell: ({ row }) => formatCurrency(row.original.total),
+  },
+  {
+    accessorKey: "updatedAt",
+    header: "Updated",
+  },
+  {
+    id: "actions",
+    enableHiding: false,
+    cell: ({ row }) => (
+      <DataTableRowActions
+        row={row}
+        actions={[
+          { label: "Open invoice", onSelect: (current) => current.original.id },
+          { label: "Mark paid", onSelect: (current) => current.original.status },
+        ]}
+      />
+    ),
+  },
+];

--- a/packages/ui/src/default/blocks/invoice-dashboard/invoice-dashboard-data.ts
+++ b/packages/ui/src/default/blocks/invoice-dashboard/invoice-dashboard-data.ts
@@ -1,0 +1,63 @@
+export type InvoiceDashboardStatus = "draft" | "open" | "paid";
+
+export type InvoiceDashboardRow = {
+  id: string;
+  customer: string;
+  status: InvoiceDashboardStatus;
+  total: number;
+  owner: string;
+  updatedAt: string;
+};
+
+export type InvoiceDashboardMetric = {
+  label: string;
+  value: string;
+  detail: string;
+};
+
+export const invoiceDashboardRows: InvoiceDashboardRow[] = [
+  {
+    id: "inv-1001",
+    customer: "Northstar Labs",
+    status: "paid",
+    total: 12800,
+    owner: "Mina",
+    updatedAt: "Today",
+  },
+  {
+    id: "inv-1002",
+    customer: "Orbit Systems",
+    status: "open",
+    total: 8400,
+    owner: "Jon",
+    updatedAt: "Yesterday",
+  },
+  {
+    id: "inv-1003",
+    customer: "Pioneer Studio",
+    status: "draft",
+    total: 5100,
+    owner: "Mina",
+    updatedAt: "Apr 28",
+  },
+  {
+    id: "inv-1004",
+    customer: "Railway Works",
+    status: "paid",
+    total: 14600,
+    owner: "Ari",
+    updatedAt: "Apr 27",
+  },
+];
+
+export const invoiceDashboardMetrics: InvoiceDashboardMetric[] = [
+  { label: "Collected", value: "$27.4k", detail: "Paid invoices this month" },
+  { label: "Outstanding", value: "$8.4k", detail: "Open invoices awaiting action" },
+  { label: "Drafts", value: "1", detail: "Needs review before sending" },
+];
+
+export const invoiceDashboardStatusOptions = [
+  { label: "Draft", value: "draft" },
+  { label: "Open", value: "open" },
+  { label: "Paid", value: "paid" },
+] as const;

--- a/packages/ui/src/default/blocks/invoice-dashboard/invoice-dashboard.tsx
+++ b/packages/ui/src/default/blocks/invoice-dashboard/invoice-dashboard.tsx
@@ -1,0 +1,162 @@
+import { createForm } from "@tanstack/solid-form";
+import { For } from "solid-js";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  CommandMenu,
+  createCommandMenuStore,
+  type CommandMenuItemData,
+} from "@/components/ui/command-menu";
+import { DataTable } from "@/components/data-table/data-table";
+import { DataTableToolbar } from "@/components/data-table/data-table-toolbar";
+import { useDataTable } from "@/components/data-table/use-data-table";
+import { SelectField } from "@/components/ui/select-field";
+import { Separator } from "@/components/ui/separator";
+import { TanStackForm, TanStackFormSubmit } from "@/components/ui/tanstack-form";
+import { TextField } from "@/components/ui/text-field";
+import { Toaster, toaster } from "@/components/ui/toast";
+import { invoiceDashboardColumns } from "./invoice-dashboard-columns";
+import {
+  invoiceDashboardMetrics,
+  invoiceDashboardRows,
+  invoiceDashboardStatusOptions,
+} from "./invoice-dashboard-data";
+
+const commandItems: CommandMenuItemData[] = [
+  {
+    value: "new-invoice",
+    label: "Create invoice",
+    description: "Start a draft from the command menu.",
+    group: "Invoices",
+    shortcut: "Mod+I",
+    shortcutLabel: "Mod+I",
+  },
+  {
+    value: "review-open",
+    label: "Review open invoices",
+    description: "Filter the table to outstanding work.",
+    group: "Invoices",
+    shortcut: "Mod+R",
+    shortcutLabel: "Mod+R",
+  },
+];
+
+export type InvoiceDashboardBlockProps = {
+  title?: string;
+  description?: string;
+};
+
+export function InvoiceDashboardBlock(props: InvoiceDashboardBlockProps) {
+  const form = createForm(() => ({
+    defaultValues: {
+      customer: "",
+      status: "draft",
+    },
+    onSubmit: ({ value }) => {
+      toaster.success({
+        title: "Invoice queued",
+        description: `${value.customer || "New customer"} is ready for review.`,
+      });
+      return value;
+    },
+  }));
+  const table = useDataTable({
+    data: invoiceDashboardRows,
+    columns: invoiceDashboardColumns,
+    getRowId: (row) => row.id,
+    initialState: {
+      pagination: { pageIndex: 0, pageSize: 3 },
+      sorting: [{ id: "total", desc: true }],
+    },
+  });
+  const commandMenuStore = createCommandMenuStore({ open: false });
+
+  return (
+    <section data-scope="ui-block" data-part="invoice-dashboard" class="ui-block-invoice-dashboard">
+      <div class="ui-block-invoice-dashboard-header">
+        <div>
+          <Badge variant="outline">App block</Badge>
+          <h1>{props.title ?? "Invoice workspace"}</h1>
+          <p>{props.description ?? "Create, review, filter, and act on invoices in one route."}</p>
+        </div>
+        <div class="ui-block-invoice-dashboard-actions">
+          <CommandMenu items={commandItems} store={commandMenuStore} trigger="Open command menu" />
+          <Button
+            type="button"
+            onClick={() =>
+              toaster.info({
+                title: "Draft created",
+                description: "Wire this action to your app mutation.",
+              })
+            }
+          >
+            New invoice
+          </Button>
+        </div>
+      </div>
+
+      <div class="ui-block-invoice-dashboard-metrics">
+        <For each={invoiceDashboardMetrics}>
+          {(metric) => (
+            <Card>
+              <CardHeader>
+                <CardDescription>{metric.label}</CardDescription>
+                <CardTitle>{metric.value}</CardTitle>
+              </CardHeader>
+              <CardContent>{metric.detail}</CardContent>
+            </Card>
+          )}
+        </For>
+      </div>
+
+      <div class="ui-block-invoice-dashboard-grid">
+        <Card>
+          <CardHeader>
+            <CardTitle>Create draft</CardTitle>
+            <CardDescription>
+              TanStack Form fields composed from Keystone UI source.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <TanStackForm form={form}>
+              <TextField
+                form={form}
+                name="customer"
+                label="Customer"
+                placeholder="Acme Corp"
+                description="Required before the draft can be sent."
+                validators={{
+                  onSubmit: ({ value }) => (value.length > 0 ? undefined : "Enter a customer."),
+                }}
+              />
+              <SelectField
+                form={form}
+                name="status"
+                label="Initial status"
+                placeholder="Choose status"
+                options={invoiceDashboardStatusOptions}
+              />
+              <TanStackFormSubmit>Create draft</TanStackFormSubmit>
+            </TanStackForm>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Invoice management</CardTitle>
+            <CardDescription>TanStack Table state with Keystone UI controls.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <DataTable table={table}>
+              <DataTableToolbar table={table} />
+            </DataTable>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Separator />
+      <Toaster viewport={{ position: "bottom-right" }} />
+    </section>
+  );
+}

--- a/packages/ui/src/default/components/data-table/data-table-column-header.tsx
+++ b/packages/ui/src/default/components/data-table/data-table-column-header.tsx
@@ -4,10 +4,14 @@ import { cn } from "@/lib/cn";
 
 export function DataTableColumnHeader<TData extends RowData, TValue>(props: {
   column: Column<TData, TValue>;
+  label?: string;
   title: JSX.Element;
   class?: string;
 }) {
   const sorted = createMemo(() => props.column.getIsSorted());
+  const label = createMemo(
+    () => props.label ?? props.column.columnDef.meta?.label ?? props.column.id,
+  );
 
   return (
     <div
@@ -19,6 +23,9 @@ export function DataTableColumnHeader<TData extends RowData, TValue>(props: {
       <button
         type="button"
         disabled={!props.column.getCanSort()}
+        aria-label={`Sort ${label()}`}
+        data-scope="ui-data-table"
+        data-part="sort-trigger"
         onClick={props.column.getToggleSortingHandler()}
       >
         <span>{props.title}</span>
@@ -27,12 +34,24 @@ export function DataTableColumnHeader<TData extends RowData, TValue>(props: {
         </span>
       </button>
       <Show when={props.column.getCanSort() && sorted()}>
-        <button type="button" onClick={() => props.column.clearSorting()}>
+        <button
+          type="button"
+          aria-label={`Clear ${label()} sorting`}
+          data-scope="ui-data-table"
+          data-part="sort-clear"
+          onClick={() => props.column.clearSorting()}
+        >
           Clear
         </button>
       </Show>
       <Show when={props.column.getCanHide()}>
-        <button type="button" onClick={() => props.column.toggleVisibility(false)}>
+        <button
+          type="button"
+          aria-label={`Hide ${label()} column`}
+          data-scope="ui-data-table"
+          data-part="column-hide"
+          onClick={() => props.column.toggleVisibility(false)}
+        >
           Hide
         </button>
       </Show>

--- a/packages/ui/src/default/components/data-table/data-table-faceted-filter.tsx
+++ b/packages/ui/src/default/components/data-table/data-table-faceted-filter.tsx
@@ -39,10 +39,12 @@ export function DataTableFacetedFilter<TData extends RowData>(props: {
         <For each={props.options}>
           {(option) => {
             const checked = createMemo(() => selectedValues().has(option.value));
+            const count = createMemo(() => optionCount(option));
             return (
               <label data-scope="ui-data-table" data-part="faceted-option">
                 <input
                   type={props.multiple === false ? "radio" : "checkbox"}
+                  name={`data-table-${props.columnId}`}
                   checked={checked()}
                   onChange={() => {
                     const next = new Set(selectedValues());
@@ -61,9 +63,9 @@ export function DataTableFacetedFilter<TData extends RowData>(props: {
                   }}
                 />
                 <span>{option.label}</span>
-                <Show when={optionCount(option) !== undefined}>
+                <Show when={count() !== undefined}>
                   <span data-scope="ui-data-table" data-part="faceted-count">
-                    {optionCount(option)}
+                    {count()}
                   </span>
                 </Show>
               </label>
@@ -74,9 +76,13 @@ export function DataTableFacetedFilter<TData extends RowData>(props: {
       <Show when={selectedValues().size > 0}>
         <button
           type="button"
+          aria-label={`Clear ${props.title} filter`}
           data-scope="ui-data-table"
           data-part="faceted-clear"
-          onClick={() => column()?.setFilterValue(undefined)}
+          onClick={() => {
+            column()?.setFilterValue(undefined);
+            props.table.setPageIndex(0);
+          }}
         >
           Clear
         </button>

--- a/packages/ui/src/default/components/data-table/data-table-pagination.tsx
+++ b/packages/ui/src/default/components/data-table/data-table-pagination.tsx
@@ -13,13 +13,15 @@ export function DataTablePagination<TData extends RowData>(props: {
     <div
       data-scope="ui-data-table"
       data-part="pagination"
+      role="navigation"
+      aria-label="Table pagination"
       class={cn("ui-data-table-pagination", props.class)}
     >
-      <span data-scope="ui-data-table" data-part="selected-summary">
+      <span data-scope="ui-data-table" data-part="selected-summary" aria-live="polite">
         {props.table.getFilteredSelectedRowModel().rows.length} of{" "}
         {props.table.getFilteredRowModel().rows.length} selected
       </span>
-      <span data-scope="ui-data-table" data-part="page-summary">
+      <span data-scope="ui-data-table" data-part="page-summary" aria-live="polite">
         Page {props.table.getState().pagination.pageIndex + 1} of {props.table.getPageCount() || 1}
       </span>
       <label data-scope="ui-data-table" data-part="page-size">
@@ -36,6 +38,7 @@ export function DataTablePagination<TData extends RowData>(props: {
       <div data-scope="ui-data-table" data-part="page-buttons">
         <button
           type="button"
+          aria-label="Go to first page"
           onClick={() => props.table.setPageIndex(0)}
           disabled={!props.table.getCanPreviousPage()}
         >
@@ -43,6 +46,7 @@ export function DataTablePagination<TData extends RowData>(props: {
         </button>
         <button
           type="button"
+          aria-label="Go to previous page"
           onClick={() => props.table.previousPage()}
           disabled={!props.table.getCanPreviousPage()}
         >
@@ -50,6 +54,7 @@ export function DataTablePagination<TData extends RowData>(props: {
         </button>
         <button
           type="button"
+          aria-label="Go to next page"
           onClick={() => props.table.nextPage()}
           disabled={!props.table.getCanNextPage()}
         >
@@ -57,6 +62,7 @@ export function DataTablePagination<TData extends RowData>(props: {
         </button>
         <button
           type="button"
+          aria-label="Go to last page"
           onClick={() => props.table.setPageIndex(props.table.getPageCount() - 1)}
           disabled={!props.table.getCanNextPage()}
         >

--- a/packages/ui/src/default/components/data-table/data-table-row-actions.tsx
+++ b/packages/ui/src/default/components/data-table/data-table-row-actions.tsx
@@ -12,6 +12,8 @@ export function DataTableRowActions<TData extends RowData>(props: {
     <div
       data-scope="ui-data-table"
       data-part="row-actions"
+      role="group"
+      aria-label="Row actions"
       class={cn("ui-data-table-row-actions", props.class)}
     >
       <For each={props.actions}>

--- a/packages/ui/src/default/components/data-table/data-table-toolbar.tsx
+++ b/packages/ui/src/default/components/data-table/data-table-toolbar.tsx
@@ -39,6 +39,7 @@ export function DataTableToolbar<TData extends RowData>(props: {
                   type="search"
                   value={String(column.getFilterValue() ?? "")}
                   placeholder={meta?.placeholder ?? `Search ${label.toLowerCase()}...`}
+                  aria-label={meta?.placeholder ?? `Search ${label}`}
                   data-scope="ui-data-table"
                   data-part="search"
                   class="ui-data-table-search"
@@ -63,6 +64,7 @@ export function DataTableToolbar<TData extends RowData>(props: {
       <Show when={hasFilters()}>
         <button
           type="button"
+          aria-label="Reset table filters and column visibility"
           data-scope="ui-data-table"
           data-part="reset"
           class="ui-data-table-reset"

--- a/packages/ui/src/default/components/data-table/data-table-view-options.tsx
+++ b/packages/ui/src/default/components/data-table/data-table-view-options.tsx
@@ -21,12 +21,15 @@ export function DataTableViewOptions<TData extends RowData>(props: {
     <div
       data-scope="ui-data-table"
       data-part="view-options"
+      role="group"
+      aria-label="Column visibility"
       class={cn("ui-data-table-view-options", props.class)}
     >
       <input
         type="search"
         value={query()}
         placeholder="Search columns..."
+        aria-label="Search columns"
         data-scope="ui-data-table"
         data-part="view-options-search"
         onInput={(event) => setQuery(event.currentTarget.value)}

--- a/packages/ui/src/default/components/data-table/data-table.tsx
+++ b/packages/ui/src/default/components/data-table/data-table.tsx
@@ -9,6 +9,7 @@ type DataTableRootProps = Omit<JSX.HTMLAttributes<HTMLDivElement>, "children">;
 
 export type DataTableProps<TData extends RowData> = DataTableRootProps & {
   table: Table<TData>;
+  caption?: JSX.Element;
   children?: JSX.Element;
   empty?: JSX.Element;
   loading?: boolean;
@@ -19,6 +20,7 @@ export type DataTableProps<TData extends RowData> = DataTableRootProps & {
 
 export function DataTable<TData extends RowData>(props: DataTableProps<TData>) {
   const [local, rootProps] = splitProps(props, [
+    "caption",
     "children",
     "class",
     "empty",
@@ -34,6 +36,9 @@ export function DataTable<TData extends RowData>(props: DataTableProps<TData>) {
       {...rootProps}
       data-scope="ui-data-table"
       data-part="root"
+      data-empty={local.table.getRowModel().rows.length === 0 ? "" : undefined}
+      data-loading={local.loading ? "" : undefined}
+      aria-busy={local.loading || undefined}
       class={cn("ui-data-table", local.class)}
     >
       <Show when={local.children}>
@@ -43,6 +48,11 @@ export function DataTable<TData extends RowData>(props: DataTableProps<TData>) {
       </Show>
       <div data-scope="ui-data-table" data-part="viewport" class="ui-data-table-viewport">
         <table data-scope="ui-data-table" data-part="table" class="ui-data-table-table">
+          <Show when={local.caption}>
+            <caption data-scope="ui-data-table" data-part="caption">
+              {local.caption}
+            </caption>
+          </Show>
           <thead data-scope="ui-data-table" data-part="header" class="ui-data-table-header">
             <For each={local.table.getHeaderGroups()}>
               {(headerGroup) => (
@@ -51,8 +61,11 @@ export function DataTable<TData extends RowData>(props: DataTableProps<TData>) {
                     {(header) => (
                       <th
                         colSpan={header.colSpan}
+                        scope="col"
+                        aria-sort={getAriaSort(header.column.getIsSorted())}
                         data-scope="ui-data-table"
                         data-part="head"
+                        data-sort={header.column.getIsSorted() || "none"}
                         class="ui-data-table-head"
                       >
                         <Show when={!header.isPlaceholder}>
@@ -89,7 +102,9 @@ export function DataTable<TData extends RowData>(props: DataTableProps<TData>) {
                     <tr
                       data-scope="ui-data-table"
                       data-part="row"
+                      aria-selected={row.getIsSelected() || undefined}
                       data-state={row.getIsSelected() ? "selected" : undefined}
+                      data-selected={row.getIsSelected() ? "" : undefined}
                       class="ui-data-table-row"
                     >
                       <For each={row.getVisibleCells()}>
@@ -116,4 +131,10 @@ export function DataTable<TData extends RowData>(props: DataTableProps<TData>) {
       </Show>
     </div>
   );
+}
+
+function getAriaSort(sort: false | "asc" | "desc"): "ascending" | "descending" | "none" {
+  if (sort === "asc") return "ascending";
+  if (sort === "desc") return "descending";
+  return "none";
 }

--- a/packages/ui/src/default/components/data-table/use-data-table-router.ts
+++ b/packages/ui/src/default/components/data-table/use-data-table-router.ts
@@ -20,14 +20,16 @@ import { dataTableFacetedFilter } from "./use-data-table";
 import type { DataTableSearch } from "./data-table-search";
 import type { DataTableColumns } from "./types";
 
+type MaybeAccessor<TValue> = TValue | Accessor<TValue>;
+
 export type DataTableRouterNavigate = (options: {
   replace?: boolean;
   search: (previous: DataTableSearch) => DataTableSearch;
 }) => void | Promise<void>;
 
 export type UseDataTableRouterOptions<TData extends RowData> = {
-  columns: DataTableColumns<TData>;
-  data: readonly TData[];
+  columns: MaybeAccessor<DataTableColumns<TData>>;
+  data: MaybeAccessor<readonly TData[]>;
   getRowId?: (originalRow: TData, index: number, parent?: Row<TData>) => string;
   navigate: DataTableRouterNavigate;
   search: Accessor<DataTableSearch> | DataTableSearch;
@@ -50,10 +52,10 @@ export function useDataTableRouter<TData extends RowData>(
 
   return createSolidTable<TData>({
     get data() {
-      return [...options.data];
+      return [...resolveDataTableOption(options.data)];
     },
     get columns() {
-      return options.columns;
+      return resolveDataTableOption(options.columns);
     },
     get state() {
       return {
@@ -122,4 +124,8 @@ export function useDataTableRouter<TData extends RowData>(
 
 function applyUpdater<TValue>(updater: Updater<TValue>, current: TValue): TValue {
   return typeof updater === "function" ? (updater as (value: TValue) => TValue)(current) : updater;
+}
+
+function resolveDataTableOption<TValue>(value: MaybeAccessor<TValue>): TValue {
+  return typeof value === "function" ? (value as Accessor<TValue>)() : value;
 }

--- a/packages/ui/src/default/components/data-table/use-data-table.ts
+++ b/packages/ui/src/default/components/data-table/use-data-table.ts
@@ -8,6 +8,7 @@ import {
   getSortedRowModel,
   type ColumnFiltersState,
   type FilterFn,
+  type OnChangeFn,
   type PaginationState,
   type Row,
   type RowData,
@@ -16,12 +17,14 @@ import {
   type Updater,
   type VisibilityState,
 } from "@tanstack/solid-table";
-import { createSignal } from "solid-js";
+import { createSignal, type Accessor } from "solid-js";
 import type { DataTableColumns } from "./types";
 
+type MaybeAccessor<TValue> = TValue | Accessor<TValue>;
+
 export type UseDataTableOptions<TData extends RowData> = {
-  columns: DataTableColumns<TData>;
-  data: readonly TData[];
+  columns: MaybeAccessor<DataTableColumns<TData>>;
+  data: MaybeAccessor<readonly TData[]>;
   getRowId?: (originalRow: TData, index: number, parent?: Row<TData>) => string;
   initialState?: {
     columnFilters?: ColumnFiltersState;
@@ -30,6 +33,22 @@ export type UseDataTableOptions<TData extends RowData> = {
     rowSelection?: RowSelectionState;
     sorting?: SortingState;
   };
+  state?: {
+    columnFilters?: ColumnFiltersState;
+    columnVisibility?: VisibilityState;
+    pagination?: PaginationState;
+    rowSelection?: RowSelectionState;
+    sorting?: SortingState;
+  };
+  onColumnFiltersChange?: OnChangeFn<ColumnFiltersState>;
+  onColumnVisibilityChange?: OnChangeFn<VisibilityState>;
+  onPaginationChange?: OnChangeFn<PaginationState>;
+  onRowSelectionChange?: OnChangeFn<RowSelectionState>;
+  onSortingChange?: OnChangeFn<SortingState>;
+  manualFiltering?: boolean;
+  manualPagination?: boolean;
+  manualSorting?: boolean;
+  pageCount?: number;
 };
 
 export const dataTableFacetedFilter: FilterFn<any> = (row, columnId, filterValue) => {
@@ -55,18 +74,18 @@ export function useDataTable<TData extends RowData>(options: UseDataTableOptions
 
   return createSolidTable<TData>({
     get data() {
-      return [...options.data];
+      return [...resolveDataTableOption(options.data)];
     },
     get columns() {
-      return options.columns;
+      return resolveDataTableOption(options.columns);
     },
     get state() {
       return {
-        sorting: sorting(),
-        columnFilters: columnFilters(),
-        columnVisibility: columnVisibility(),
-        pagination: pagination(),
-        rowSelection: rowSelection(),
+        columnFilters: options.state?.columnFilters ?? columnFilters(),
+        columnVisibility: options.state?.columnVisibility ?? columnVisibility(),
+        pagination: options.state?.pagination ?? pagination(),
+        rowSelection: options.state?.rowSelection ?? rowSelection(),
+        sorting: options.state?.sorting ?? sorting(),
       };
     },
     filterFns: {
@@ -80,16 +99,39 @@ export function useDataTable<TData extends RowData>(options: UseDataTableOptions
     getFacetedRowModel: getFacetedRowModel(),
     getFacetedUniqueValues: getFacetedUniqueValues(),
     getRowId: options.getRowId,
-    onSortingChange: (updater) => setSorting((current) => applyUpdater(updater, current)),
-    onColumnFiltersChange: (updater) =>
-      setColumnFilters((current) => applyUpdater(updater, current)),
-    onColumnVisibilityChange: (updater) =>
-      setColumnVisibility((current) => applyUpdater(updater, current)),
-    onPaginationChange: (updater) => setPagination((current) => applyUpdater(updater, current)),
-    onRowSelectionChange: (updater) => setRowSelection((current) => applyUpdater(updater, current)),
+    manualFiltering: options.manualFiltering,
+    manualPagination: options.manualPagination,
+    manualSorting: options.manualSorting,
+    pageCount: options.pageCount,
+    onSortingChange: (updater) => {
+      setSorting((current) => applyUpdater(updater, options.state?.sorting ?? current));
+      options.onSortingChange?.(updater);
+    },
+    onColumnFiltersChange: (updater) => {
+      setColumnFilters((current) => applyUpdater(updater, options.state?.columnFilters ?? current));
+      options.onColumnFiltersChange?.(updater);
+    },
+    onColumnVisibilityChange: (updater) => {
+      setColumnVisibility((current) =>
+        applyUpdater(updater, options.state?.columnVisibility ?? current),
+      );
+      options.onColumnVisibilityChange?.(updater);
+    },
+    onPaginationChange: (updater) => {
+      setPagination((current) => applyUpdater(updater, options.state?.pagination ?? current));
+      options.onPaginationChange?.(updater);
+    },
+    onRowSelectionChange: (updater) => {
+      setRowSelection((current) => applyUpdater(updater, options.state?.rowSelection ?? current));
+      options.onRowSelectionChange?.(updater);
+    },
   });
 }
 
 function applyUpdater<TValue>(updater: Updater<TValue>, current: TValue): TValue {
   return typeof updater === "function" ? (updater as (value: TValue) => TValue)(current) : updater;
+}
+
+function resolveDataTableOption<TValue>(value: MaybeAccessor<TValue>): TValue {
+  return typeof value === "function" ? (value as Accessor<TValue>)() : value;
 }

--- a/packages/ui/src/default/templates/tanstack-start-dashboard/package.json
+++ b/packages/ui/src/default/templates/tanstack-start-dashboard/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "keystone-tanstack-start-dashboard",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite dev",
+    "build": "vite build",
+    "check-types": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@keystone-ui/core": "^0.0.0",
+    "@tailwindcss/vite": "^4.2.2",
+    "@tanstack/solid-form": "^1.29.1",
+    "@tanstack/solid-router": "^1.168.20",
+    "@tanstack/solid-start": "^1.167.58",
+    "@tanstack/solid-store": "^0.11.0",
+    "@tanstack/solid-table": "^8.21.3",
+    "solid-js": "^1.9.12",
+    "tailwindcss": "^4.2.2"
+  },
+  "devDependencies": {
+    "typescript": "^6",
+    "vite": "^8.0.8",
+    "vite-plugin-solid": "^2.11.12"
+  }
+}

--- a/packages/ui/src/default/templates/tanstack-start-dashboard/src/routeTree.gen.ts
+++ b/packages/ui/src/default/templates/tanstack-start-dashboard/src/routeTree.gen.ts
@@ -1,0 +1,12 @@
+/* eslint-disable */
+
+import { Route as rootRoute } from "./routes/__root";
+import { Route as IndexRoute } from "./routes/index";
+
+const IndexRouteWithParent = IndexRoute.update({
+  id: "/",
+  path: "/",
+  getParentRoute: () => rootRoute,
+} as any);
+
+export const routeTree = rootRoute.addChildren([IndexRouteWithParent]);

--- a/packages/ui/src/default/templates/tanstack-start-dashboard/src/router.tsx
+++ b/packages/ui/src/default/templates/tanstack-start-dashboard/src/router.tsx
@@ -1,0 +1,16 @@
+import { createRouter as createTanStackRouter } from "@tanstack/solid-router";
+import { routeTree } from "./routeTree.gen";
+
+export function getRouter() {
+  return createTanStackRouter({
+    routeTree,
+    defaultPreload: "intent",
+    scrollRestoration: true,
+  });
+}
+
+declare module "@tanstack/solid-router" {
+  interface Register {
+    router: ReturnType<typeof getRouter>;
+  }
+}

--- a/packages/ui/src/default/templates/tanstack-start-dashboard/src/routes/__root.tsx
+++ b/packages/ui/src/default/templates/tanstack-start-dashboard/src/routes/__root.tsx
@@ -1,0 +1,28 @@
+import { createRootRoute, HeadContent, Outlet, Scripts } from "@tanstack/solid-router";
+import styles from "../styles.css?url";
+
+export const Route = createRootRoute({
+  head: () => ({
+    links: [{ rel: "stylesheet", href: styles }],
+    meta: [
+      { charSet: "utf-8" },
+      { name: "viewport", content: "width=device-width, initial-scale=1" },
+      { title: "Keystone Invoice Dashboard" },
+    ],
+  }),
+  component: RootDocument,
+});
+
+function RootDocument() {
+  return (
+    <html lang="en">
+      <head>
+        <HeadContent />
+      </head>
+      <body>
+        <Outlet />
+        <Scripts />
+      </body>
+    </html>
+  );
+}

--- a/packages/ui/src/default/templates/tanstack-start-dashboard/src/routes/index.tsx
+++ b/packages/ui/src/default/templates/tanstack-start-dashboard/src/routes/index.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from "@tanstack/solid-router";
+import { InvoiceDashboardBlock } from "@/components/blocks/invoice-dashboard/invoice-dashboard";
+
+export const Route = createFileRoute("/")({
+  component: DashboardRoute,
+});
+
+function DashboardRoute() {
+  return (
+    <main class="min-h-screen bg-background px-6 py-8 text-foreground">
+      <InvoiceDashboardBlock />
+    </main>
+  );
+}

--- a/packages/ui/src/default/templates/tanstack-start-dashboard/src/styles.css
+++ b/packages/ui/src/default/templates/tanstack-start-dashboard/src/styles.css
@@ -1,0 +1,31 @@
+@import "tailwindcss";
+
+:root {
+  color-scheme: light;
+  --background: oklch(0.99 0.004 106);
+  --foreground: oklch(0.19 0.016 256);
+  --muted: oklch(0.96 0.006 106);
+  --muted-foreground: oklch(0.47 0.026 256);
+  --popover: oklch(1 0 0);
+  --popover-foreground: var(--foreground);
+  --border: oklch(0.9 0.011 252);
+  --input: var(--border);
+  --ring: oklch(0.55 0.17 251);
+  --accent: oklch(0.94 0.024 251);
+  --destructive: oklch(0.58 0.22 25);
+  --success: oklch(0.57 0.15 146);
+  --warning: oklch(0.72 0.17 72);
+  --info: oklch(0.58 0.16 244);
+}
+
+body {
+  margin: 0;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}

--- a/packages/ui/src/default/templates/tanstack-start-dashboard/tsconfig.json
+++ b/packages/ui/src/default/templates/tanstack-start-dashboard/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "jsx": "preserve",
+    "jsxImportSource": "solid-js",
+    "strict": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/packages/ui/src/default/templates/tanstack-start-dashboard/vite.config.ts
+++ b/packages/ui/src/default/templates/tanstack-start-dashboard/vite.config.ts
@@ -1,0 +1,14 @@
+import path from "node:path";
+import tailwindcss from "@tailwindcss/vite";
+import { tanstackStart } from "@tanstack/solid-start/plugin/vite";
+import { defineConfig } from "vite";
+import solidPlugin from "vite-plugin-solid";
+
+export default defineConfig({
+  plugins: [tanstackStart(), solidPlugin({ ssr: true }), tailwindcss()],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+});

--- a/packages/ui/src/default/ui/select-field.tsx
+++ b/packages/ui/src/default/ui/select-field.tsx
@@ -1,12 +1,16 @@
-import { For, type JSX } from "solid-js";
+import { For, Show, type JSX } from "solid-js";
 import {
   Select,
   SelectContent,
+  SelectGroup,
+  SelectGroupLabel,
   SelectItem,
   SelectTrigger,
   SelectValue,
   type SelectContentProps,
+  type SelectGroupProps,
   type SelectItemProps,
+  type SelectProps,
   type SelectTriggerProps,
 } from "@/components/ui/select";
 import {
@@ -30,24 +34,73 @@ export type SelectFieldOption = {
   disabled?: boolean;
   indicator?: JSX.Element;
   label: JSX.Element;
+  textValue?: string;
   value: string;
 };
+
+export type SelectFieldOptionGroup = {
+  disabled?: boolean;
+  label: JSX.Element;
+  textValue?: string;
+  value: string;
+  options: readonly SelectFieldOption[];
+};
+
+type SelectFieldRootProps = Omit<
+  SelectProps,
+  | "children"
+  | "defaultValue"
+  | "disabled"
+  | "form"
+  | "invalid"
+  | "multiple"
+  | "name"
+  | "onValueChange"
+  | "onValuesChange"
+  | "placeholder"
+  | "readOnly"
+  | "required"
+  | "value"
+>;
 
 export type SelectFieldProps = Omit<
   TanStackFieldProps<string, HTMLButtonElement>,
   "children" | "validators"
 > & {
-  options: readonly SelectFieldOption[];
+  options: readonly (SelectFieldOption | SelectFieldOptionGroup)[];
   validators?: SelectFieldValidators;
+  empty?: JSX.Element;
   placeholder?: string;
+  selectProps?: SelectFieldRootProps;
   triggerClass?: string;
   contentClass?: string;
   listboxClass?: string;
   itemClass?: string;
+  groupClass?: string;
+  groupLabelClass?: string;
   triggerProps?: Omit<SelectTriggerProps, "children" | "class">;
   contentProps?: Omit<SelectContentProps, "children" | "class" | "listboxClass">;
+  groupProps?: Omit<SelectGroupProps, "children" | "class" | "disabled" | "label" | "value">;
   itemProps?: Omit<SelectItemProps, "children" | "class" | "disabled" | "indicator" | "value">;
 };
+
+function optionText(option: SelectFieldOption) {
+  return option.textValue ?? (typeof option.label === "string" ? option.label : option.value);
+}
+
+function groupText(group: SelectFieldOptionGroup) {
+  return group.textValue ?? (typeof group.label === "string" ? group.label : group.value);
+}
+
+function isOptionGroup(
+  option: SelectFieldOption | SelectFieldOptionGroup,
+): option is SelectFieldOptionGroup {
+  return "options" in option;
+}
+
+function hasOptions(options: readonly (SelectFieldOption | SelectFieldOptionGroup)[]) {
+  return options.some((option) => (isOptionGroup(option) ? option.options.length > 0 : true));
+}
 
 export function SelectField(props: SelectFieldProps) {
   return (
@@ -73,13 +126,29 @@ export function SelectField(props: SelectFieldProps) {
         <SelectFieldControl
           contentClass={props.contentClass}
           contentProps={props.contentProps}
+          describedBy={[
+            props.description ? context.descriptionId() : undefined,
+            context.invalid() && context.firstError() ? context.errorId() : undefined,
+          ]
+            .filter(Boolean)
+            .join(" ")}
+          disabled={props.disabled}
+          empty={props.empty}
           field={context.field}
+          formId={props.formId}
+          groupClass={props.groupClass}
+          groupLabelClass={props.groupLabelClass}
+          groupProps={props.groupProps}
           invalid={context.invalid()}
           itemClass={props.itemClass}
           itemProps={props.itemProps}
+          labelledBy={props.label ? context.labelId() : undefined}
           listboxClass={props.listboxClass}
           options={props.options}
           placeholder={props.placeholder}
+          readOnly={props.readOnly}
+          required={props.required}
+          selectProps={props.selectProps}
           setFocused={context.setFocused}
           triggerClass={props.triggerClass}
           triggerProps={props.triggerProps}
@@ -93,13 +162,24 @@ export function SelectField(props: SelectFieldProps) {
 function SelectFieldControl(props: {
   contentClass?: string;
   contentProps?: Omit<SelectContentProps, "children" | "class" | "listboxClass">;
+  describedBy?: string;
+  disabled?: boolean;
+  empty?: JSX.Element;
   field: () => TanStackFieldApi<string, HTMLButtonElement>;
+  formId?: string;
+  groupClass?: string;
+  groupLabelClass?: string;
+  groupProps?: Omit<SelectGroupProps, "children" | "class" | "disabled" | "label" | "value">;
   invalid: boolean;
   itemClass?: string;
   itemProps?: Omit<SelectItemProps, "children" | "class" | "disabled" | "indicator" | "value">;
+  labelledBy?: string;
   listboxClass?: string;
-  options: readonly SelectFieldOption[];
+  options: readonly (SelectFieldOption | SelectFieldOptionGroup)[];
   placeholder?: string;
+  readOnly?: boolean;
+  required?: boolean;
+  selectProps?: SelectFieldRootProps;
   setFocused: (focused: boolean) => void;
   triggerClass?: string;
   triggerProps?: Omit<SelectTriggerProps, "children" | "class">;
@@ -107,11 +187,17 @@ function SelectFieldControl(props: {
 }) {
   return (
     <Select
-      name={props.field().name}
-      value={typeof props.value === "string" ? props.value : undefined}
-      placeholder={props.placeholder}
+      {...props.selectProps}
+      disabled={props.disabled}
+      form={props.formId}
       invalid={props.invalid}
-      onOpenChange={(open) => {
+      name={props.field().name}
+      readOnly={props.readOnly}
+      required={props.required}
+      value={typeof props.value === "string" && props.value.length > 0 ? props.value : undefined}
+      placeholder={props.placeholder}
+      onOpenChange={(open, detail) => {
+        props.selectProps?.onOpenChange?.(open, detail);
         props.setFocused(open);
         if (!open) {
           props.field().handleBlur();
@@ -121,7 +207,9 @@ function SelectFieldControl(props: {
     >
       <SelectTrigger
         {...props.triggerProps}
+        aria-describedby={props.describedBy || undefined}
         aria-invalid={props.invalid || undefined}
+        aria-labelledby={props.labelledBy}
         data-scope="ui-select-field"
         data-part="trigger"
         data-slot="select-field-trigger"
@@ -137,23 +225,88 @@ function SelectFieldControl(props: {
         listboxClass={cn("ui-select-field-listbox", props.listboxClass)}
         class={cn("ui-select-field-content", props.contentClass)}
       >
-        <For each={props.options}>
-          {(option) => (
-            <SelectItem
-              {...props.itemProps}
-              value={option.value}
-              disabled={option.disabled}
-              indicator={option.indicator}
+        <Show
+          when={hasOptions(props.options)}
+          fallback={
+            <div
               data-scope="ui-select-field"
-              data-part="item"
-              data-slot="select-field-item"
-              class={cn("ui-select-field-item", props.itemClass)}
+              data-part="empty"
+              data-slot="select-field-empty"
+              class="ui-select-field-empty px-2 py-1.5 text-muted-foreground text-sm"
             >
-              {option.label}
-            </SelectItem>
-          )}
-        </For>
+              {props.empty ?? "No options"}
+            </div>
+          }
+        >
+          <For each={props.options}>
+            {(option) => (
+              <Show
+                when={isOptionGroup(option) ? option : undefined}
+                fallback={
+                  <SelectFieldItem
+                    itemClass={props.itemClass}
+                    itemProps={props.itemProps}
+                    option={option as SelectFieldOption}
+                  />
+                }
+              >
+                {(group) => (
+                  <SelectGroup
+                    {...props.groupProps}
+                    value={group().value}
+                    label={groupText(group())}
+                    disabled={group().disabled}
+                    data-scope="ui-select-field"
+                    data-part="group"
+                    data-slot="select-field-group"
+                    class={cn("ui-select-field-group", props.groupClass)}
+                  >
+                    <SelectGroupLabel
+                      data-scope="ui-select-field"
+                      data-part="group-label"
+                      data-slot="select-field-group-label"
+                      class={cn("ui-select-field-group-label", props.groupLabelClass)}
+                    >
+                      {group().label}
+                    </SelectGroupLabel>
+                    <For each={group().options}>
+                      {(groupOption) => (
+                        <SelectFieldItem
+                          itemClass={props.itemClass}
+                          itemProps={props.itemProps}
+                          option={groupOption}
+                        />
+                      )}
+                    </For>
+                  </SelectGroup>
+                )}
+              </Show>
+            )}
+          </For>
+        </Show>
       </SelectContent>
     </Select>
+  );
+}
+
+function SelectFieldItem(props: {
+  itemClass?: string;
+  itemProps?: Omit<SelectItemProps, "children" | "class" | "disabled" | "indicator" | "value">;
+  option: SelectFieldOption;
+}) {
+  return (
+    <SelectItem
+      {...props.itemProps}
+      value={props.option.value}
+      label={optionText(props.option)}
+      disabled={props.option.disabled}
+      indicator={props.option.indicator}
+      data-scope="ui-select-field"
+      data-part="item"
+      data-slot="select-field-item"
+      class={cn("ui-select-field-item", props.itemClass)}
+    >
+      {props.option.label}
+    </SelectItem>
   );
 }

--- a/packages/ui/src/default/ui/tabs.tsx
+++ b/packages/ui/src/default/ui/tabs.tsx
@@ -15,32 +15,112 @@ export type TabsTriggerProps = CoreTabsTriggerProps;
 export type TabsIndicatorProps = CoreTabsIndicatorProps;
 export type TabsContentProps = CoreTabsContentProps;
 
+const classes = (...tokens: string[]) => tokens.join(" ");
+
+const tabsRootClass = classes("flex", "w-full", "flex-col", "gap-3");
+
+const tabsListClass = classes(
+  "relative",
+  "inline-flex",
+  "w-fit",
+  "items-center",
+  "gap-1",
+  "rounded-lg",
+  "border",
+  "border-input",
+  "bg-muted",
+  "p-1",
+  "text-muted-foreground",
+  "data-[orientation=vertical]:flex-col",
+  "data-[orientation=vertical]:items-stretch",
+);
+
+const tabsTriggerClass = classes(
+  "relative",
+  "z-10",
+  "inline-flex",
+  "min-h-8",
+  "items-center",
+  "justify-center",
+  "gap-2",
+  "whitespace-nowrap",
+  "rounded-md",
+  "px-3",
+  "py-1.5",
+  "text-sm",
+  "font-medium",
+  "outline-none",
+  "transition-colors",
+  "focus-visible:ring-2",
+  "focus-visible:ring-ring",
+  "focus-visible:ring-offset-1",
+  "focus-visible:ring-offset-background",
+  "disabled:pointer-events-none",
+  "disabled:opacity-50",
+  "data-selected:text-foreground",
+  "data-selected:shadow-xs",
+);
+
+const tabsIndicatorClass = classes(
+  "pointer-events-none",
+  "absolute",
+  "left-0",
+  "top-0",
+  "z-0",
+  "rounded-md",
+  "bg-background",
+  "shadow-xs",
+  "transition-[height,transform,width]",
+  "duration-200",
+  "ease-out",
+  "[height:var(--keystone-tabs-indicator-height,0px)]",
+  "[transform:translate3d(var(--keystone-tabs-indicator-x,0px),var(--keystone-tabs-indicator-y,0px),0)]",
+  "[width:var(--keystone-tabs-indicator-width,0px)]",
+);
+
+const tabsContentClass = classes(
+  "outline-none",
+  "focus-visible:ring-2",
+  "focus-visible:ring-ring",
+  "focus-visible:ring-offset-2",
+  "focus-visible:ring-offset-background",
+);
+
 export function Tabs(props: TabsProps) {
   const [local, rest] = splitProps(props, ["class"]);
 
-  return <CoreTabs.Root {...rest} class={cn("ui-tabs", local.class)} />;
+  return <CoreTabs.Root {...rest} class={cn("ui-tabs", tabsRootClass, local.class)} />;
 }
 
 export function TabsList(props: TabsListProps) {
   const [local, rest] = splitProps(props, ["class"]);
 
-  return <CoreTabs.List {...rest} class={cn("ui-tabs-list", local.class)} />;
+  return <CoreTabs.List {...rest} class={cn("ui-tabs-list", tabsListClass, local.class)} />;
 }
 
 export function TabsTrigger(props: TabsTriggerProps) {
   const [local, rest] = splitProps(props, ["class"]);
 
-  return <CoreTabs.Trigger {...rest} class={cn("ui-tabs-trigger", local.class)} />;
+  return (
+    <CoreTabs.Trigger {...rest} class={cn("ui-tabs-trigger", tabsTriggerClass, local.class)} />
+  );
 }
 
 export function TabsIndicator(props: TabsIndicatorProps) {
   const [local, rest] = splitProps(props, ["class"]);
 
-  return <CoreTabs.Indicator {...rest} class={cn("ui-tabs-indicator", local.class)} />;
+  return (
+    <CoreTabs.Indicator
+      {...rest}
+      class={cn("ui-tabs-indicator", tabsIndicatorClass, local.class)}
+    />
+  );
 }
 
 export function TabsContent(props: TabsContentProps) {
   const [local, rest] = splitProps(props, ["class"]);
 
-  return <CoreTabs.Content {...rest} class={cn("ui-tabs-content", local.class)} />;
+  return (
+    <CoreTabs.Content {...rest} class={cn("ui-tabs-content", tabsContentClass, local.class)} />
+  );
 }

--- a/packages/ui/src/default/ui/toast.tsx
+++ b/packages/ui/src/default/ui/toast.tsx
@@ -12,68 +12,464 @@ import {
   type ToastTitleProps as CoreToastTitleProps,
   type ToastViewportProps as CoreToastViewportProps,
 } from "@keystone-ui/core/toast";
-import { splitProps } from "solid-js";
+import { splitProps, type JSX } from "solid-js";
 import { cn } from "@/lib/cn";
 
 export type ToastProviderProps = CoreToastProviderProps;
-export type ToastViewportProps = CoreToastViewportProps;
-export type ToastProps = CoreToastRootProps;
+export type ToastPosition =
+  | "bottom-center"
+  | "bottom-left"
+  | "bottom-right"
+  | "top-center"
+  | "top-left"
+  | "top-right";
+export type ToastViewportProps = CoreToastViewportProps & {
+  offset?: string;
+  position?: ToastPosition;
+};
+export type ToastProps = CoreToastRootProps & {
+  inset?: boolean;
+};
 export type ToastTitleProps = CoreToastTitleProps;
 export type ToastDescriptionProps = CoreToastDescriptionProps;
 export type ToastActionProps = CoreToastActionProps;
 export type ToastCloseProps = CoreToastCloseProps;
+export type ToastIconProps = JSX.HTMLAttributes<HTMLDivElement> & {
+  type?: ToastData["type"];
+};
+export type ToasterProps = ToastProviderProps & {
+  closeButton?: boolean;
+  icon?: boolean;
+  renderToast?: (toast: ToastData) => JSX.Element;
+  viewport?: ToastViewportProps;
+};
 export type { ToastData, ToastInput, ToastManager };
 
 export { toaster };
+
+const classes = (...tokens: string[]) => tokens.join(" ");
+
+const toastViewportPositionClass: Record<ToastPosition, string> = {
+  "bottom-center": classes("bottom-(--toast-offset)", "left-1/2", "-translate-x-1/2"),
+  "bottom-left": classes("bottom-(--toast-offset)", "left-(--toast-offset)"),
+  "bottom-right": classes("right-(--toast-offset)", "bottom-(--toast-offset)"),
+  "top-center": classes("top-(--toast-offset)", "left-1/2", "-translate-x-1/2"),
+  "top-left": classes("top-(--toast-offset)", "left-(--toast-offset)"),
+  "top-right": classes("top-(--toast-offset)", "right-(--toast-offset)"),
+};
+
+const toastIconClass: Record<ToastData["type"], string> = {
+  default: "text-muted-foreground",
+  error: "text-destructive",
+  info: "text-info",
+  loading: "text-muted-foreground",
+  success: "text-success",
+  warning: "text-warning",
+};
 
 export function ToastProvider(props: ToastProviderProps) {
   return <CoreToast.Provider {...props} />;
 }
 
 export function ToastViewport(props: ToastViewportProps) {
-  const [local, rest] = splitProps(props, ["class"]);
-  return <CoreToast.Viewport {...rest} class={cn("ui-toast-viewport", local.class)} />;
+  const [local, rest] = splitProps(props, ["class", "offset", "position", "style"]);
+  const position = () => local.position ?? "bottom-right";
+
+  return (
+    <CoreToast.Viewport
+      {...rest}
+      data-position={position()}
+      data-slot="toast-viewport"
+      style={{
+        "--toast-offset": local.offset ?? "24px",
+        ...(typeof local.style === "object" ? local.style : undefined),
+      }}
+      class={cn(
+        classes(
+          "ui-toast-viewport",
+          "fixed",
+          "z-50",
+          "m-0",
+          "flex",
+          "w-[calc(100vw-2*var(--toast-offset))]",
+          "max-w-(--toast-width)",
+          "list-none",
+          "flex-col",
+          "gap-(--toast-gap)",
+          "p-0",
+          "outline-none",
+          "[--toast-gap:--spacing(3)]",
+          "[--toast-width:24rem]",
+          "max-sm:right-(--toast-offset)",
+          "max-sm:left-(--toast-offset)",
+          "max-sm:w-auto",
+          "max-sm:max-w-none",
+          "max-sm:translate-x-0",
+        ),
+        toastViewportPositionClass[position()],
+        local.class,
+      )}
+    />
+  );
 }
 
 export function Toast(props: ToastProps) {
-  const [local, rest] = splitProps(props, ["class"]);
-  return <CoreToast.Root {...rest} class={cn("ui-toast", local.class)} />;
+  const [local, rest] = splitProps(props, ["class", "inset"]);
+  return (
+    <CoreToast.Root
+      {...rest}
+      data-inset={local.inset ? "" : undefined}
+      data-slot="toast"
+      class={cn(
+        classes(
+          "ui-toast",
+          "group/toast",
+          "relative",
+          "grid",
+          "min-h-14",
+          "w-full",
+          "grid-cols-[auto_1fr_auto]",
+          "items-start",
+          "gap-x-3",
+          "gap-y-1",
+          "overflow-hidden",
+          "rounded-xl",
+          "border",
+          "bg-popover",
+          "px-4",
+          "py-3",
+          "text-popover-foreground",
+          "shadow-lg/8",
+          "outline-none",
+          "transition-[opacity,translate,scale]",
+          "duration-200",
+          "before:pointer-events-none",
+          "before:absolute",
+          "before:inset-0",
+          "before:rounded-[calc(var(--radius-xl)-1px)]",
+          "before:shadow-[0_1px_--theme(--color-black/4%)]",
+          "focus-visible:ring-2",
+          "focus-visible:ring-ring",
+          "focus-visible:ring-offset-1",
+          "focus-visible:ring-offset-background",
+          "data-[status=closed]:opacity-0",
+          "data-[type=error]:border-destructive/24",
+          "data-[type=error]:bg-destructive/6",
+          "data-[type=success]:border-success/24",
+          "data-[type=success]:bg-success/6",
+          "data-[type=warning]:border-warning/24",
+          "data-[type=warning]:bg-warning/8",
+          "data-[inset]:grid-cols-[1fr_auto]",
+          "dark:before:shadow-[0_-1px_--theme(--color-white/6%)]",
+        ),
+        local.class,
+      )}
+    />
+  );
 }
 
 export function ToastTitle(props: ToastTitleProps) {
   const [local, rest] = splitProps(props, ["class"]);
-  return <CoreToast.Title {...rest} class={cn("ui-toast-title", local.class)} />;
+  return (
+    <CoreToast.Title
+      {...rest}
+      data-slot="toast-title"
+      class={cn(
+        classes(
+          "ui-toast-title",
+          "col-start-2",
+          "min-w-0",
+          "text-sm",
+          "leading-5",
+          "font-medium",
+          "text-foreground",
+          "group-data-[inset]/toast:col-start-1",
+        ),
+        local.class,
+      )}
+    />
+  );
 }
 
 export function ToastDescription(props: ToastDescriptionProps) {
   const [local, rest] = splitProps(props, ["class"]);
-  return <CoreToast.Description {...rest} class={cn("ui-toast-description", local.class)} />;
+  return (
+    <CoreToast.Description
+      {...rest}
+      data-slot="toast-description"
+      class={cn(
+        classes(
+          "ui-toast-description",
+          "col-start-2",
+          "min-w-0",
+          "text-sm",
+          "leading-5",
+          "text-muted-foreground",
+          "group-data-[inset]/toast:col-start-1",
+        ),
+        local.class,
+      )}
+    />
+  );
 }
 
 export function ToastAction(props: ToastActionProps) {
   const [local, rest] = splitProps(props, ["class"]);
-  return <CoreToast.Action {...rest} class={cn("ui-toast-action", local.class)} />;
+  return (
+    <CoreToast.Action
+      {...rest}
+      data-slot="toast-action"
+      class={cn(
+        classes(
+          "ui-toast-action",
+          "col-start-2",
+          "mt-2",
+          "inline-flex",
+          "h-8",
+          "w-fit",
+          "items-center",
+          "justify-center",
+          "rounded-lg",
+          "border",
+          "border-input",
+          "bg-background",
+          "px-3",
+          "text-sm",
+          "font-medium",
+          "text-foreground",
+          "shadow-xs/5",
+          "outline-none",
+          "transition-colors",
+          "hover:bg-accent",
+          "focus-visible:ring-2",
+          "focus-visible:ring-ring",
+          "focus-visible:ring-offset-1",
+          "focus-visible:ring-offset-background",
+          "group-data-[inset]/toast:col-start-1",
+        ),
+        local.class,
+      )}
+    />
+  );
 }
 
 export function ToastClose(props: ToastCloseProps) {
-  const [local, rest] = splitProps(props, ["class"]);
-  return <CoreToast.Close {...rest} class={cn("ui-toast-close", local.class)} />;
+  const [local, rest] = splitProps(props, ["children", "class"]);
+  return (
+    <CoreToast.Close
+      {...rest}
+      data-slot="toast-close"
+      class={cn(
+        classes(
+          "ui-toast-close",
+          "col-start-3",
+          "row-span-2",
+          "-me-1.5",
+          "-mt-1.5",
+          "inline-flex",
+          "size-8",
+          "shrink-0",
+          "cursor-pointer",
+          "items-center",
+          "justify-center",
+          "rounded-lg",
+          "border",
+          "border-transparent",
+          "text-muted-foreground",
+          "outline-none",
+          "transition-colors",
+          "hover:bg-accent",
+          "hover:text-foreground",
+          "focus-visible:ring-2",
+          "focus-visible:ring-ring",
+          "focus-visible:ring-offset-1",
+          "focus-visible:ring-offset-background",
+        ),
+        local.class,
+      )}
+    >
+      {local.children ?? <ToastCloseIcon />}
+    </CoreToast.Close>
+  );
 }
 
-export function Toaster(props: ToastProviderProps & { viewport?: ToastViewportProps }) {
-  const [local, providerProps] = splitProps(props, ["viewport"]);
+export function ToastIcon(props: ToastIconProps) {
+  const [local, rest] = splitProps(props, ["class", "type"]);
+  const type = () => local.type ?? "default";
+
+  return (
+    <div
+      {...rest}
+      aria-hidden="true"
+      data-slot="toast-icon"
+      data-type={type()}
+      class={cn(
+        classes(
+          "ui-toast-icon",
+          "col-start-1",
+          "row-span-2",
+          "mt-0.5",
+          "flex",
+          "size-4.5",
+          "items-center",
+          "justify-center",
+          "group-data-[inset]/toast:hidden",
+        ),
+        toastIconClass[type()],
+        local.class,
+      )}
+    >
+      {type() === "loading" ? <ToastLoadingIcon /> : <ToastStatusIcon type={type()} />}
+    </div>
+  );
+}
+
+export function Toaster(props: ToasterProps) {
+  const [local, providerProps] = splitProps(props, [
+    "closeButton",
+    "icon",
+    "renderToast",
+    "viewport",
+  ]);
+  const showCloseButton = () => local.closeButton ?? true;
+  const showIcon = () => local.icon ?? true;
+
   return (
     <ToastProvider {...providerProps}>
       <ToastViewport {...local.viewport}>
-        {(toast: ToastData) => (
-          <Toast toast={toast}>
-            <ToastTitle />
-            <ToastDescription />
-            <ToastAction />
-            <ToastClose>Close</ToastClose>
-          </Toast>
-        )}
+        {(toast: ToastData) =>
+          local.renderToast?.(toast) ?? (
+            <Toast toast={toast} inset={!showIcon()}>
+              {showIcon() && <ToastIcon type={toast.type} />}
+              <ToastTitle />
+              <ToastDescription />
+              <ToastAction />
+              {showCloseButton() && <ToastClose />}
+            </Toast>
+          )
+        }
       </ToastViewport>
     </ToastProvider>
+  );
+}
+
+export const ToastPrimitive = CoreToast;
+
+function ToastCloseIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      fill="none"
+      height="16"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      viewBox="0 0 24 24"
+      width="16"
+    >
+      <path d="M18 6 6 18" />
+      <path d="m6 6 12 12" />
+    </svg>
+  );
+}
+
+function ToastLoadingIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      class="animate-spin"
+      fill="none"
+      height="18"
+      viewBox="0 0 24 24"
+      width="18"
+    >
+      <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+      <path
+        class="opacity-75"
+        d="M4 12a8 8 0 0 1 8-8"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-width="4"
+      />
+    </svg>
+  );
+}
+
+function ToastStatusIcon(props: { type: ToastData["type"] }) {
+  if (props.type === "success") {
+    return (
+      <svg
+        aria-hidden="true"
+        fill="none"
+        height="18"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        viewBox="0 0 24 24"
+        width="18"
+      >
+        <path d="M20 6 9 17l-5-5" />
+      </svg>
+    );
+  }
+
+  if (props.type === "error") {
+    return (
+      <svg
+        aria-hidden="true"
+        fill="none"
+        height="18"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        viewBox="0 0 24 24"
+        width="18"
+      >
+        <circle cx="12" cy="12" r="10" />
+        <path d="m15 9-6 6" />
+        <path d="m9 9 6 6" />
+      </svg>
+    );
+  }
+
+  if (props.type === "warning") {
+    return (
+      <svg
+        aria-hidden="true"
+        fill="none"
+        height="18"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        viewBox="0 0 24 24"
+        width="18"
+      >
+        <path d="m21.7 18-8-14a2 2 0 0 0-3.4 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.7-3" />
+        <path d="M12 9v4" />
+        <path d="M12 17h.01" />
+      </svg>
+    );
+  }
+
+  return (
+    <svg
+      aria-hidden="true"
+      fill="none"
+      height="18"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      viewBox="0 0 24 24"
+      width="18"
+    >
+      <circle cx="12" cy="12" r="10" />
+      <path d="M12 16v-4" />
+      <path d="M12 8h.01" />
+    </svg>
   );
 }

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -14,5 +14,6 @@
     },
     "types": []
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx"]
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["src/default/templates"]
 }

--- a/registry/default/items/data-table.json
+++ b/registry/default/items/data-table.json
@@ -20,13 +20,18 @@
     "install": "mason add data-table",
     "dataShape": "Pass an array of row objects through data and TanStack ColumnDef<TData, unknown>[] through columns. Use getRowId when the row key is not stable by index.",
     "columns": "Columns are ordinary TanStack Table column definitions. Use DataTableColumnHeader in header renderers and column meta for toolbar filters.",
+    "api": "DataTable receives a TanStack Table instance and optional caption, toolbar slot, empty/loading slots, page size options, skeleton row count, and pagination toggle. useDataTable accepts data/columns as values or accessors for reactive row updates.",
     "sorting": "Sorting is managed locally by useDataTable with TanStack getSortedRowModel and column.getToggleSortingHandler.",
     "filtering": "Text and faceted filters are rendered by DataTableToolbar from column meta and use TanStack columnFilters state.",
     "pagination": "Pagination is local through getPaginationRowModel and DataTablePagination.",
+    "state": "useDataTable is uncontrolled by default through Solid signals initialized from initialState. Pass state plus onSortingChange, onColumnFiltersChange, onColumnVisibilityChange, onPaginationChange, or onRowSelectionChange to control individual TanStack state slices; use manualSorting, manualFiltering, manualPagination, and pageCount for server-owned row models.",
+    "accessibility": "The kit uses native table, caption, thead, tbody, th, tr, td, button, input, select, fieldset, legend, and label semantics. Headers expose scope and aria-sort, loading sets aria-busy, selected rows expose aria-selected, pagination is a labelled navigation region, and toolbar controls have programmatic labels.",
+    "dataAttributes": "Stable styling hooks use data-scope=\"ui-data-table\" and data-part values for root, header-slot, viewport, table, caption, header, header-row, head, body, row, cell, empty-row, empty, skeleton-row, skeleton-cell, column-header, sort-trigger, sort-clear, column-hide, toolbar, search, reset, toolbar-actions, faceted-filter, faceted-option, faceted-count, faceted-clear, view-options, view-options-search, view-option, row-actions, pagination, selected-summary, page-summary, page-size, and page-buttons. Root exposes data-loading and data-empty; rows expose data-selected/data-state; headers expose data-sort.",
     "rowActions": "Use DataTableRowActions in a display column. Each action receives the TanStack row.",
     "routerAdapter": "Install data-table-tanstack-router for URL-backed search param state with TanStack Router.",
     "customization": "Use ui-data-table classes and data-part values for root, toolbar, search, faceted-filter, table, header, row, cell, empty, skeleton, row-actions, and pagination.",
-    "limitations": "This source is a client-side table pattern. Server-side pagination, virtualization, persisted column preferences, and async loading orchestration should be added in app code.",
+    "ssr": "The table renders deterministic native markup and does not read browser globals during render. Hydration-sensitive row identity should come from getRowId rather than row index when data can reorder or update frequently.",
+    "limitations": "This source is a TanStack Table composition kit, not a custom table engine. Virtualization, persisted column preferences, async fetching/loading orchestration, drag column ordering/sizing, and advanced query builders should be layered in app code or future companion registry items.",
     "sourceFiles": [
       "packages/ui/src/default/components/data-table/data-table.tsx",
       "packages/ui/src/default/components/data-table/data-table-column-header.tsx",
@@ -43,7 +48,7 @@
     "dependencies": ["@tanstack/solid-table", "cn"],
     "parity": {
       "tanstackTable": "First-class comparison is TanStack Table: the kit uses Solid Table column definitions, local sorting, filtering, pagination, column visibility, row actions, and toolbar composition. Gaps: server-side orchestration, virtualization, persisted views, async loading policy, column sizing/ordering, and advanced filter builders remain app-code follow-up work.",
-      "shadcn": "Comparable to shadcn data-table source kits in copy-paste ownership and composable subcomponents. Gaps: no CLI-generated schema, no baked-in URL state without the adapter, and no opinionated server data layer."
+      "shadcn": "Comparable to shadcn data-table source kits in copy-paste ownership and composable subcomponents, with Solid-native accessors and Mason multi-file install metadata. Gaps: no CLI-generated schema, no baked-in URL state without the adapter, and no opinionated server data layer."
     }
   },
   "files": [

--- a/registry/default/items/invoice-dashboard.json
+++ b/registry/default/items/invoice-dashboard.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://mason.build/schema/registry-item.json",
+  "name": "invoice-dashboard",
+  "type": "registry:block",
+  "title": "InvoiceDashboardBlock",
+  "description": "Multi-file invoice workspace block composed from Keystone UI source and TanStack app components.",
+  "version": "0.1.0",
+  "dependencies": ["@tanstack/solid-form@^1.29.1", "@tanstack/solid-table@^8.21.3"],
+  "compatibility": {
+    "mason": ">=0.1.0 <0.2.0",
+    "solid": ">=1.9.9 <2.0.0",
+    "tanstack-form": ">=1.29.0 <2.0.0",
+    "tanstack-table": ">=8.21.0 <9.0.0"
+  },
+  "categories": ["dashboard", "form", "table", "block"],
+  "keywords": ["invoice-dashboard", "dashboard", "settings", "data-table", "tanstack-form"],
+  "docs": "https://keystone-ui.dev/docs/blocks/invoice-dashboard",
+  "registryDependencies": [
+    "badge",
+    "button",
+    "card",
+    "command-menu",
+    "data-table",
+    "select-field",
+    "separator",
+    "tanstack-form",
+    "text-field",
+    "toast"
+  ],
+  "meta": {
+    "install": "mason add invoice-dashboard",
+    "fileTree": "Installs invoice-dashboard.tsx, invoice-dashboard-columns.tsx, and invoice-dashboard-data.ts as user-owned source under src/components/blocks/invoice-dashboard/.",
+    "dependencies": [
+      "@tanstack/solid-form",
+      "@tanstack/solid-table",
+      "badge",
+      "button",
+      "card",
+      "command-menu",
+      "data-table",
+      "select-field",
+      "separator",
+      "tanstack-form",
+      "text-field",
+      "toast"
+    ],
+    "customization": "Replace the sample invoice data with route loader or app-store data, adjust columns in invoice-dashboard-columns.tsx, and wire submit/toast actions to real mutations.",
+    "frameworkAssumptions": "Designed for Solid apps using the Mason default @ alias, Tailwind-compatible class tokens, TanStack Form, and TanStack Table.",
+    "sourceFiles": [
+      "packages/ui/src/default/blocks/invoice-dashboard/invoice-dashboard.tsx",
+      "packages/ui/src/default/blocks/invoice-dashboard/invoice-dashboard-columns.tsx",
+      "packages/ui/src/default/blocks/invoice-dashboard/invoice-dashboard-data.ts"
+    ],
+    "interactions": "Representative workflow covers command menu launch, draft creation form validation/submission, toast feedback, table sorting/filtering/pagination, and row actions.",
+    "parity": {
+      "shadcn": "Matches shadcn-style block ownership by composing installed UI primitives instead of duplicating their source. Gaps: no server actions, auth, persisted filters, or production data loader contract.",
+      "tanstackForm": "Uses TanStack Form for app-level draft creation while Core remains independent. Gaps: schema validators and async submit lifecycle are intentionally left to the host app.",
+      "tanstackTable": "Uses the first-party DataTable kit for a realistic management table. Gaps: server pagination, virtualization, and saved views remain follow-up work.",
+      "sonner": "Uses the Keystone Toast source for workflow feedback. Gaps: no optimistic mutation queue or undo contract yet."
+    }
+  },
+  "files": [
+    {
+      "path": "packages/ui/src/default/blocks/invoice-dashboard/invoice-dashboard.tsx",
+      "type": "registry:block",
+      "target": "src/components/blocks/invoice-dashboard/invoice-dashboard.tsx"
+    },
+    {
+      "path": "packages/ui/src/default/blocks/invoice-dashboard/invoice-dashboard-columns.tsx",
+      "type": "registry:block",
+      "target": "src/components/blocks/invoice-dashboard/invoice-dashboard-columns.tsx"
+    },
+    {
+      "path": "packages/ui/src/default/blocks/invoice-dashboard/invoice-dashboard-data.ts",
+      "type": "registry:block",
+      "target": "src/components/blocks/invoice-dashboard/invoice-dashboard-data.ts"
+    }
+  ]
+}

--- a/registry/default/items/select-field.json
+++ b/registry/default/items/select-field.json
@@ -16,11 +16,11 @@
   "registryDependencies": ["cn", "select", "tanstack-field"],
   "meta": {
     "install": "mason add select-field",
-    "customization": "Use ui-select-field classes, TanStackField shell classes, Select classes, Core data attributes, and neutral data-slot hooks while TanStack Form owns field state and Core owns listbox behavior.",
+    "customization": "Use ui-select-field classes, TanStackField shell classes, Select classes, Core data attributes, neutral data-slot hooks, selectProps, and trigger/content/listbox/group/item escape hatches while TanStack Form owns field state and Core owns listbox behavior.",
     "sourceFiles": ["packages/ui/src/default/ui/select-field.tsx"],
     "dependencies": ["@keystone-ui/core", "@tanstack/solid-form", "cn", "select", "tanstack-field"],
-    "api": "SelectField exports SelectField, SelectFieldOption, SelectFieldProps, and SelectFieldValidators. It composes TanStackField with the styled Select item, passes validators to form.Field, derives touched error state through TanStackField, maps Select value changes to field.handleChange, maps popup close to field.handleBlur, and accepts trigger/content/listbox/item class and prop escape hatches.",
-    "accessibility": "Backed by TanStackField for label, description, error, aria-describedby, invalid state, and alert messaging, and by @keystone-ui/core/select for trigger/listbox roles, active descendant, highlighted and selected item state, disabled items, hidden form value serialization, Escape dismissal, typeahead, and native reset support.",
+    "api": "SelectField exports SelectField, SelectFieldOption, SelectFieldOptionGroup, SelectFieldProps, and SelectFieldValidators. It composes TanStackField with the styled Select item, passes validators to form.Field, derives touched error state through TanStackField, maps Select value changes to field.handleChange, maps popup close to field.handleBlur, treats the empty string as no selection for placeholder rendering, supports grouped and disabled options, uses textValue for typeahead/value text when labels are JSX, exposes an empty state, forwards disabled/readOnly/required/formId to Core Select, and accepts select/trigger/content/listbox/group/item class and prop escape hatches.",
+    "accessibility": "Backed by TanStackField for label, description, error, aria-describedby, invalid state, and alert messaging, and by @keystone-ui/core/select for trigger/listbox roles, active descendant, highlighted and selected item state, disabled items and groups, hidden form value serialization, Escape dismissal, typeahead, and native reset support. SelectField wires the trigger to TanStackField label/description/error IDs through aria-labelledby and aria-describedby while Core owns the popup/listbox relationship.",
     "anatomy": [
       "field-root",
       "field-label",
@@ -28,9 +28,12 @@
       "value",
       "content",
       "listbox",
+      "group",
+      "group-label",
       "item",
       "item-text",
       "item-indicator",
+      "empty",
       "field-description",
       "field-error"
     ],
@@ -49,7 +52,10 @@
       "--color-destructive",
       "--color-ring"
     ],
-    "limitations": "SelectField is intentionally single-value string-first. Multi-select values, object value adapters, async option loading, and schema-specific validation helpers remain app-owned composition until the underlying Select API grows those contracts.",
+    "state": "TanStack Form owns value, touched, dirty, blurred, validating, and errors. SelectField maps undefined Core Select values back to an empty string for field state, maps non-empty strings into Core Select value, marks the field focused while the popup is open, and calls field.handleBlur when the popup closes.",
+    "dataAttributes": "Generated source exposes ui-select-field data slots including data-slot=\"select-field-trigger\", data-slot=\"select-field-content\", data-slot=\"select-field-group\", data-slot=\"select-field-group-label\", data-slot=\"select-field-item\", and data-slot=\"select-field-empty\"; Core Select additionally exposes select data-scope/data-part states such as data-state, data-disabled, data-invalid, data-placeholder, data-required, data-readonly, data-highlighted, and data-selected.",
+    "ssr": "Initial placeholder/value output, hidden input serialization, and TanStackField relationship IDs are deterministic. Portal mounting, collection registration, floating measurement, and active descendant movement remain client-side Core Select effects.",
+    "limitations": "SelectField is intentionally single-value string-first and reserves the empty string as the no-selection value for placeholder display. Multi-select values, object value adapters, async option loading, filtering, virtualization, and schema-specific validation helpers remain app-owned composition until the underlying Select API grows those contracts.",
     "parity": {
       "tanstackForm": "First-class comparison is TanStack Form: SelectField now composes TanStackField, passes validators through form.Field, maps Core Select value and blur events into TanStack field handlers, and exposes field-driven touched/invalid/error state.",
       "baseUi": "Behavior parity for the underlying select is inherited through Keystone Core Select: collection registration, keyboard navigation, typeahead, positioning, hidden form value, data attributes, disabled items, and reset support.",

--- a/registry/default/items/tabs.json
+++ b/registry/default/items/tabs.json
@@ -16,13 +16,21 @@
   "registryDependencies": ["cn"],
   "meta": {
     "install": "mason add tabs",
-    "customization": "Style the generated wrappers through ui-tabs classes while Keystone keeps tablist roles, selection state, keyboard navigation, ARIA relationships, and data attributes.",
+    "customization": "Style the generated wrappers through ui-tabs classes while Keystone keeps tablist roles, selection state, keyboard navigation, ARIA relationships, measured indicator variables, dynamic trigger removal fallback, panel focus heuristics, and data attributes.",
     "sourceFiles": ["packages/ui/src/default/ui/tabs.tsx"],
     "dependencies": ["@keystone-ui/core", "cn"],
+    "anatomy": ["Tabs", "TabsList", "TabsTrigger", "TabsIndicator", "TabsContent"],
     "parts": ["root", "list", "trigger", "indicator", "content"],
+    "cssVariables": [
+      "--keystone-tabs-indicator-x",
+      "--keystone-tabs-indicator-y",
+      "--keystone-tabs-indicator-width",
+      "--keystone-tabs-indicator-height"
+    ],
+    "accessibility": "Keystone Core owns role=tablist/tab/tabpanel, aria-selected, aria-controls, aria-labelledby, horizontal and vertical keyboard navigation, RTL-aware horizontal arrows, disabled trigger semantics, and panel tabIndex heuristics.",
     "parity": {
-      "baseUi": "Thin vertical covers controlled and uncontrolled value state, disabled triggers, horizontal and vertical roving focus, RTL-aware horizontal keys, automatic/manual activation, tablist/tabpanel ARIA, UI wrapper metadata, and behavior tests. Gaps: measured indicator positioning, delete/closable tab coordination, activation latency policy, dynamic removal focus restoration, and broader touch/cursor tests remain follow-up work.",
-      "kobalte": "Matches Solid Tabs Root/List/Trigger/Content direction with controlled value, orientation, direction, activation mode, disabled triggers, and stable data attributes. Gaps: indicator measurement, create-dom-collection depth, dynamic tab lifecycle, and SSR edge-case coverage remain follow-up work."
+      "baseUi": "Covers controlled and uncontrolled value state, disabled triggers, horizontal and vertical roving focus, RTL-aware horizontal keys, automatic/manual activation, tablist/tabpanel ARIA, measured indicator CSS variables, dynamic removal focus/selection fallback, force-mounted panels, styled generated source, UI wrapper metadata, and behavior tests. Intentional gaps: app-owned delete/closable tab coordination, activation latency policy for heavy panels, and broader touch/cursor tests.",
+      "kobalte": "Matches Solid Tabs Root/List/Trigger/Content direction with controlled value, orientation, direction, activation mode, disabled triggers, forceMount, panel focus heuristics, measured indicator variables, dynamic tab lifecycle fallback, and stable data attributes. Intentional gaps: app-owned delete/closable tab coordination and deeper touch/cursor edge coverage."
     }
   },
   "files": [

--- a/registry/default/items/tanstack-start-dashboard.json
+++ b/registry/default/items/tanstack-start-dashboard.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "https://mason.build/schema/registry-item.json",
+  "name": "tanstack-start-dashboard",
+  "type": "registry:template",
+  "title": "TanStack Start Dashboard Template",
+  "description": "Solid TanStack Start app shape that mounts the invoice dashboard block as the first route.",
+  "version": "0.1.0",
+  "dependencies": [
+    "@keystone-ui/core@^0.0.0",
+    "@tailwindcss/vite@^4.2.2",
+    "@tanstack/solid-form@^1.29.1",
+    "@tanstack/solid-router@^1.168.20",
+    "@tanstack/solid-start@^1.167.58",
+    "@tanstack/solid-store@^0.11.0",
+    "@tanstack/solid-table@^8.21.3",
+    "solid-js@^1.9.12",
+    "tailwindcss@^4.2.2"
+  ],
+  "devDependencies": ["typescript@^6.0.0", "vite@^8.0.8", "vite-plugin-solid@^2.11.12"],
+  "compatibility": {
+    "solid": ">=1.9.9 <2.0.0",
+    "tanstack-router": ">=1.168.0 <2.0.0",
+    "tanstack-start": ">=1.167.0 <2.0.0"
+  },
+  "categories": ["template", "tanstack-start", "dashboard", "app"],
+  "keywords": ["tanstack-start", "solid-start", "dashboard", "invoice-dashboard", "template"],
+  "docs": "https://keystone-ui.dev/docs/templates/tanstack-start-dashboard",
+  "registryDependencies": ["invoice-dashboard"],
+  "meta": {
+    "install": "Use this template as the app scaffold, then run mason add invoice-dashboard inside the generated project.",
+    "fileTree": "Provides package.json, tsconfig.json, vite.config.ts, src/router.tsx, src/routes/__root.tsx, src/routes/index.tsx, generated route tree placeholder, and src/styles.css.",
+    "dependencies": [
+      "@keystone-ui/core",
+      "@tailwindcss/vite",
+      "@tanstack/solid-form",
+      "@tanstack/solid-router",
+      "@tanstack/solid-start",
+      "@tanstack/solid-store",
+      "@tanstack/solid-table",
+      "solid-js",
+      "tailwindcss"
+    ],
+    "customization": "Use src/routes/index.tsx as the first route integration point, replace the generated route tree through TanStack Router generation, and move shared tokens into your app stylesheet.",
+    "frameworkAssumptions": "Targets TanStack Start with file routes, Vite, Solid JSX, Tailwind v4, and the Mason default @ alias.",
+    "sourceFiles": [
+      "packages/ui/src/default/templates/tanstack-start-dashboard/package.json",
+      "packages/ui/src/default/templates/tanstack-start-dashboard/tsconfig.json",
+      "packages/ui/src/default/templates/tanstack-start-dashboard/vite.config.ts",
+      "packages/ui/src/default/templates/tanstack-start-dashboard/src/router.tsx",
+      "packages/ui/src/default/templates/tanstack-start-dashboard/src/routes/__root.tsx",
+      "packages/ui/src/default/templates/tanstack-start-dashboard/src/routes/index.tsx",
+      "packages/ui/src/default/templates/tanstack-start-dashboard/src/routeTree.gen.ts",
+      "packages/ui/src/default/templates/tanstack-start-dashboard/src/styles.css"
+    ],
+    "verification": "Template metadata is validated in the registry test suite; the invoice-dashboard block is installed and built in scripts/verify-example-app.ts.",
+    "parity": {
+      "tanstackStart": "Uses the same TanStack Start route/document/router shape as the docs app, but trims it to a product dashboard scaffold. Gaps: route generation is represented by a placeholder routeTree.gen.ts and should be regenerated in a real app.",
+      "shadcn": "Template follows source-owned app scaffolding conventions while delegating UI source to registry dependencies. Gaps: no CLI create command or themed marketing shell yet.",
+      "mason": "Documents the registry dependency on invoice-dashboard and framework assumptions for future template install support. Gaps: registry:template is validated but not installed by the current add command."
+    }
+  },
+  "files": [
+    {
+      "path": "packages/ui/src/default/templates/tanstack-start-dashboard/package.json",
+      "type": "registry:template"
+    },
+    {
+      "path": "packages/ui/src/default/templates/tanstack-start-dashboard/tsconfig.json",
+      "type": "registry:template"
+    },
+    {
+      "path": "packages/ui/src/default/templates/tanstack-start-dashboard/vite.config.ts",
+      "type": "registry:template"
+    },
+    {
+      "path": "packages/ui/src/default/templates/tanstack-start-dashboard/src/router.tsx",
+      "type": "registry:template"
+    },
+    {
+      "path": "packages/ui/src/default/templates/tanstack-start-dashboard/src/routes/__root.tsx",
+      "type": "registry:template"
+    },
+    {
+      "path": "packages/ui/src/default/templates/tanstack-start-dashboard/src/routes/index.tsx",
+      "type": "registry:template"
+    },
+    {
+      "path": "packages/ui/src/default/templates/tanstack-start-dashboard/src/routeTree.gen.ts",
+      "type": "registry:template"
+    },
+    {
+      "path": "packages/ui/src/default/templates/tanstack-start-dashboard/src/styles.css",
+      "type": "registry:template"
+    }
+  ]
+}

--- a/registry/default/items/toast.json
+++ b/registry/default/items/toast.json
@@ -16,14 +16,50 @@
   "registryDependencies": ["cn"],
   "meta": {
     "install": "mason add toast",
-    "customization": "Style generated ui-toast classes while Core owns manager updates, live-region roles, dismissal, timer scheduling, and stable toast part attributes.",
+    "customization": "Style generated ui-toast classes, data-slot hooks, position classes, and toast CSS variables while Core owns manager updates, live-region roles, dismissal, timer scheduling, pause/resume, viewport limits, and stable toast data attributes.",
     "sourceFiles": ["packages/ui/src/default/ui/toast.tsx"],
     "dependencies": ["@keystone-ui/core", "cn"],
-    "parts": ["viewport", "root", "title", "description", "action", "close"],
+    "api": [
+      "Toaster",
+      "toaster",
+      "ToastProvider",
+      "ToastViewport",
+      "Toast",
+      "ToastIcon",
+      "ToastTitle",
+      "ToastDescription",
+      "ToastAction",
+      "ToastClose",
+      "ToastPrimitive"
+    ],
+    "anatomy": {
+      "coreParts": ["viewport", "root", "title", "description", "action", "close"],
+      "uiSlots": [
+        "toast-viewport",
+        "toast",
+        "toast-icon",
+        "toast-title",
+        "toast-description",
+        "toast-action",
+        "toast-close"
+      ]
+    },
+    "accessibility": [
+      "Viewport renders a labeled region and visible toasts as list items through Core.",
+      "Toast priority maps to status or alert roles through Core.",
+      "Title and description relationships, action callbacks, close labeling, hover pause, focus pause, duration, limit, and dismiss behavior remain Core-owned.",
+      "The UI icon slot is decorative and marked aria-hidden."
+    ],
+    "cssVariables": ["--toast-offset", "--toast-gap", "--toast-width"],
+    "parts": ["viewport", "root", "icon", "title", "description", "action", "close"],
+    "limitations": [
+      "Swipe gestures, stacked height measurement, expand mode, promise helper lifecycle, cancel action, and window blur timer pausing are intentionally deferred to Core or a later UI helper.",
+      "Toast does not participate in focus trapping, outside hiding, inerting, prevent-scroll, or overlay layering."
+    ],
     "parity": {
-      "baseUi": "Matches the manager/provider/store direction with add, update, dismiss, clear, limit, timer scheduling, viewport rendering, action and close parts, and hover/focus pause behavior. Gaps: loading-to-complete promise transitions, transition status metadata, window blur pausing, viewport geometry, and advanced positioner/portal composition remain follow-up work.",
-      "kobalte": "Matches the core Toaster/Region/Toast Root, Title, Description, Close, action-like composition, Solid store subscription, duration, visible limit, pause-on-interaction, and polite/assertive live-region behavior. Gaps: region hotkey focus, swipe gestures, progress track/fill, persistent lifecycle status, and promise helper parity remain follow-up work.",
-      "sonner": "Matches the ergonomic default toaster export, id-based update/dismiss, toast type variants, action callbacks, close button, duration, viewport limit, and generated Toaster wrapper. Gaps: stacked height CSS variables, expand mode, swipe directions, rich color/icon presets, cancel action, custom JSX toast renderer presets, position offsets, and mobile offset props remain follow-up work."
+      "baseUi": "Inherits Core manager/provider/store behavior with add, update, dismiss, clear, subscribe, limit, timer scheduling, viewport rendering, action and close parts, roles, and hover/focus pause behavior. UI adds source-owned styling, slots, offsets, positions, and tone affordances without exporting private Core internals.",
+      "kobalte": "Inherits Core Toaster/Region/Toast Root, Title, Description, Close, action-like composition, Solid store subscription, duration, visible limit, pause-on-interaction, and polite/assertive live-region behavior. UI provides the styled copy-paste anatomy and decorative icon slot.",
+      "sonner": "Matches the ergonomic default toaster export, id-based update/dismiss, toast type variants, action callbacks, close button, duration, viewport limit, position offsets, responsive viewport constraints, tone icons, and custom render hook. Swipe, measured stacking, promise helpers, cancel action, and expand mode remain explicit limitations rather than UI reimplementations."
     }
   },
   "files": [

--- a/registry/default/registry.json
+++ b/registry/default/registry.json
@@ -16,6 +16,12 @@
       "description": "Account settings form block composed from UI base components."
     },
     {
+      "name": "invoice-dashboard",
+      "type": "registry:block",
+      "title": "InvoiceDashboardBlock",
+      "description": "Multi-file invoice workspace block composed from Keystone UI source and TanStack app components."
+    },
+    {
       "name": "cn",
       "type": "registry:lib",
       "title": "Class Name Utility",
@@ -146,6 +152,12 @@
       "type": "registry:ui",
       "title": "DataTable TanStack Router Adapter",
       "description": "URL-backed DataTable state adapter for TanStack Router search params."
+    },
+    {
+      "name": "tanstack-start-dashboard",
+      "type": "registry:template",
+      "title": "TanStack Start Dashboard Template",
+      "description": "Solid TanStack Start app shape that mounts the invoice dashboard block as the first route."
     },
     {
       "name": "card",

--- a/scripts/verify-example-app.ts
+++ b/scripts/verify-example-app.ts
@@ -97,6 +97,7 @@ async function main() {
     await addCommand({ cwd: app, item: "command-menu", registry });
     await addCommand({ cwd: app, item: "data-table", registry });
     await addCommand({ cwd: app, item: "data-table-tanstack-router", registry });
+    await addCommand({ cwd: app, item: "invoice-dashboard", registry });
     await writeFile(
       path.join(app, "vite.config.ts"),
       `import { fileURLToPath, URL } from "node:url";
@@ -139,6 +140,7 @@ import { DataTableColumnHeader } from "@/components/data-table/data-table-column
 import { DataTableRowActions } from "@/components/data-table/data-table-row-actions";
 import { DataTableToolbar } from "@/components/data-table/data-table-toolbar";
 import { dataTableFacetedFilter, useDataTable } from "@/components/data-table/use-data-table";
+import { InvoiceDashboardBlock } from "@/components/blocks/invoice-dashboard/invoice-dashboard";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { SelectField } from "@/components/ui/select-field";
 import { Sheet, SheetContent, SheetDescription, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
@@ -265,6 +267,7 @@ function App() {
       <DataTable table={table}>
         <DataTableToolbar table={table} />
       </DataTable>
+      <InvoiceDashboardBlock />
       <CommandMenu
         items={commandItems}
         store={commandMenuStore}
@@ -334,6 +337,7 @@ import { DataTableColumnHeader } from "@/components/data-table/data-table-column
 import { DataTableRowActions } from "@/components/data-table/data-table-row-actions";
 import { DataTableToolbar } from "@/components/data-table/data-table-toolbar";
 import { dataTableFacetedFilter, useDataTable } from "@/components/data-table/use-data-table";
+import { InvoiceDashboardBlock } from "@/components/blocks/invoice-dashboard/invoice-dashboard";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { SelectField } from "@/components/ui/select-field";
 import { Sheet, SheetContent, SheetDescription, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
@@ -455,6 +459,7 @@ function App() {
       <DataTable table={table}>
         <DataTableToolbar table={table} />
       </DataTable>
+      <InvoiceDashboardBlock />
       <CommandMenu
         items={commandItems}
         store={commandMenuStore}
@@ -505,8 +510,12 @@ for (const expected of [
   "ui-text-field-input",
   "ui-select-field-trigger",
   "ui-command-menu-trigger",
+  "ui-block-invoice-dashboard",
   "ui-data-table-table",
   "ui-data-table-pagination",
+  "Invoice workspace",
+  "Create draft",
+  "Northstar Labs",
   "Ada Lovelace",
   "Katherine Johnson",
   'data-scope="ui-text-field"',


### PR DESCRIPTION
## Summary

Adds the UI data-table end-state work with a dashboard block/template path and hardens the related Core/UI component contracts.

## Core changes

- Extends Core tabs with dynamic-removal fallback, measured indicators, and panel tabindex handling.
- Expands UI DataTable APIs for accessors, controlled state slices, manual modes, accessibility hooks, and registry metadata.
- Deepens SelectField, Tabs, and Toast source with grouped select options, styled tabs anatomy, toast positioning/icons, and exposed primitive access.
- Adds `invoice-dashboard` block source and a `tanstack-start-dashboard` template registry item.
- Updates agent docs, registry validation coverage, and example-app verification for the new block/template path.

## Behavior / invariants

- Core still owns primitive behavior; UI composes app-layer TanStack Form/Table patterns.
- Registry items carry parity metadata and source-contract validation for generated files.
- UI templates are excluded from the UI package typecheck scope.

## Known limitations

- The TanStack Start template is registry-validated but not installed by the current add command.
- Dashboard data/actions are representative source and still need host-app loaders/mutations for production use.

## Validation

- `bun run check`
- `bun run check-types`
- `bun run test:core`
- `bun run test:mason-registry`
- `bun run verify:example-app`
