### PR TITLE
[codex] ship docs foundation ui registry items

### DIFF
--- a/docs/agents/end-state-primitive-component-inventory.md
+++ b/docs/agents/end-state-primitive-component-inventory.md
@@ -140,6 +140,7 @@ Core owns headless accessible primitives and shared primitive helpers. UI owns s
 - Separator
 - Skeleton
 - Spinner
+- Group (`proven`; compact grouped controls/content with attached and inset variants, separate from FieldGroup/Toolbar/Card; see [ui-group-vertical.md](ui-group-vertical.md))
 - Card
 - Item
 - Empty
@@ -149,8 +150,8 @@ Core owns headless accessible primitives and shared primitive helpers. UI owns s
 - Image
 - Table
 - DataList
-- CodeBlock
-- CopyButton
+- CodeBlock (`proven`; docs/product code surface with caption metadata, copy action, wrapping, and stable anatomy hooks; see [ui-codeblock-copybutton-vertical.md](ui-codeblock-copybutton-vertical.md))
+- CopyButton (`proven`; native copy control backed by UI-owned clipboard helper; see [ui-codeblock-copybutton-vertical.md](ui-codeblock-copybutton-vertical.md))
 
 ### Styled Form UI
 
@@ -173,7 +174,7 @@ Core owns headless accessible primitives and shared primitive helpers. UI owns s
 - NumberField
 - OTPInput
 - FileInput
-- SearchInput
+- SearchInput (`proven`; native search input with clear/loading affordances and source-owned app/filter composition boundary; see [ui-breadcrumb-search-input-vertical.md](ui-breadcrumb-search-input-vertical.md))
 - SubmitButton
 
 ### TanStack Form UI
@@ -235,7 +236,7 @@ Core owns headless accessible primitives and shared primitive helpers. UI owns s
 
 - AppStoreProvider (`implemented`; optional TanStack Store app-shell state provider for generated UI Store/Hotkeys source; see [ui-store-hotkeys-vertical.md](ui-store-hotkeys-vertical.md))
 - ThemeStore (`0.2`; TanStack Store-backed theme state with provider/hook ergonomics, light/dark/system resolution, persistence, document theme application, and SSR theme script; see [ui-store-hotkeys-vertical.md](ui-store-hotkeys-vertical.md))
-- SidebarStore (`0.2`; TanStack Store-backed app-shell sidebar state with desktop/mobile open state, active item tracking, persistence, media-query sync, and Mod+B toggle; see [ui-store-hotkeys-vertical.md](ui-store-hotkeys-vertical.md))
+- SidebarStore (`proven`; TanStack Store-backed app-shell sidebar state with desktop/mobile open state, active item tracking, persistence, media-query sync, and Mod+B toggle; see [ui-sidebar-vertical.md](ui-sidebar-vertical.md))
 - CommandStore (`implemented`; extracted TanStack Store command state, while Keystone Combobox keeps intrinsic command menu behavior; see [ui-store-hotkeys-vertical.md](ui-store-hotkeys-vertical.md))
 - CommandMenu (`proven for 0.1`; see [ui-command-menu-vertical.md](ui-command-menu-vertical.md); 0.2 should extract reusable app primitives instead of expanding the component)
 - KeyboardShortcuts (`implemented`; app-level shortcut registration and scoping, not Core primitive keyboard behavior; see [ui-store-hotkeys-vertical.md](ui-store-hotkeys-vertical.md))
@@ -264,8 +265,8 @@ Core owns headless accessible primitives and shared primitive helpers. UI owns s
 - Chart
 - ResizablePanels
 - Carousel
-- Sidebar
-- Breadcrumb
+- Sidebar (`proven`; UI-owned app sidebar source kit with native landmarks/nav controls, desktop/mobile state via SidebarStore, stable data hooks, and no Core layout primitive; see [ui-sidebar-vertical.md](ui-sidebar-vertical.md))
+- Breadcrumb (`proven`; native nav/list/link/page parts for docs, app routes, and topbar composition; see [ui-breadcrumb-search-input-vertical.md](ui-breadcrumb-search-input-vertical.md))
 - Pagination
 - Toolbar
 

--- a/docs/agents/ui-breadcrumb-search-input-vertical.md
+++ b/docs/agents/ui-breadcrumb-search-input-vertical.md
@@ -1,0 +1,25 @@
+# UI Breadcrumb And SearchInput Vertical
+
+## Status
+
+- Breadcrumb: implemented as source-owned UI display/navigation parts for docs, app routes, and topbar trails.
+- SearchInput: implemented as a native search input composition for filters, topbars, docs search, and command/search entry points.
+
+## Audit
+
+- Breadcrumb had inventory and docs navigation mentions but no registry item or UI source.
+- SearchInput existed only as an input-group composition example; reusable source and registry metadata were missing.
+- Reusable local patterns: `Input` visual control classes, source-owned registry metadata, Solid part exports, and focused Vitest DOM contract tests.
+
+## End-State Contract
+
+- Breadcrumb owns native navigation semantics only: `nav`, ordered list, anchors, presentation separators, `aria-current=page`, and stable `data-scope`/`data-part`/`data-slot` attributes.
+- Breadcrumb intentionally does not own router matching, data loading, responsive collapse policy, or menu state.
+- SearchInput owns a native `type=search` control, decorative leading icon, optional clear button, loading status, invalid/disabled/loading state attributes, controlled and uncontrolled value rendering, and clear behavior that runs user handlers before internal clearing.
+- SearchInput intentionally does not filter data, own command behavior, sync router state, or register with Field/TanStack Field.
+
+## Verification
+
+- Component tests cover Breadcrumb landmark/list/link/page/separator/ellipsis semantics.
+- Component tests cover SearchInput native type, loading status, clear behavior, focus restoration, and `defaultPrevented` clear handling.
+- Registry metadata records API, anatomy, accessibility, limitations, and parity notes for both items.

--- a/docs/agents/ui-codeblock-copybutton-vertical.md
+++ b/docs/agents/ui-codeblock-copybutton-vertical.md
@@ -1,0 +1,27 @@
+# UI CodeBlock And CopyButton Vertical
+
+## Status
+
+- CodeBlock: implemented as source-owned UI display source for docs and product code surfaces.
+- CopyButton: implemented as an accessible native button backed by a UI-owned clipboard helper.
+- useCopyToClipboard: implemented as generated UI hook source because #175 and #174 need shared clipboard behavior and #329 tracks the reusable helper.
+
+## Audit
+
+- CodeBlock and CopyButton existed only in `apps/web/src/components/docs-shell.tsx` as app-local docs helpers.
+- Inventory listed both under UI base components, but no reusable UI package source, registry metadata, or package tests existed.
+- Reusable local patterns: source-owned UI anatomy, inline icons, `cn`, generated hook registry shape from `use-media-query`, and focused DOM contract tests.
+
+## End-State Contract
+
+- CodeBlock owns native `figure`, optional `figcaption`, `pre`, and `code` semantics, language metadata, optional copy action, action slot, wrapping mode, and stable `data-scope`/`data-part`/`data-slot` hooks.
+- CodeBlock intentionally does not tokenize syntax, parse markdown, virtualize long files, or own docs routing.
+- CopyButton owns native button semantics, labelled/icon-only rendering, copied/error state attributes, user-first click handling, and disabled state when clipboard support is unavailable.
+- createCopyToClipboard owns browser clipboard API access, temporary copied state, failure state, callbacks, timer cleanup, and SSR-safe capability checks.
+
+## Verification
+
+- Hook tests cover successful copy state and unavailable clipboard fallback.
+- CopyButton tests cover copy behavior, accessible copied label, copied state attribute, and `event.preventDefault` cancellation.
+- CodeBlock tests cover figure/header/code/copy anatomy and copy-free plain rendering.
+- Registry metadata records API, anatomy, accessibility, limitations, and parity notes for all three generated-source items.

--- a/docs/agents/ui-group-vertical.md
+++ b/docs/agents/ui-group-vertical.md
@@ -1,0 +1,39 @@
+# UI Group Vertical
+
+## Status
+
+Proven for the 0.2 UI app-layer backlog through `group` registry source.
+
+## Scope
+
+`Group` is a UI-only styled source component for compact groups of related controls or content. It covers:
+
+- root, item, label, and description anatomy
+- horizontal and vertical orientation
+- default, attached, and inset variants
+- small/default/large density hooks
+- root data-state pass-through for disabled, invalid, and selected styling
+- attached styling for child `button`, `input-control`, and `group-item` slots
+
+## Boundary
+
+Use `Group` for small dense clusters such as attached action buttons, input-adjacent controls, status chips, and compact grouped metadata.
+
+Do not use `Group` as:
+
+- `FieldGroup`: form labelling, descriptions, errors, validation, required/disabled/read-only propagation, and field-control wiring belong to Field/FieldGroup surfaces.
+- `Toolbar`: roving focus, toolbar roles, keyboard navigation, pressed toolbar buttons, and separator semantics belong to Toolbar.
+- `Card`: larger content regions with header/content/footer anatomy, surface depth, table clipping, and content hierarchy belong to Card.
+
+## Accessibility Contract
+
+`Group` is presentational by default. Consumers may add `role="group"` and `aria-label` or `aria-labelledby` when the group itself needs an accessible name. `GroupLabel` and `GroupDescription` are visual composition parts unless the caller wires them with native ARIA attributes.
+
+The `disabled`, `invalid`, and `selected` props only project `data-disabled`, `data-invalid`, and `data-selected` to the root. They do not disable nested controls, set form validity, select children, or change ARIA attributes. Nested Button, Input, Field, Toolbar, and custom controls own behavior.
+
+## Registry Evidence
+
+- Source: `packages/ui/src/default/ui/group.tsx`
+- Registry item: `registry/default/items/group.json`
+- Root registry entry: `registry/default/registry.json`
+- Validation coverage: `packages/mason-registry/src/registry-validation.test.ts`

--- a/docs/agents/ui-sidebar-vertical.md
+++ b/docs/agents/ui-sidebar-vertical.md
@@ -1,0 +1,48 @@
+# UI Sidebar Vertical
+
+## Issue
+
+GitHub: [#260](https://github.com/erik-kroon/keystone-ui/issues/260)
+
+## Audit
+
+- Existing reusable source: `packages/ui/src/default/stores/sidebar-store.tsx` already owned TanStack Store-backed desktop/mobile sidebar state, active item tracking, persistence, media-query sync, SSR-safe creation, and Mod+B toggling.
+- Existing registry metadata: `registry/default/items/sidebar-store.json` documented the store contract and explicitly said the visual Sidebar component was missing.
+- Existing workspace shell source: `packages/ui/src/default/blocks/resizable-workspace-shell.tsx` proved UI-owned app layout patterns without promoting layout behavior into Core.
+- Missing before this vertical: no `sidebar` UI registry item, no visual anatomy, no nav/link/trigger semantics, no CSS variable/data attribute contract for generated sidebar source, no user-visible sidebar tests, and no inventory status.
+
+## End-State Contract
+
+Sidebar is a UI source kit, not a Core primitive. It composes native landmarks and controls:
+
+- `SidebarProvider` owns controlled/uncontrolled desktop open state through `sidebar-store`.
+- `SidebarLayout` sets `--sidebar-width`, `--sidebar-width-icon`, and `--sidebar-width-mobile`.
+- `Sidebar` renders desktop `aside` landmark source with `data-state`, `data-side`, `data-variant`, and `data-collapsible`.
+- `SidebarMobile` renders the mobile panel as `role="dialog"` with `aria-modal="true"` from the store's mobile state.
+- `SidebarTrigger` is a native button with `aria-expanded` and optional `aria-controls`.
+- `SidebarRail` is a shadcn-style rail toggle adapted as a Solid button.
+- `SidebarNav`, `SidebarMenu`, `SidebarMenuItem`, `SidebarMenuLink`, `SidebarMenuButton`, `SidebarMenuAction`, `SidebarMenuBadge`, `SidebarMenuSkeleton`, `SidebarMenuSub`, `SidebarMenuSubItem`, and `SidebarMenuSubButton` keep navigation as native document navigation.
+- `SidebarGroupAction`, `SidebarInput`, and `SidebarSeparator` cover the shadcn sidebar support anatomy through Solid source and existing UI primitives.
+- Active links expose `aria-current="page"` and `data-active`.
+- User event handlers run first; internal state changes stop when `event.defaultPrevented`.
+- Browser globals remain isolated to `mountSidebarStore`, so server render can create sidebar source without reading `document`, `window`, `localStorage`, or `matchMedia`.
+
+## Accessibility And Behavior
+
+- Native `aside`, `nav`, `main`, `a`, and `button` semantics are preferred over custom widget roles.
+- No roving focus is introduced because sidebar menus are document navigation, not composite selection widgets.
+- The app-level keyboard shortcut remains `Mod+B` by default through `sidebar-store`, and can be disabled or changed.
+- Mobile focus trapping is intentionally not hand-rolled in this UI item. Products that require enforced modal focus should compose with the existing Sheet/Dialog source.
+
+## Registry Status
+
+- `sidebar-store`: proven state source for app shell coordination.
+- `sidebar`: proven visual source kit for app-sidebar anatomy and generated-source ergonomics.
+- Shadcn parity source checked against local clone `inspo/shadcn` at `309d950`, especially `apps/v4/styles/base-nova/ui/sidebar.tsx` and the base sidebar docs.
+
+## Known Limitations
+
+- No route adapter is included.
+- Collapsed menu tooltips are lightweight source-owned labels, not a Core tooltip primitive integration.
+- No nested persisted menu tree state is included.
+- No Core primitive was added; future promotion requires a separate ADR/RFC proving reusable intrinsic behavior.

--- a/packages/mason-registry/src/registry-validation.test.ts
+++ b/packages/mason-registry/src/registry-validation.test.ts
@@ -143,20 +143,24 @@ describe("Mason registry validation tracer", () => {
     expect(validatedNames).toEqual([
       "accordion",
       "account-settings",
+      "app-shell",
       "app-store-provider",
       "autocomplete",
       "badge",
+      "breadcrumb",
       "button",
       "card",
       "checkbox-field",
       "checkbox",
       "cn",
+      "code-block",
       "collapsible",
       "combobox-field",
       "combobox",
       "command-menu",
       "command-store",
       "context-menu",
+      "copy-button",
       "data-table-tanstack-router",
       "data-table",
       "date-picker-field",
@@ -168,6 +172,8 @@ describe("Mason registry validation tracer", () => {
       "file-field",
       "form-message",
       "form-submit",
+      "frame",
+      "group",
       "hover-card",
       "input",
       "invoice-dashboard",
@@ -176,11 +182,14 @@ describe("Mason registry validation tracer", () => {
       "label",
       "menu",
       "menubar",
+      "nav-list",
       "navigation-menu",
       "popover",
       "radio-group-field",
       "radio-group",
+      "realtime-data-table",
       "resizable-workspace-shell",
+      "search-input",
       "select-field",
       "select",
       "separator",
@@ -189,6 +198,7 @@ describe("Mason registry validation tracer", () => {
       "shortcut-recorder",
       "shortcut-sequence-recorder",
       "sidebar-store",
+      "sidebar",
       "slider-field",
       "slider",
       "switch-field",
@@ -204,6 +214,9 @@ describe("Mason registry validation tracer", () => {
       "toast",
       "toolbar",
       "tooltip",
+      "topbar",
+      "use-copy-to-clipboard",
+      "use-media-query",
     ]);
   });
 
@@ -231,6 +244,47 @@ describe("Mason registry validation tracer", () => {
     if (!empty.ok) {
       expect(empty.errors.map((error) => error.code)).toContain("parity.invalid");
     }
+  });
+
+  test("validates docs-ready metadata on the real default group item", async () => {
+    const item = await import("../../../registry/default/items/group.json");
+    const result = validateItem(item.default, { registryRoot: repoRoot });
+    const source = await readFile(resolve(uiPackageSourceRoot, "ui/group.tsx"), "utf8");
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.registryDependencies).toEqual(["cn"]);
+      expect(result.value.meta?.api).toContain("GroupItem");
+      expect(result.value.meta?.accessibility).toContain("role=group");
+      expect(result.value.meta?.anatomy).toEqual(["root", "item", "label", "description"]);
+      expect(result.value.meta?.statePassThrough).toContain("do not disable");
+      expect(result.value.meta?.composition).toContain("FieldGroup");
+      expect(result.value.meta?.composition).toContain("Toolbar");
+      expect(result.value.meta?.composition).toContain("Card");
+      expect(result.value.meta?.limitations).toContain("no Core primitive behavior");
+      expect(result.value.meta?.parity).toMatchObject({
+        visualReference: expect.any(String),
+        baseUi: expect.any(String),
+        kobalte: expect.any(String),
+      });
+    }
+
+    expect(source).toContain("export function Group");
+    expect(source).toContain("export function GroupItem");
+    expect(source).toContain("export function GroupLabel");
+    expect(source).toContain("export function GroupDescription");
+    expect(source).toContain('data-scope="ui-group"');
+    expect(source).toContain('data-part="root"');
+    expect(source).toContain('data-slot="group"');
+    expect(source).toContain("data-variant={variant()}");
+    expect(source).toContain("data-orientation={orientation()}");
+    expect(source).toContain('data-disabled={local.disabled ? "" : undefined}');
+    expect(source).toContain('data-invalid={local.invalid ? "" : undefined}');
+    expect(source).toContain('data-selected={local.selected ? "" : undefined}');
+    expect(source).toContain('"attached"');
+    expect(source).toContain('"inset"');
+    expect(source).toContain("[&>[data-slot=button]:not(:first-child)]:rounded-s-none");
+    expect(source).toContain("[&>[data-slot=input-control]:not(:last-child)]:rounded-e-none");
   });
 
   test("validates docs-ready metadata on the real default data-table item", async () => {
@@ -406,6 +460,64 @@ describe("Mason registry validation tracer", () => {
     expect(columns).toContain("dataTableFacetedFilter");
     expect(data).toContain("invoiceDashboardRows");
     expect(data).toContain("invoiceDashboardStatusOptions");
+  });
+
+  test("validates docs-ready metadata on the real default realtime-data-table block", async () => {
+    const item = await import("../../../registry/default/items/realtime-data-table.json");
+    const result = validateItem(item.default, { registryRoot: repoRoot });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.type).toBe("registry:block");
+      expect(result.value.dependencies).toContain("@tanstack/solid-table@^8.21.3");
+      expect(result.value.registryDependencies).toEqual(["badge", "button", "data-table"]);
+      expect(result.value.files).toHaveLength(3);
+      expect(
+        result.value.files.every((file) =>
+          file.target?.startsWith("src/components/blocks/realtime-data-table/"),
+        ),
+      ).toBe(true);
+      expect(result.value.meta?.realtimeBehavior).toContain("accessor");
+      expect(result.value.meta?.sorting).toContain("latency");
+      expect(result.value.meta?.rowIdentity).toContain("getRowId");
+      expect(result.value.meta?.states).toContain("empty state");
+      expect(result.value.meta?.accessibility).toContain("keyboard reachable");
+      expect(result.value.meta?.parity).toMatchObject({
+        tanstackTable: expect.any(String),
+        dataDenseWorkspace: expect.any(String),
+        shadcn: expect.any(String),
+      });
+    }
+  });
+
+  test("captures the real default realtime-data-table generated source contract", async () => {
+    const sourceRoot = resolve(uiPackageSourceRoot, "blocks/realtime-data-table");
+    const [block, columns, data] = await Promise.all([
+      readFile(resolve(sourceRoot, "realtime-data-table.tsx"), "utf8"),
+      readFile(resolve(sourceRoot, "realtime-data-table-columns.tsx"), "utf8"),
+      readFile(resolve(sourceRoot, "realtime-data-table-data.ts"), "utf8"),
+    ]);
+
+    expect(block).toContain("export function RealtimeDataTableBlock");
+    expect(block).toContain('data-part="realtime-data-table"');
+    expect(block).toContain('data-part="realtime-controls"');
+    expect(block).toContain('role="group"');
+    expect(block).toContain('aria-live="polite"');
+    expect(block).toContain("data: rows");
+    expect(block).toContain("getRowId: (row) => row.id");
+    expect(block).toContain("DataTableToolbar");
+    expect(block).toContain("loading={loading()}");
+    expect(block).toContain("setRows([])");
+    expect(block).toContain("window.setInterval");
+
+    expect(columns).toContain("DataTableColumnHeader");
+    expect(columns).toContain("dataTableFacetedFilter");
+    expect(columns).toContain("realtimeDataTableStatusOptions");
+    expect(columns).toContain('accessorKey: "latency"');
+    expect(columns).toContain('accessorKey: "throughput"');
+    expect(data).toContain("nextRealtimeDataTableRows");
+    expect(data).toContain("realtimeDataTableRows");
+    expect(data).toContain("RealtimeDataTableRow");
   });
 
   test("validates docs-ready metadata on the real default keyboard-command-surface block", async () => {

--- a/packages/ui/src/default/blocks/realtime-data-table/realtime-data-table-columns.tsx
+++ b/packages/ui/src/default/blocks/realtime-data-table/realtime-data-table-columns.tsx
@@ -1,0 +1,78 @@
+import type { ColumnDef } from "@tanstack/solid-table";
+import { Badge } from "@/components/ui/badge";
+import { DataTableColumnHeader } from "@/components/data-table/data-table-column-header";
+import { dataTableFacetedFilter } from "@/components/data-table/use-data-table";
+import {
+  realtimeDataTableStatusOptions,
+  type RealtimeDataTableRow,
+  type RealtimeDataTableStatus,
+} from "./realtime-data-table-data";
+
+const statusVariant: Record<RealtimeDataTableStatus, "muted" | "outline" | "solid"> = {
+  degraded: "outline",
+  healthy: "solid",
+  investigating: "muted",
+};
+
+function formatNumber(value: number) {
+  return new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 }).format(value);
+}
+
+export const realtimeDataTableColumns: ColumnDef<RealtimeDataTableRow, unknown>[] = [
+  {
+    accessorKey: "service",
+    header: ({ column }) => <DataTableColumnHeader column={column} title="Service" />,
+    cell: ({ row }) => (
+      <div class="ui-block-realtime-data-table-service">
+        <span>{row.original.service}</span>
+        <small>{row.original.id}</small>
+      </div>
+    ),
+    meta: {
+      label: "Service",
+      placeholder: "Search services",
+      variant: "text",
+    },
+  },
+  {
+    accessorKey: "status",
+    header: "Status",
+    cell: ({ row }) => (
+      <Badge variant={statusVariant[row.original.status]}>{row.original.status}</Badge>
+    ),
+    filterFn: dataTableFacetedFilter,
+    meta: {
+      label: "Status",
+      options: realtimeDataTableStatusOptions,
+      variant: "multiSelect",
+    },
+  },
+  {
+    accessorKey: "region",
+    header: "Region",
+    meta: {
+      label: "Region",
+      placeholder: "Search regions",
+      variant: "text",
+    },
+  },
+  {
+    accessorKey: "latency",
+    header: ({ column }) => <DataTableColumnHeader column={column} title="Latency" />,
+    cell: ({ row }) => `${row.original.latency} ms`,
+  },
+  {
+    accessorKey: "throughput",
+    header: ({ column }) => <DataTableColumnHeader column={column} title="Throughput" />,
+    cell: ({ row }) => `${formatNumber(row.original.throughput)} rpm`,
+  },
+  {
+    accessorKey: "errorRate",
+    header: ({ column }) => <DataTableColumnHeader column={column} title="Errors" />,
+    cell: ({ row }) => `${row.original.errorRate.toFixed(2)}%`,
+  },
+  {
+    accessorKey: "updatedAt",
+    header: "Updated",
+  },
+];

--- a/packages/ui/src/default/blocks/realtime-data-table/realtime-data-table-data.ts
+++ b/packages/ui/src/default/blocks/realtime-data-table/realtime-data-table-data.ts
@@ -1,0 +1,95 @@
+export type RealtimeDataTableStatus = "healthy" | "degraded" | "investigating";
+
+export type RealtimeDataTableRow = {
+  id: string;
+  service: string;
+  region: string;
+  status: RealtimeDataTableStatus;
+  latency: number;
+  throughput: number;
+  errorRate: number;
+  updatedAt: string;
+  tick: number;
+};
+
+export const realtimeDataTableStatusOptions = [
+  { label: "Healthy", value: "healthy" },
+  { label: "Degraded", value: "degraded" },
+  { label: "Investigating", value: "investigating" },
+] as const;
+
+export const realtimeDataTableRows: RealtimeDataTableRow[] = [
+  {
+    id: "svc-edge-us",
+    service: "Edge API",
+    region: "US East",
+    status: "healthy",
+    latency: 42,
+    throughput: 1280,
+    errorRate: 0.12,
+    updatedAt: "09:00:00",
+    tick: 0,
+  },
+  {
+    id: "svc-billing-eu",
+    service: "Billing Sync",
+    region: "EU West",
+    status: "degraded",
+    latency: 118,
+    throughput: 430,
+    errorRate: 1.8,
+    updatedAt: "09:00:00",
+    tick: 0,
+  },
+  {
+    id: "svc-search-apac",
+    service: "Search Index",
+    region: "APAC",
+    status: "healthy",
+    latency: 64,
+    throughput: 920,
+    errorRate: 0.28,
+    updatedAt: "09:00:00",
+    tick: 0,
+  },
+  {
+    id: "svc-worker-us",
+    service: "Worker Queue",
+    region: "US West",
+    status: "investigating",
+    latency: 156,
+    throughput: 310,
+    errorRate: 3.4,
+    updatedAt: "09:00:00",
+    tick: 0,
+  },
+];
+
+export function nextRealtimeDataTableRows(
+  rows: readonly RealtimeDataTableRow[],
+  tick: number,
+): RealtimeDataTableRow[] {
+  return rows.map((row, index) => {
+    const direction = (tick + index) % 2 === 0 ? 1 : -1;
+    const latency = Math.max(24, row.latency + direction * (6 + index * 2));
+    const throughput = Math.max(120, row.throughput + direction * (35 + index * 8));
+    const errorRate = Math.max(0, row.errorRate + direction * (index % 2 === 0 ? 0.04 : 0.12));
+    const status = getStatus(latency, errorRate);
+
+    return {
+      ...row,
+      latency,
+      throughput,
+      errorRate: Math.round(errorRate * 100) / 100,
+      status,
+      tick,
+      updatedAt: `09:00:${String(tick).padStart(2, "0")}`,
+    };
+  });
+}
+
+function getStatus(latency: number, errorRate: number): RealtimeDataTableStatus {
+  if (errorRate >= 2.5 || latency >= 145) return "investigating";
+  if (errorRate >= 1 || latency >= 100) return "degraded";
+  return "healthy";
+}

--- a/packages/ui/src/default/blocks/realtime-data-table/realtime-data-table.tsx
+++ b/packages/ui/src/default/blocks/realtime-data-table/realtime-data-table.tsx
@@ -1,0 +1,126 @@
+import { createSignal, onCleanup, onMount, Show } from "solid-js";
+import { Button } from "@/components/ui/button";
+import { DataTable } from "@/components/data-table/data-table";
+import { DataTableToolbar } from "@/components/data-table/data-table-toolbar";
+import { useDataTable } from "@/components/data-table/use-data-table";
+import { realtimeDataTableColumns } from "./realtime-data-table-columns";
+import {
+  nextRealtimeDataTableRows,
+  realtimeDataTableRows,
+  type RealtimeDataTableRow,
+} from "./realtime-data-table-data";
+
+export type RealtimeDataTableBlockProps = {
+  title?: string;
+  description?: string;
+  autoUpdate?: boolean;
+  updateInterval?: number;
+};
+
+export function RealtimeDataTableBlock(props: RealtimeDataTableBlockProps) {
+  const [rows, setRows] = createSignal<RealtimeDataTableRow[]>(realtimeDataTableRows);
+  const [tick, setTick] = createSignal(0);
+  const [loading, setLoading] = createSignal(false);
+  const [paused, setPaused] = createSignal(!props.autoUpdate);
+
+  const table = useDataTable({
+    data: rows,
+    columns: realtimeDataTableColumns,
+    getRowId: (row) => row.id,
+    initialState: {
+      pagination: { pageIndex: 0, pageSize: 4 },
+      sorting: [{ id: "latency", desc: true }],
+    },
+  });
+
+  const applyRealtimeTick = () => {
+    const nextTick = tick() + 1;
+    setTick(nextTick);
+    setRows((current) => nextRealtimeDataTableRows(current, nextTick));
+  };
+
+  onMount(() => {
+    const interval = window.setInterval(() => {
+      if (!paused() && !loading() && rows().length > 0) {
+        applyRealtimeTick();
+      }
+    }, props.updateInterval ?? 2500);
+
+    onCleanup(() => window.clearInterval(interval));
+  });
+
+  return (
+    <section
+      data-scope="ui-block"
+      data-part="realtime-data-table"
+      class="ui-block-realtime-data-table space-y-4"
+    >
+      <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div class="space-y-1">
+          <h2 class="text-lg font-semibold">{props.title ?? "Realtime service telemetry"}</h2>
+          <p class="max-w-2xl text-sm text-muted-foreground">
+            {props.description ??
+              "Reactive TanStack Table rows update in place while stable row IDs preserve sorting, selection, and hydration-sensitive identity."}
+          </p>
+        </div>
+        <div
+          aria-label="Realtime table controls"
+          class="flex flex-wrap items-center gap-2"
+          data-scope="ui-block"
+          data-part="realtime-controls"
+          role="group"
+        >
+          <Button
+            type="button"
+            variant="outline"
+            aria-pressed={!paused()}
+            onClick={() => setPaused((current) => !current)}
+          >
+            <Show when={paused()} fallback="Pause">
+              Resume
+            </Show>
+          </Button>
+          <Button type="button" variant="outline" onClick={applyRealtimeTick}>
+            Apply tick
+          </Button>
+          <Button type="button" variant="outline" onClick={() => setLoading((current) => !current)}>
+            <Show when={loading()} fallback="Show loading">
+              Hide loading
+            </Show>
+          </Button>
+          <Button type="button" variant="outline" onClick={() => setRows([])}>
+            Clear rows
+          </Button>
+          <Button
+            type="button"
+            onClick={() => {
+              setRows(realtimeDataTableRows);
+              setTick(0);
+              setLoading(false);
+            }}
+          >
+            Reset rows
+          </Button>
+        </div>
+      </div>
+
+      <div
+        aria-live="polite"
+        class="rounded-md border bg-muted/30 px-3 py-2 text-sm text-muted-foreground"
+        data-scope="ui-block"
+        data-part="realtime-status"
+      >
+        Tick {tick()} updates {rows().length} stable service rows.
+      </div>
+
+      <DataTable
+        table={table}
+        loading={loading()}
+        skeletonRows={4}
+        empty="No telemetry rows match the current table state."
+      >
+        <DataTableToolbar table={table} />
+      </DataTable>
+    </section>
+  );
+}

--- a/packages/ui/src/default/hooks/use-copy-to-clipboard.test.ts
+++ b/packages/ui/src/default/hooks/use-copy-to-clipboard.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "vitest";
+import { createRoot } from "solid-js";
+import { createCopyToClipboard } from "./use-copy-to-clipboard";
+
+function createTestWindow(writeText?: (value: string) => Promise<void>) {
+  return {
+    navigator: {
+      clipboard: writeText ? { writeText } : undefined,
+    },
+  } as unknown as Window;
+}
+
+describe("createCopyToClipboard", () => {
+  test("copies text and exposes temporary copied state", async () => {
+    const values: string[] = [];
+
+    await createRoot(async (dispose) => {
+      const clipboard = createCopyToClipboard({
+        copiedDuration: 1,
+        window: createTestWindow(async (value) => {
+          values.push(value);
+        }),
+      });
+
+      await expect(clipboard.copy("npm install")).resolves.toBe(true);
+      expect(values).toEqual(["npm install"]);
+      expect(clipboard.status()).toBe("copied");
+      expect(clipboard.copied()).toBe(true);
+
+      dispose();
+    });
+  });
+
+  test("reports unavailable clipboard APIs without throwing", async () => {
+    await createRoot(async (dispose) => {
+      const clipboard = createCopyToClipboard({ window: createTestWindow() });
+
+      await expect(clipboard.copy("hello")).resolves.toBe(false);
+      expect(clipboard.status()).toBe("error");
+      expect(clipboard.error()).toBeInstanceOf(Error);
+
+      dispose();
+    });
+  });
+});

--- a/packages/ui/src/default/hooks/use-copy-to-clipboard.ts
+++ b/packages/ui/src/default/hooks/use-copy-to-clipboard.ts
@@ -1,0 +1,84 @@
+import { createSignal, onCleanup, type Accessor } from "solid-js";
+
+export type CopyToClipboardStatus = "idle" | "copied" | "error";
+
+export type CopyToClipboardOptions = {
+  copiedDuration?: number;
+  onCopy?: (value: string) => void;
+  onError?: (error: unknown, value: string) => void;
+  window?: Window;
+};
+
+export type CopyToClipboardResult = {
+  copied: Accessor<boolean>;
+  copy: (value: string) => Promise<boolean>;
+  error: Accessor<unknown>;
+  isSupported: () => boolean;
+  reset: () => void;
+  status: Accessor<CopyToClipboardStatus>;
+};
+
+function getClipboard(options: CopyToClipboardOptions) {
+  const targetNavigator =
+    options.window?.navigator ??
+    (typeof globalThis.navigator === "undefined" ? undefined : globalThis.navigator);
+  return targetNavigator?.clipboard;
+}
+
+export function createCopyToClipboard(options: CopyToClipboardOptions = {}): CopyToClipboardResult {
+  const [status, setStatus] = createSignal<CopyToClipboardStatus>("idle");
+  const [error, setError] = createSignal<unknown>();
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  const clearCopiedTimeout = () => {
+    if (!timeoutId) return;
+    clearTimeout(timeoutId);
+    timeoutId = undefined;
+  };
+
+  const reset = () => {
+    clearCopiedTimeout();
+    setStatus("idle");
+    setError(undefined);
+  };
+
+  const isSupported = () => typeof getClipboard(options)?.writeText === "function";
+
+  const copy = async (value: string) => {
+    const clipboard = getClipboard(options);
+    if (typeof clipboard?.writeText !== "function") {
+      const nextError = new Error("Clipboard API is not available.");
+      setError(nextError);
+      setStatus("error");
+      options.onError?.(nextError, value);
+      return false;
+    }
+
+    try {
+      await clipboard.writeText(value);
+      clearCopiedTimeout();
+      setError(undefined);
+      setStatus("copied");
+      options.onCopy?.(value);
+      timeoutId = setTimeout(() => setStatus("idle"), options.copiedDuration ?? 1600);
+      return true;
+    } catch (nextError) {
+      clearCopiedTimeout();
+      setError(nextError);
+      setStatus("error");
+      options.onError?.(nextError, value);
+      return false;
+    }
+  };
+
+  onCleanup(clearCopiedTimeout);
+
+  return {
+    copied: () => status() === "copied",
+    copy,
+    error,
+    isSupported,
+    reset,
+    status,
+  };
+}

--- a/packages/ui/src/default/hooks/use-media-query.test.tsx
+++ b/packages/ui/src/default/hooks/use-media-query.test.tsx
@@ -1,0 +1,65 @@
+import { render } from "solid-js/web";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { createBreakpointQuery, normalizeMediaQuery, useMediaQuery } from "./use-media-query";
+
+describe("useMediaQuery", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("keeps the default value until mounted", () => {
+    const matches = useMediaQuery("(min-width: 768px)", { defaultValue: true });
+
+    expect(matches()).toBe(true);
+  });
+
+  test("reads matchMedia after mount and cleans up listeners", async () => {
+    const addEventListener = vi.fn();
+    const removeEventListener = vi.fn();
+    const matchMedia = vi.fn(() => ({
+      matches: true,
+      media: "(min-width: 768px)",
+      addEventListener,
+      removeEventListener,
+    }));
+    const host = document.createElement("div");
+    let matches = () => false;
+
+    document.body.append(host);
+    const dispose = render(() => {
+      matches = useMediaQuery("(min-width: 768px)", {
+        window: { matchMedia } as unknown as Window,
+      });
+      return null;
+    }, host);
+
+    await tick();
+
+    expect(matchMedia).toHaveBeenCalledWith("(min-width: 768px)");
+    expect(matches()).toBe(true);
+    expect(addEventListener).toHaveBeenCalledWith("change", expect.any(Function));
+
+    dispose();
+    expect(removeEventListener).toHaveBeenCalledWith("change", expect.any(Function));
+    host.remove();
+  });
+
+  test("normalizes breakpoint and feature helpers", () => {
+    expect(createBreakpointQuery("md")).toBe("(min-width: 768px)");
+    expect(createBreakpointQuery("md", "down")).toBe("(max-width: 767.98px)");
+    expect(
+      normalizeMediaQuery({
+        max: "48rem",
+        orientation: "portrait",
+        pointer: "coarse",
+        preference: "reduced-motion",
+      }),
+    ).toBe(
+      "(max-width: 48rem) and (orientation: portrait) and (pointer: coarse) and (prefers-reduced-motion: reduce)",
+    );
+  });
+});
+
+function tick() {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}

--- a/packages/ui/src/default/hooks/use-media-query.ts
+++ b/packages/ui/src/default/hooks/use-media-query.ts
@@ -1,0 +1,127 @@
+import { createSignal, onCleanup, onMount, type Accessor } from "solid-js";
+
+export type MediaQueryInput =
+  | string
+  | {
+      max?: number | string;
+      min?: number | string;
+      orientation?: "landscape" | "portrait";
+      pointer?: "coarse" | "fine" | "none";
+      preference?: "dark" | "light" | "motion" | "reduced-motion";
+    };
+
+export type UseMediaQueryOptions = {
+  defaultValue?: boolean;
+  window?: Window;
+};
+
+export const mediaQueryBreakpoints = {
+  sm: 640,
+  md: 768,
+  lg: 1024,
+  xl: 1280,
+  "2xl": 1536,
+} as const;
+
+export type MediaQueryBreakpoint = keyof typeof mediaQueryBreakpoints;
+
+export function useMediaQuery(query: MediaQueryInput, options: UseMediaQueryOptions = {}) {
+  return createMediaQuery(query, options);
+}
+
+export function createMediaQuery(
+  query: MediaQueryInput,
+  options: UseMediaQueryOptions = {},
+): Accessor<boolean> {
+  const [matches, setMatches] = createSignal(options.defaultValue ?? false);
+
+  onMount(() => {
+    const view = options.window ?? globalThis.window;
+    const normalizedQuery = normalizeMediaQuery(query);
+    const mediaQueryList = view?.matchMedia?.(normalizedQuery);
+    if (!mediaQueryList) return;
+
+    const sync = () => setMatches(mediaQueryList.matches);
+    sync();
+    addMediaQueryListener(mediaQueryList, sync);
+
+    onCleanup(() => removeMediaQueryListener(mediaQueryList, sync));
+  });
+
+  return matches;
+}
+
+export function createBreakpointQuery(
+  breakpoint: MediaQueryBreakpoint | number,
+  direction: "down" | "up" = "up",
+) {
+  const value = typeof breakpoint === "number" ? breakpoint : mediaQueryBreakpoints[breakpoint];
+
+  if (direction === "down") {
+    return `(max-width: ${value - 0.02}px)`;
+  }
+
+  return `(min-width: ${value}px)`;
+}
+
+export function createPointerQuery(pointer: "coarse" | "fine" | "none") {
+  return `(pointer: ${pointer})`;
+}
+
+export function normalizeMediaQuery(query: MediaQueryInput) {
+  if (typeof query === "string") return query;
+
+  const parts: string[] = [];
+
+  if (query.min !== undefined) {
+    parts.push(`(min-width: ${formatMediaValue(query.min)})`);
+  }
+
+  if (query.max !== undefined) {
+    parts.push(`(max-width: ${formatMediaValue(query.max)})`);
+  }
+
+  if (query.orientation) {
+    parts.push(`(orientation: ${query.orientation})`);
+  }
+
+  if (query.pointer) {
+    parts.push(createPointerQuery(query.pointer));
+  }
+
+  if (query.preference === "dark" || query.preference === "light") {
+    parts.push(`(prefers-color-scheme: ${query.preference})`);
+  }
+
+  if (query.preference === "motion") {
+    parts.push("(prefers-reduced-motion: no-preference)");
+  }
+
+  if (query.preference === "reduced-motion") {
+    parts.push("(prefers-reduced-motion: reduce)");
+  }
+
+  return parts.length > 0 ? parts.join(" and ") : "all";
+}
+
+function formatMediaValue(value: number | string) {
+  return typeof value === "number" ? `${value}px` : value;
+}
+
+function addMediaQueryListener(mediaQueryList: MediaQueryList, listener: () => void) {
+  if (mediaQueryList.addEventListener) {
+    mediaQueryList.addEventListener("change", listener);
+    return;
+  }
+
+  mediaQueryList.addListener?.(listener);
+}
+
+function removeMediaQueryListener(mediaQueryList: MediaQueryList, listener: () => void) {
+  if (mediaQueryList.removeEventListener) {
+    mediaQueryList.removeEventListener("change", listener);
+    return;
+  }
+
+  mediaQueryList.removeListener?.(listener);
+}

--- a/packages/ui/src/default/ui/app-shell.tsx
+++ b/packages/ui/src/default/ui/app-shell.tsx
@@ -1,0 +1,171 @@
+import { Show, splitProps, type JSX, type ParentProps } from "solid-js";
+import { cn } from "@/lib/cn";
+
+export type AppShellProps = ParentProps<
+  JSX.HTMLAttributes<HTMLDivElement> & {
+    commandMenu?: JSX.Element;
+    inspector?: JSX.Element;
+    main?: JSX.Element;
+    sidebar?: JSX.Element;
+    sidebarState?: "collapsed" | "expanded";
+    topbar?: JSX.Element;
+  }
+>;
+
+export type AppShellRootProps = JSX.HTMLAttributes<HTMLDivElement> & {
+  sidebarState?: "collapsed" | "expanded";
+};
+export type AppShellTopbarProps = JSX.HTMLAttributes<HTMLDivElement>;
+export type AppShellSidebarProps = JSX.HTMLAttributes<HTMLElement>;
+export type AppShellMainProps = JSX.HTMLAttributes<HTMLElement>;
+export type AppShellInspectorProps = JSX.HTMLAttributes<HTMLElement>;
+export type AppShellCommandSurfaceProps = JSX.HTMLAttributes<HTMLDivElement>;
+
+const classes = (...tokens: string[]) => tokens.join(" ");
+
+export function AppShell(props: AppShellProps) {
+  const [local, rest] = splitProps(props, [
+    "children",
+    "commandMenu",
+    "inspector",
+    "main",
+    "sidebar",
+    "sidebarState",
+    "topbar",
+  ]);
+
+  return (
+    <AppShellRoot {...rest} sidebarState={local.sidebarState}>
+      <Show when={local.topbar}>
+        <AppShellTopbar>{local.topbar}</AppShellTopbar>
+      </Show>
+      <Show when={local.sidebar}>
+        <AppShellSidebar>{local.sidebar}</AppShellSidebar>
+      </Show>
+      <AppShellMain>{local.main ?? local.children}</AppShellMain>
+      <Show when={local.inspector}>
+        <AppShellInspector>{local.inspector}</AppShellInspector>
+      </Show>
+      <Show when={local.commandMenu}>
+        <AppShellCommandSurface>{local.commandMenu}</AppShellCommandSurface>
+      </Show>
+    </AppShellRoot>
+  );
+}
+
+export function AppShellRoot(props: AppShellRootProps) {
+  const [local, rest] = splitProps(props, ["class", "sidebarState"]);
+  return (
+    <div
+      {...rest}
+      data-scope="ui-app-shell"
+      data-part="root"
+      data-sidebar-state={local.sidebarState}
+      class={cn(
+        classes(
+          "ui-app-shell",
+          "grid",
+          "min-h-dvh",
+          "min-w-0",
+          "bg-background",
+          "text-foreground",
+          "[grid-template-areas:'topbar'_'main'_'sidebar'_'inspector']",
+          "grid-rows-[auto_minmax(0,1fr)_auto_auto]",
+          "lg:[grid-template-areas:'topbar_topbar_topbar'_'sidebar_main_inspector']",
+          "lg:grid-cols-[minmax(14rem,18rem)_minmax(0,1fr)_minmax(18rem,24rem)]",
+          "lg:grid-rows-[auto_minmax(0,1fr)]",
+          "data-[sidebar-state=collapsed]:lg:grid-cols-[4rem_minmax(0,1fr)_minmax(18rem,24rem)]",
+        ),
+        local.class,
+      )}
+    />
+  );
+}
+
+export function AppShellTopbar(props: AppShellTopbarProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return (
+    <div
+      {...rest}
+      data-scope="ui-app-shell"
+      data-part="topbar"
+      class={cn("ui-app-shell-topbar min-w-0 [grid-area:topbar]", local.class)}
+    />
+  );
+}
+
+export function AppShellSidebar(props: AppShellSidebarProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return (
+    <aside
+      {...rest}
+      data-scope="ui-app-shell"
+      data-part="sidebar"
+      class={cn(
+        classes(
+          "ui-app-shell-sidebar",
+          "min-w-0",
+          "border-t",
+          "bg-muted/24",
+          "p-2",
+          "[grid-area:sidebar]",
+          "lg:min-h-0",
+          "lg:overflow-auto",
+          "lg:border-t-0",
+          "lg:border-e",
+        ),
+        local.class,
+      )}
+    />
+  );
+}
+
+export function AppShellMain(props: AppShellMainProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return (
+    <main
+      {...rest}
+      data-scope="ui-app-shell"
+      data-part="main"
+      class={cn("ui-app-shell-main min-h-0 min-w-0 overflow-auto [grid-area:main]", local.class)}
+    />
+  );
+}
+
+export function AppShellInspector(props: AppShellInspectorProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return (
+    <aside
+      {...rest}
+      data-scope="ui-app-shell"
+      data-part="inspector"
+      class={cn(
+        classes(
+          "ui-app-shell-inspector",
+          "min-w-0",
+          "border-t",
+          "bg-muted/16",
+          "p-3",
+          "[grid-area:inspector]",
+          "lg:min-h-0",
+          "lg:overflow-auto",
+          "lg:border-s",
+          "lg:border-t-0",
+        ),
+        local.class,
+      )}
+    />
+  );
+}
+
+export function AppShellCommandSurface(props: AppShellCommandSurfaceProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return (
+    <div
+      {...rest}
+      data-scope="ui-app-shell"
+      data-part="command-surface"
+      class={cn("ui-app-shell-command-surface contents", local.class)}
+    />
+  );
+}

--- a/packages/ui/src/default/ui/breadcrumb.test.tsx
+++ b/packages/ui/src/default/ui/breadcrumb.test.tsx
@@ -1,0 +1,77 @@
+import { render } from "solid-js/web";
+import { describe, expect, test } from "vitest";
+import {
+  Breadcrumb,
+  BreadcrumbEllipsis,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "./breadcrumb";
+
+describe("Breadcrumb", () => {
+  test("renders nav, ordered list, separators, links, and current page semantics", () => {
+    const host = document.createElement("div");
+    const dispose = render(
+      () => (
+        <Breadcrumb
+          items={[
+            { href: "/docs", label: "Docs" },
+            { href: "/docs/components", label: "Components" },
+            { current: true, label: "Breadcrumb" },
+          ]}
+        />
+      ),
+      host,
+    );
+
+    const nav = host.querySelector("nav");
+    const links = host.querySelectorAll("[data-slot='breadcrumb-link']");
+    const page = host.querySelector("[data-slot='breadcrumb-page']");
+
+    expect(nav?.getAttribute("aria-label")).toBe("Breadcrumb");
+    expect(host.querySelector("[data-slot='breadcrumb-list']")?.tagName).toBe("OL");
+    expect(links).toHaveLength(2);
+    expect(links[0]?.getAttribute("href")).toBe("/docs");
+    expect(page?.getAttribute("aria-current")).toBe("page");
+    expect(page?.textContent).toBe("Breadcrumb");
+    expect(host.querySelectorAll("[data-slot='breadcrumb-separator']")).toHaveLength(2);
+
+    dispose();
+  });
+
+  test("supports source-owned composition parts and menu ellipsis", () => {
+    const host = document.createElement("div");
+    const dispose = render(
+      () => (
+        <Breadcrumb label="Project path">
+          <BreadcrumbList>
+            <BreadcrumbItem>
+              <BreadcrumbLink href="/app">App</BreadcrumbLink>
+            </BreadcrumbItem>
+            <BreadcrumbSeparator />
+            <BreadcrumbItem>
+              <BreadcrumbEllipsis />
+            </BreadcrumbItem>
+            <BreadcrumbSeparator />
+            <BreadcrumbItem>
+              <BreadcrumbPage>Settings</BreadcrumbPage>
+            </BreadcrumbItem>
+          </BreadcrumbList>
+        </Breadcrumb>
+      ),
+      host,
+    );
+
+    expect(host.querySelector("nav")?.getAttribute("aria-label")).toBe("Project path");
+    expect(host.querySelector("[data-slot='breadcrumb-ellipsis']")?.getAttribute("type")).toBe(
+      "button",
+    );
+    expect(
+      host.querySelector("[data-slot='breadcrumb-ellipsis']")?.getAttribute("aria-label"),
+    ).toBe("Show breadcrumb menu");
+
+    dispose();
+  });
+});

--- a/packages/ui/src/default/ui/breadcrumb.tsx
+++ b/packages/ui/src/default/ui/breadcrumb.tsx
@@ -1,0 +1,260 @@
+import { For, Show, splitProps, type JSX, type ParentProps } from "solid-js";
+import { cn } from "@/lib/cn";
+
+export type BreadcrumbItemData = {
+  current?: boolean;
+  disabled?: boolean;
+  href?: string;
+  label: JSX.Element;
+};
+
+export type BreadcrumbProps = ParentProps<
+  JSX.HTMLAttributes<HTMLElement> & {
+    items?: readonly BreadcrumbItemData[];
+    label?: string;
+    linkClass?: string;
+    listClass?: string;
+    pageClass?: string;
+    separator?: JSX.Element;
+    separatorClass?: string;
+  }
+>;
+export type BreadcrumbListProps = ParentProps<JSX.OlHTMLAttributes<HTMLOListElement>>;
+export type BreadcrumbItemProps = ParentProps<JSX.LiHTMLAttributes<HTMLLIElement>>;
+export type BreadcrumbLinkProps = ParentProps<JSX.AnchorHTMLAttributes<HTMLAnchorElement>>;
+export type BreadcrumbPageProps = ParentProps<JSX.HTMLAttributes<HTMLSpanElement>>;
+export type BreadcrumbSeparatorProps = ParentProps<JSX.LiHTMLAttributes<HTMLLIElement>>;
+export type BreadcrumbEllipsisProps = JSX.ButtonHTMLAttributes<HTMLButtonElement> & {
+  label?: string;
+};
+
+const classes = (...tokens: string[]) => tokens.join(" ");
+
+function ChevronSeparator() {
+  return (
+    <svg
+      aria-hidden="true"
+      fill="none"
+      height="24"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      viewBox="0 0 24 24"
+      width="24"
+    >
+      <path d="m9 18 6-6-6-6" />
+    </svg>
+  );
+}
+
+export function Breadcrumb(props: BreadcrumbProps) {
+  const [local, rest] = splitProps(props, [
+    "children",
+    "class",
+    "items",
+    "label",
+    "linkClass",
+    "listClass",
+    "pageClass",
+    "separator",
+    "separatorClass",
+  ]);
+
+  return (
+    <nav
+      {...rest}
+      aria-label={local.label ?? rest["aria-label"] ?? "Breadcrumb"}
+      data-scope="ui-breadcrumb"
+      data-part="root"
+      data-slot="breadcrumb"
+      class={cn("ui-breadcrumb", local.class)}
+    >
+      <Show when={local.items} fallback={local.children}>
+        {(items) => (
+          <BreadcrumbList class={local.listClass}>
+            <For each={items()}>
+              {(item, index) => {
+                const current = () => item.current || index() === items().length - 1;
+
+                return (
+                  <>
+                    <BreadcrumbItem data-current={current() ? "" : undefined}>
+                      <Show
+                        when={!current() && item.href && !item.disabled}
+                        fallback={
+                          <BreadcrumbPage class={local.pageClass}>{item.label}</BreadcrumbPage>
+                        }
+                      >
+                        <BreadcrumbLink
+                          class={local.linkClass}
+                          href={item.href}
+                          aria-disabled={item.disabled || undefined}
+                        >
+                          {item.label}
+                        </BreadcrumbLink>
+                      </Show>
+                    </BreadcrumbItem>
+                    <Show when={index() < items().length - 1}>
+                      <BreadcrumbSeparator class={local.separatorClass}>
+                        {local.separator}
+                      </BreadcrumbSeparator>
+                    </Show>
+                  </>
+                );
+              }}
+            </For>
+          </BreadcrumbList>
+        )}
+      </Show>
+    </nav>
+  );
+}
+
+export function BreadcrumbList(props: BreadcrumbListProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+
+  return (
+    <ol
+      {...rest}
+      data-scope="ui-breadcrumb"
+      data-part="list"
+      data-slot="breadcrumb-list"
+      class={cn(
+        classes(
+          "ui-breadcrumb-list",
+          "flex",
+          "min-w-0",
+          "flex-wrap",
+          "items-center",
+          "gap-1.5",
+          "text-muted-foreground",
+          "text-sm",
+        ),
+        local.class,
+      )}
+    />
+  );
+}
+
+export function BreadcrumbItem(props: BreadcrumbItemProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+
+  return (
+    <li
+      {...rest}
+      data-scope="ui-breadcrumb"
+      data-part="item"
+      data-slot="breadcrumb-item"
+      class={cn("ui-breadcrumb-item inline-flex min-w-0 items-center gap-1.5", local.class)}
+    />
+  );
+}
+
+export function BreadcrumbLink(props: BreadcrumbLinkProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+
+  return (
+    <a
+      {...rest}
+      data-scope="ui-breadcrumb"
+      data-part="link"
+      data-slot="breadcrumb-link"
+      class={cn(
+        classes(
+          "ui-breadcrumb-link",
+          "min-w-0",
+          "truncate",
+          "rounded-md",
+          "outline-none",
+          "transition-colors",
+          "hover:text-foreground",
+          "focus-visible:ring-2",
+          "focus-visible:ring-ring",
+          "focus-visible:ring-offset-1",
+          "focus-visible:ring-offset-background",
+          "aria-disabled:pointer-events-none",
+          "aria-disabled:opacity-64",
+        ),
+        local.class,
+      )}
+    />
+  );
+}
+
+export function BreadcrumbPage(props: BreadcrumbPageProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+
+  return (
+    <span
+      {...rest}
+      aria-current={rest["aria-current"] ?? "page"}
+      data-scope="ui-breadcrumb"
+      data-part="page"
+      data-slot="breadcrumb-page"
+      class={cn("ui-breadcrumb-page min-w-0 truncate font-medium text-foreground", local.class)}
+    />
+  );
+}
+
+export function BreadcrumbSeparator(props: BreadcrumbSeparatorProps) {
+  const [local, rest] = splitProps(props, ["children", "class"]);
+
+  return (
+    <li
+      {...rest}
+      aria-hidden="true"
+      data-scope="ui-breadcrumb"
+      data-part="separator"
+      data-slot="breadcrumb-separator"
+      role="presentation"
+      class={cn(
+        "ui-breadcrumb-separator inline-flex shrink-0 items-center text-muted-foreground/56 [&_svg]:size-3.5",
+        local.class,
+      )}
+    >
+      {local.children ?? <ChevronSeparator />}
+    </li>
+  );
+}
+
+export function BreadcrumbEllipsis(props: BreadcrumbEllipsisProps) {
+  const [local, rest] = splitProps(props, ["class", "label"]);
+
+  return (
+    <button
+      {...rest}
+      aria-label={local.label ?? rest["aria-label"] ?? "Show breadcrumb menu"}
+      data-scope="ui-breadcrumb"
+      data-part="ellipsis"
+      data-slot="breadcrumb-ellipsis"
+      type={rest.type ?? "button"}
+      class={cn(
+        classes(
+          "ui-breadcrumb-ellipsis",
+          "inline-flex",
+          "size-7",
+          "items-center",
+          "justify-center",
+          "rounded-md",
+          "text-muted-foreground",
+          "outline-none",
+          "transition-colors",
+          "hover:bg-accent",
+          "hover:text-accent-foreground",
+          "focus-visible:ring-2",
+          "focus-visible:ring-ring",
+          "focus-visible:ring-offset-1",
+          "focus-visible:ring-offset-background",
+          "disabled:pointer-events-none",
+          "disabled:opacity-64",
+        ),
+        local.class,
+      )}
+    >
+      <span aria-hidden="true" class="text-lg leading-none">
+        ...
+      </span>
+    </button>
+  );
+}

--- a/packages/ui/src/default/ui/code-block.test.tsx
+++ b/packages/ui/src/default/ui/code-block.test.tsx
@@ -1,0 +1,46 @@
+import { render } from "solid-js/web";
+import { describe, expect, test } from "vitest";
+import { CodeBlock } from "./code-block";
+
+describe("CodeBlock", () => {
+  test("renders figure, caption, language metadata, code text, and copy action", () => {
+    const host = document.createElement("div");
+    const dispose = render(
+      () => (
+        <CodeBlock
+          code="const value = 1;"
+          description="Install source"
+          language="tsx"
+          title="Example"
+        />
+      ),
+      host,
+    );
+
+    const figure = host.querySelector("[data-slot='code-block']");
+    const code = host.querySelector("[data-slot='code-block-code']");
+
+    expect(figure?.tagName).toBe("FIGURE");
+    expect(figure?.getAttribute("data-language")).toBe("tsx");
+    expect(host.querySelector("[data-slot='code-block-header']")?.tagName).toBe("FIGCAPTION");
+    expect(host.querySelector("[data-slot='code-block-title']")?.textContent).toBe("Example");
+    expect(host.querySelector("[data-slot='code-block-description']")?.textContent).toBe(
+      "Install source",
+    );
+    expect(code?.textContent).toBe("const value = 1;");
+    expect(host.querySelector("[data-slot='copy-button']")).not.toBeNull();
+
+    dispose();
+  });
+
+  test("can render a plain code surface without copy controls", () => {
+    const host = document.createElement("div");
+    const dispose = render(() => <CodeBlock code="plain" copy={false} />, host);
+
+    expect(host.querySelector("[data-slot='code-block-header']")).toBeNull();
+    expect(host.querySelector("[data-slot='copy-button']")).toBeNull();
+    expect(host.querySelector("[data-slot='code-block-code']")?.textContent).toBe("plain");
+
+    dispose();
+  });
+});

--- a/packages/ui/src/default/ui/code-block.tsx
+++ b/packages/ui/src/default/ui/code-block.tsx
@@ -1,0 +1,207 @@
+import { Show, splitProps, type JSX, type ParentProps } from "solid-js";
+import { CopyButton } from "@/components/ui/copy-button";
+import { cn } from "@/lib/cn";
+
+export type CodeBlockProps = ParentProps<
+  Omit<JSX.HTMLAttributes<HTMLElement>, "children"> & {
+    actions?: JSX.Element;
+    code: string;
+    codeClass?: string;
+    copy?: boolean;
+    copyClass?: string;
+    copyLabel?: string;
+    description?: JSX.Element;
+    language?: string;
+    preClass?: string;
+    title?: JSX.Element;
+    wrap?: boolean;
+  }
+>;
+
+export type CodeBlockHeaderProps = ParentProps<JSX.HTMLAttributes<HTMLElement>>;
+export type CodeBlockTitleProps = ParentProps<JSX.HTMLAttributes<HTMLSpanElement>>;
+export type CodeBlockDescriptionProps = ParentProps<JSX.HTMLAttributes<HTMLSpanElement>>;
+export type CodeBlockActionsProps = ParentProps<JSX.HTMLAttributes<HTMLDivElement>>;
+export type CodeBlockPreProps = ParentProps<JSX.HTMLAttributes<HTMLPreElement>>;
+export type CodeBlockCodeProps = ParentProps<JSX.HTMLAttributes<HTMLElement>>;
+
+const classes = (...tokens: string[]) => tokens.join(" ");
+
+export function CodeBlock(props: CodeBlockProps) {
+  const [local, rest] = splitProps(props, [
+    "actions",
+    "class",
+    "code",
+    "codeClass",
+    "copy",
+    "copyClass",
+    "copyLabel",
+    "description",
+    "language",
+    "preClass",
+    "title",
+    "wrap",
+  ]);
+  const hasHeader = () =>
+    Boolean(
+      local.title || local.description || local.language || local.actions || local.copy !== false,
+    );
+
+  return (
+    <figure
+      {...rest}
+      data-scope="ui-code-block"
+      data-part="root"
+      data-language={local.language}
+      data-slot="code-block"
+      data-wrap={local.wrap ? "" : undefined}
+      class={cn(
+        classes(
+          "ui-code-block",
+          "relative",
+          "overflow-hidden",
+          "rounded-lg",
+          "border",
+          "border-input",
+          "bg-muted/48",
+          "text-foreground",
+          "shadow-xs/5",
+        ),
+        local.class,
+      )}
+    >
+      <Show when={hasHeader()}>
+        <CodeBlockHeader>
+          <span class="min-w-0">
+            <Show when={local.title ?? local.language}>
+              <CodeBlockTitle>{local.title ?? local.language}</CodeBlockTitle>
+            </Show>
+            <Show when={local.description}>
+              <CodeBlockDescription>{local.description}</CodeBlockDescription>
+            </Show>
+          </span>
+          <CodeBlockActions>
+            {local.actions}
+            <Show when={local.copy !== false}>
+              <CopyButton
+                class={local.copyClass}
+                label={local.copyLabel ?? "Copy code"}
+                value={local.code}
+              />
+            </Show>
+          </CodeBlockActions>
+        </CodeBlockHeader>
+      </Show>
+      <CodeBlockPre class={local.preClass} data-wrap={local.wrap ? "" : undefined}>
+        <CodeBlockCode class={local.codeClass} data-language={local.language}>
+          {local.code}
+        </CodeBlockCode>
+      </CodeBlockPre>
+    </figure>
+  );
+}
+
+export function CodeBlockHeader(props: CodeBlockHeaderProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+
+  return (
+    <figcaption
+      {...rest}
+      data-scope="ui-code-block"
+      data-part="header"
+      data-slot="code-block-header"
+      class={cn(
+        "ui-code-block-header flex min-w-0 items-center justify-between gap-3 border-input border-b bg-background/72 px-3 py-2",
+        local.class,
+      )}
+    />
+  );
+}
+
+export function CodeBlockTitle(props: CodeBlockTitleProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+
+  return (
+    <span
+      {...rest}
+      data-scope="ui-code-block"
+      data-part="title"
+      data-slot="code-block-title"
+      class={cn(
+        "ui-code-block-title block truncate font-medium text-foreground text-sm",
+        local.class,
+      )}
+    />
+  );
+}
+
+export function CodeBlockDescription(props: CodeBlockDescriptionProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+
+  return (
+    <span
+      {...rest}
+      data-scope="ui-code-block"
+      data-part="description"
+      data-slot="code-block-description"
+      class={cn(
+        "ui-code-block-description block truncate text-muted-foreground text-xs",
+        local.class,
+      )}
+    />
+  );
+}
+
+export function CodeBlockActions(props: CodeBlockActionsProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+
+  return (
+    <div
+      {...rest}
+      data-scope="ui-code-block"
+      data-part="actions"
+      data-slot="code-block-actions"
+      class={cn("ui-code-block-actions flex shrink-0 items-center gap-1.5", local.class)}
+    />
+  );
+}
+
+export function CodeBlockPre(props: CodeBlockPreProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+
+  return (
+    <pre
+      {...rest}
+      data-scope="ui-code-block"
+      data-part="pre"
+      data-slot="code-block-pre"
+      class={cn(
+        classes(
+          "ui-code-block-pre",
+          "overflow-x-auto",
+          "p-4",
+          "font-mono",
+          "text-sm",
+          "leading-6",
+          "data-wrap:whitespace-pre-wrap",
+          "not-data-wrap:whitespace-pre",
+        ),
+        local.class,
+      )}
+    />
+  );
+}
+
+export function CodeBlockCode(props: CodeBlockCodeProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+
+  return (
+    <code
+      {...rest}
+      data-scope="ui-code-block"
+      data-part="code"
+      data-slot="code-block-code"
+      class={cn("ui-code-block-code font-mono", local.class)}
+    />
+  );
+}

--- a/packages/ui/src/default/ui/copy-button.test.tsx
+++ b/packages/ui/src/default/ui/copy-button.test.tsx
@@ -1,0 +1,71 @@
+import { render } from "solid-js/web";
+import { describe, expect, test } from "vitest";
+import { CopyButton } from "./copy-button";
+
+describe("CopyButton", () => {
+  test("copies the provided value and updates accessible state", async () => {
+    const host = document.createElement("div");
+    document.body.append(host);
+    const values: string[] = [];
+    const originalClipboard = globalThis.navigator.clipboard;
+    Object.defineProperty(globalThis.navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: async (value: string) => values.push(value) },
+    });
+
+    const dispose = render(
+      () => <CopyButton copiedDuration={1000} label="Copy install command" value="bun add" />,
+      host,
+    );
+    const button = host.querySelector<HTMLButtonElement>("[data-slot='copy-button']");
+
+    button?.click();
+    await Promise.resolve();
+
+    expect(values).toEqual(["bun add"]);
+    expect(button?.getAttribute("aria-label")).toBe("Copied");
+    expect(button?.hasAttribute("data-copied")).toBe(true);
+
+    dispose();
+    host.remove();
+    Object.defineProperty(globalThis.navigator, "clipboard", {
+      configurable: true,
+      value: originalClipboard,
+    });
+  });
+
+  test("runs user click handlers before copying", async () => {
+    const host = document.createElement("div");
+    document.body.append(host);
+    const values: string[] = [];
+    const originalClipboard = globalThis.navigator.clipboard;
+    Object.defineProperty(globalThis.navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: async (value: string) => values.push(value) },
+    });
+
+    const dispose = render(
+      () => (
+        <CopyButton
+          value="blocked"
+          onClick={(event) => {
+            event.preventDefault();
+          }}
+        />
+      ),
+      host,
+    );
+
+    host.querySelector<HTMLButtonElement>("[data-slot='copy-button']")?.click();
+    await Promise.resolve();
+
+    expect(values).toEqual([]);
+
+    dispose();
+    host.remove();
+    Object.defineProperty(globalThis.navigator, "clipboard", {
+      configurable: true,
+      value: originalClipboard,
+    });
+  });
+});

--- a/packages/ui/src/default/ui/copy-button.tsx
+++ b/packages/ui/src/default/ui/copy-button.tsx
@@ -1,0 +1,175 @@
+import { Show, splitProps, type JSX, type ParentProps } from "solid-js";
+import { createCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
+import { cn } from "@/lib/cn";
+
+export type CopyButtonProps = ParentProps<
+  Omit<JSX.ButtonHTMLAttributes<HTMLButtonElement>, "children" | "value"> & {
+    copiedDuration?: number;
+    copiedLabel?: string;
+    errorLabel?: string;
+    label?: string;
+    onCopy?: (value: string) => void;
+    onCopyError?: (error: unknown, value: string) => void;
+    showLabel?: boolean;
+    value: string;
+  }
+>;
+
+const classes = (...tokens: string[]) => tokens.join(" ");
+
+function ClipboardIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      fill="none"
+      height="24"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      viewBox="0 0 24 24"
+      width="24"
+    >
+      <rect height="14" rx="2" ry="2" width="14" x="8" y="8" />
+      <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
+    </svg>
+  );
+}
+
+function CheckIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      fill="none"
+      height="24"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      viewBox="0 0 24 24"
+      width="24"
+    >
+      <path d="M20 6 9 17l-5-5" />
+    </svg>
+  );
+}
+
+function ErrorIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      fill="none"
+      height="24"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      viewBox="0 0 24 24"
+      width="24"
+    >
+      <path d="M18 6 6 18" />
+      <path d="m6 6 12 12" />
+    </svg>
+  );
+}
+
+export function CopyButton(props: CopyButtonProps) {
+  const [local, rest] = splitProps(props, [
+    "aria-label",
+    "class",
+    "copiedDuration",
+    "copiedLabel",
+    "disabled",
+    "errorLabel",
+    "label",
+    "onClick",
+    "onCopy",
+    "onCopyError",
+    "showLabel",
+    "value",
+  ]);
+  const clipboard = createCopyToClipboard({
+    copiedDuration: local.copiedDuration,
+    onCopy: local.onCopy,
+    onError: local.onCopyError,
+  });
+  const label = () => local.label ?? "Copy";
+  const copiedLabel = () => local.copiedLabel ?? "Copied";
+  const errorLabel = () => local.errorLabel ?? "Copy failed";
+  const currentLabel = () =>
+    clipboard.status() === "copied"
+      ? copiedLabel()
+      : clipboard.status() === "error"
+        ? errorLabel()
+        : label();
+
+  return (
+    <button
+      {...rest}
+      aria-label={local["aria-label"] ?? currentLabel()}
+      data-scope="ui-copy-button"
+      data-part="root"
+      data-copied={clipboard.copied() ? "" : undefined}
+      data-error={clipboard.status() === "error" ? "" : undefined}
+      data-unsupported={!clipboard.isSupported() ? "" : undefined}
+      data-slot="copy-button"
+      disabled={local.disabled}
+      title={currentLabel()}
+      type={rest.type ?? "button"}
+      onClick={async (event) => {
+        if (typeof local.onClick === "function") {
+          local.onClick(event);
+        }
+        if (event.defaultPrevented) return;
+        await clipboard.copy(local.value);
+      }}
+      class={cn(
+        classes(
+          "ui-copy-button",
+          "inline-flex",
+          "h-8",
+          "shrink-0",
+          "items-center",
+          "justify-center",
+          "gap-1.5",
+          "rounded-lg",
+          "border",
+          "border-input",
+          "bg-background",
+          "px-2.5",
+          "text-muted-foreground",
+          "text-sm",
+          "shadow-xs/5",
+          "outline-none",
+          "transition-[background-color,color,box-shadow]",
+          "hover:bg-accent",
+          "hover:text-accent-foreground",
+          "focus-visible:ring-2",
+          "focus-visible:ring-ring",
+          "focus-visible:ring-offset-1",
+          "focus-visible:ring-offset-background",
+          "disabled:pointer-events-none",
+          "disabled:opacity-64",
+          "data-copied:text-foreground",
+          "data-error:text-destructive",
+          "[&_svg]:size-4",
+          "[&_svg]:shrink-0",
+        ),
+        !local.showLabel && "size-8 px-0",
+        local.class,
+      )}
+    >
+      <Show
+        when={clipboard.status() === "copied"}
+        fallback={
+          <Show when={clipboard.status() === "error"} fallback={<ClipboardIcon />}>
+            <ErrorIcon />
+          </Show>
+        }
+      >
+        <CheckIcon />
+      </Show>
+      <span class={local.showLabel ? undefined : "sr-only"}>{currentLabel()}</span>
+    </button>
+  );
+}

--- a/packages/ui/src/default/ui/frame.tsx
+++ b/packages/ui/src/default/ui/frame.tsx
@@ -1,0 +1,360 @@
+import { Show, splitProps, type JSX, type ParentProps } from "solid-js";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import { cn } from "@/lib/cn";
+
+export type FrameVariant = "bordered" | "elevated" | "flush" | "inset";
+export type FrameAspect = "auto" | "portrait" | "square" | "video" | "wide";
+
+export type FrameProps = ParentProps<
+  Omit<JSX.HTMLAttributes<HTMLElement>, "title"> & {
+    actions?: JSX.Element;
+    aspect?: FrameAspect;
+    description?: JSX.Element;
+    empty?: JSX.Element;
+    error?: JSX.Element;
+    footer?: JSX.Element;
+    loading?: boolean;
+    loadingLabel?: JSX.Element;
+    title?: JSX.Element;
+    variant?: FrameVariant;
+  }
+>;
+
+export type FrameRootProps = ParentProps<
+  JSX.HTMLAttributes<HTMLElement> & {
+    aspect?: FrameAspect;
+    variant?: FrameVariant;
+  }
+>;
+export type FrameHeaderProps = JSX.HTMLAttributes<HTMLDivElement>;
+export type FrameTitleProps = JSX.HTMLAttributes<HTMLDivElement>;
+export type FrameDescriptionProps = JSX.HTMLAttributes<HTMLDivElement>;
+export type FrameActionsProps = JSX.HTMLAttributes<HTMLDivElement>;
+export type FrameViewportProps = JSX.HTMLAttributes<HTMLDivElement> & {
+  aspect?: FrameAspect;
+};
+export type FrameContentProps = JSX.HTMLAttributes<HTMLDivElement>;
+export type FrameFooterProps = JSX.HTMLAttributes<HTMLDivElement>;
+export type FrameStatusProps = ParentProps<
+  JSX.HTMLAttributes<HTMLDivElement> & {
+    tone?: "empty" | "error" | "loading";
+  }
+>;
+export type FrameLoadingProps = Omit<FrameStatusProps, "tone">;
+export type FrameEmptyProps = Omit<FrameStatusProps, "tone">;
+export type FrameErrorProps = Omit<FrameStatusProps, "tone"> & {
+  action?: JSX.Element;
+  retryLabel?: JSX.Element;
+  onRetry?: JSX.EventHandler<HTMLButtonElement, MouseEvent>;
+};
+
+const classes = (...tokens: string[]) => tokens.join(" ");
+
+const frameVariantClass: Record<FrameVariant, string> = {
+  bordered: classes("border", "bg-card", "text-card-foreground", "shadow-xs/5"),
+  elevated: classes("border", "bg-card", "text-card-foreground", "shadow-lg/5"),
+  flush: classes("bg-transparent", "text-foreground", "shadow-none"),
+  inset: classes("border", "bg-muted/40", "p-2", "text-foreground", "shadow-inner"),
+};
+
+const frameAspectClass: Record<FrameAspect, string> = {
+  auto: "",
+  portrait: "aspect-[3/4]",
+  square: "aspect-square",
+  video: "aspect-video",
+  wide: "aspect-[21/9]",
+};
+
+export function Frame(props: FrameProps) {
+  const [local, rest] = splitProps(props, [
+    "actions",
+    "aspect",
+    "children",
+    "description",
+    "empty",
+    "error",
+    "footer",
+    "loading",
+    "loadingLabel",
+    "title",
+    "variant",
+  ]);
+  const hasHeader = () => Boolean(local.title || local.description || local.actions);
+
+  return (
+    <FrameRoot {...rest} aspect={local.aspect} variant={local.variant}>
+      <Card class="min-h-0 min-w-0 flex-1 overflow-hidden rounded-[inherit] border-0 bg-transparent shadow-none before:hidden">
+        <Show when={hasHeader()}>
+          <FrameHeader>
+            <div class="min-w-0">
+              <Show when={local.title}>
+                <FrameTitle>{local.title}</FrameTitle>
+              </Show>
+              <Show when={local.description}>
+                <FrameDescription>{local.description}</FrameDescription>
+              </Show>
+            </div>
+            <Show when={local.actions}>
+              <FrameActions>{local.actions}</FrameActions>
+            </Show>
+          </FrameHeader>
+          <FrameSeparator />
+        </Show>
+        <FrameViewport aspect={local.aspect}>
+          <Show
+            when={!local.loading && !local.error && !local.empty}
+            fallback={
+              <>
+                <Show when={local.loading}>
+                  <FrameLoading>{local.loadingLabel ?? "Loading"}</FrameLoading>
+                </Show>
+                <Show when={!local.loading && local.error}>
+                  <FrameError>{local.error}</FrameError>
+                </Show>
+                <Show when={!local.loading && !local.error && local.empty}>
+                  <FrameEmpty>{local.empty}</FrameEmpty>
+                </Show>
+              </>
+            }
+          >
+            <FrameContent>{local.children}</FrameContent>
+          </Show>
+        </FrameViewport>
+        <Show when={local.footer}>
+          <FrameSeparator />
+          <FrameFooter>{local.footer}</FrameFooter>
+        </Show>
+      </Card>
+    </FrameRoot>
+  );
+}
+
+export function FrameRoot(props: FrameRootProps) {
+  const [local, rest] = splitProps(props, ["aspect", "class", "variant"]);
+  const variant = () => local.variant ?? "bordered";
+  const aspect = () => local.aspect ?? "auto";
+
+  return (
+    <section
+      {...rest}
+      data-scope="ui-frame"
+      data-part="root"
+      data-aspect={aspect()}
+      data-variant={variant()}
+      class={cn(
+        classes(
+          "ui-frame",
+          "relative",
+          "flex",
+          "min-w-0",
+          "flex-col",
+          "overflow-hidden",
+          "rounded-xl",
+          "not-dark:bg-clip-padding",
+          "data-[aspect=auto]:min-h-0",
+          "before:pointer-events-none",
+          "before:absolute",
+          "before:inset-0",
+          "before:rounded-[calc(var(--radius-xl)-1px)]",
+          "before:shadow-[0_1px_--theme(--color-black/4%)]",
+          "data-[variant=flush]:before:hidden",
+          "dark:before:shadow-[0_-1px_--theme(--color-white/6%)]",
+        ),
+        frameVariantClass[variant()],
+        local.class,
+      )}
+    />
+  );
+}
+
+export function FrameHeader(props: FrameHeaderProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+
+  return (
+    <div
+      {...rest}
+      data-scope="ui-frame"
+      data-part="header"
+      class={cn(
+        "ui-frame-header grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-start gap-3 px-4 py-3",
+        local.class,
+      )}
+    />
+  );
+}
+
+export function FrameTitle(props: FrameTitleProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+
+  return (
+    <div
+      {...rest}
+      data-scope="ui-frame"
+      data-part="title"
+      class={cn("ui-frame-title truncate font-semibold text-sm", local.class)}
+    />
+  );
+}
+
+export function FrameDescription(props: FrameDescriptionProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+
+  return (
+    <div
+      {...rest}
+      data-scope="ui-frame"
+      data-part="description"
+      class={cn("ui-frame-description mt-0.5 truncate text-muted-foreground text-xs", local.class)}
+    />
+  );
+}
+
+export function FrameActions(props: FrameActionsProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+
+  return (
+    <div
+      {...rest}
+      data-scope="ui-frame"
+      data-part="actions"
+      class={cn("ui-frame-actions flex shrink-0 items-center gap-1.5", local.class)}
+    />
+  );
+}
+
+export function FrameSeparator() {
+  return (
+    <div data-scope="ui-frame" data-part="separator" class="ui-frame-separator">
+      <Separator />
+    </div>
+  );
+}
+
+export function FrameViewport(props: FrameViewportProps) {
+  const [local, rest] = splitProps(props, ["aspect", "class"]);
+  const aspect = () => local.aspect ?? "auto";
+
+  return (
+    <div
+      {...rest}
+      data-scope="ui-frame"
+      data-part="viewport"
+      data-aspect={aspect()}
+      class={cn(
+        classes(
+          "ui-frame-viewport",
+          "relative",
+          "min-h-0",
+          "min-w-0",
+          "flex-1",
+          "overflow-auto",
+          "bg-background",
+          "data-[aspect=auto]:min-h-24",
+        ),
+        frameAspectClass[aspect()],
+        local.class,
+      )}
+    />
+  );
+}
+
+export function FrameContent(props: FrameContentProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+
+  return (
+    <div
+      {...rest}
+      data-scope="ui-frame"
+      data-part="content"
+      class={cn("ui-frame-content min-h-full min-w-0", local.class)}
+    />
+  );
+}
+
+export function FrameFooter(props: FrameFooterProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+
+  return (
+    <div
+      {...rest}
+      data-scope="ui-frame"
+      data-part="footer"
+      class={cn(
+        "ui-frame-footer flex min-w-0 items-center justify-between gap-3 px-4 py-3 text-muted-foreground text-xs",
+        local.class,
+      )}
+    />
+  );
+}
+
+export function FrameStatus(props: FrameStatusProps) {
+  const [local, rest] = splitProps(props, ["class", "tone"]);
+  const tone = () => local.tone ?? "empty";
+
+  return (
+    <div
+      {...rest}
+      data-scope="ui-frame"
+      data-part="status"
+      data-tone={tone()}
+      role={tone() === "error" ? "alert" : "status"}
+      class={cn(
+        classes(
+          "ui-frame-status",
+          "flex",
+          "min-h-24",
+          "min-w-0",
+          "flex-col",
+          "items-center",
+          "justify-center",
+          "gap-2",
+          "p-6",
+          "text-center",
+          "text-muted-foreground",
+          "text-sm",
+          "data-[tone=error]:text-destructive-foreground",
+        ),
+        local.class,
+      )}
+    />
+  );
+}
+
+export function FrameLoading(props: FrameLoadingProps) {
+  const [local, rest] = splitProps(props, ["class", "children"]);
+
+  return (
+    <FrameStatus {...rest} tone="loading" class={local.class}>
+      <span
+        aria-hidden="true"
+        data-scope="ui-frame"
+        data-part="loading-indicator"
+        class="size-4 animate-spin rounded-full border-2 border-current border-r-transparent"
+      />
+      <span>{local.children}</span>
+    </FrameStatus>
+  );
+}
+
+export function FrameEmpty(props: FrameEmptyProps) {
+  return <FrameStatus {...props} tone="empty" />;
+}
+
+export function FrameError(props: FrameErrorProps) {
+  const [local, rest] = splitProps(props, ["action", "children", "onRetry", "retryLabel"]);
+
+  return (
+    <FrameStatus {...rest} tone="error">
+      <span>{local.children}</span>
+      <Show when={local.action ?? local.onRetry}>
+        {local.action ?? (
+          <Button variant="outline" size="sm" onClick={local.onRetry}>
+            {local.retryLabel ?? "Retry"}
+          </Button>
+        )}
+      </Show>
+    </FrameStatus>
+  );
+}

--- a/packages/ui/src/default/ui/group.tsx
+++ b/packages/ui/src/default/ui/group.tsx
@@ -1,0 +1,178 @@
+import { splitProps, type JSX, type ParentProps } from "solid-js";
+import { cn } from "@/lib/cn";
+
+export type GroupOrientation = "horizontal" | "vertical";
+export type GroupVariant = "default" | "attached" | "inset";
+export type GroupSize = "sm" | "default" | "lg";
+
+export type GroupProps = ParentProps<
+  JSX.HTMLAttributes<HTMLDivElement> & {
+    disabled?: boolean;
+    invalid?: boolean;
+    orientation?: GroupOrientation;
+    selected?: boolean;
+    size?: GroupSize;
+    variant?: GroupVariant;
+  }
+>;
+
+export type GroupItemProps = ParentProps<JSX.HTMLAttributes<HTMLDivElement>>;
+export type GroupLabelProps = ParentProps<JSX.HTMLAttributes<HTMLSpanElement>>;
+export type GroupDescriptionProps = ParentProps<JSX.HTMLAttributes<HTMLSpanElement>>;
+
+const classes = (...tokens: string[]) => tokens.join(" ");
+
+const groupSizeClass: Record<GroupSize, string> = {
+  sm: classes("gap-1", "text-xs"),
+  default: classes("gap-1.5", "text-sm"),
+  lg: classes("gap-2", "text-sm"),
+};
+
+const groupVariantClass: Record<GroupVariant, string> = {
+  default: classes("ui-group-default"),
+  attached: classes(
+    "ui-group-attached",
+    "isolate",
+    "gap-0",
+    "data-[orientation=horizontal]:*:not-first:-ms-px",
+    "data-[orientation=vertical]:*:not-first:-mt-px",
+    "[&>[data-slot=button]:not(:first-child)]:rounded-s-none",
+    "[&>[data-slot=button]:not(:last-child)]:rounded-e-none",
+    "[&>[data-slot=input-control]:not(:first-child)]:rounded-s-none",
+    "[&>[data-slot=input-control]:not(:last-child)]:rounded-e-none",
+    "[&>[data-slot=group-item]:not(:first-child)]:rounded-s-none",
+    "[&>[data-slot=group-item]:not(:last-child)]:rounded-e-none",
+    "data-[orientation=vertical]:[&>[data-slot=button]:not(:first-child)]:rounded-t-none",
+    "data-[orientation=vertical]:[&>[data-slot=button]:not(:last-child)]:rounded-b-none",
+    "data-[orientation=vertical]:[&>[data-slot=input-control]:not(:first-child)]:rounded-t-none",
+    "data-[orientation=vertical]:[&>[data-slot=input-control]:not(:last-child)]:rounded-b-none",
+    "data-[orientation=vertical]:[&>[data-slot=group-item]:not(:first-child)]:rounded-t-none",
+    "data-[orientation=vertical]:[&>[data-slot=group-item]:not(:last-child)]:rounded-b-none",
+  ),
+  inset: classes(
+    "ui-group-inset",
+    "rounded-xl",
+    "border",
+    "border-border",
+    "bg-muted/40",
+    "p-1.5",
+    "shadow-xs/5",
+    "dark:bg-muted/24",
+  ),
+};
+
+function groupPart<T extends HTMLElement>(
+  part: string,
+  className: string,
+  props: ParentProps<JSX.HTMLAttributes<T>>,
+  slot = `group-${part}`,
+) {
+  const [local, rest] = splitProps(props, ["class"]);
+
+  return (
+    <div
+      {...(rest as JSX.HTMLAttributes<HTMLDivElement>)}
+      data-scope="ui-group"
+      data-part={part}
+      data-slot={slot}
+      class={cn(className, local.class)}
+    />
+  );
+}
+
+export function Group(props: GroupProps) {
+  const [local, rest] = splitProps(props, [
+    "class",
+    "disabled",
+    "invalid",
+    "orientation",
+    "selected",
+    "size",
+    "variant",
+  ]);
+  const orientation = () => local.orientation ?? "horizontal";
+  const size = () => local.size ?? "default";
+  const variant = () => local.variant ?? "default";
+
+  return (
+    <div
+      {...rest}
+      data-scope="ui-group"
+      data-part="root"
+      data-disabled={local.disabled ? "" : undefined}
+      data-invalid={local.invalid ? "" : undefined}
+      data-orientation={orientation()}
+      data-selected={local.selected ? "" : undefined}
+      data-size={size()}
+      data-slot="group"
+      data-variant={variant()}
+      class={cn(
+        classes(
+          "ui-group",
+          "min-w-0",
+          "text-foreground",
+          "data-disabled:opacity-64",
+          "data-invalid:ring-destructive/16",
+          "data-invalid:ring-3",
+          "data-selected:bg-accent/48",
+        ),
+        orientation() === "horizontal" && classes("inline-flex", "items-stretch"),
+        orientation() === "vertical" && classes("flex", "flex-col"),
+        groupSizeClass[size()],
+        groupVariantClass[variant()],
+        local.class,
+      )}
+    />
+  );
+}
+
+export function GroupItem(props: GroupItemProps) {
+  return groupPart(
+    "item",
+    classes(
+      "ui-group-item",
+      "inline-flex",
+      "min-w-0",
+      "items-center",
+      "gap-2",
+      "rounded-lg",
+      "border",
+      "border-border",
+      "bg-background",
+      "px-3",
+      "py-1.5",
+      "text-sm",
+      "shadow-xs/5",
+    ),
+    props,
+    "group-item",
+  );
+}
+
+export function GroupLabel(props: GroupLabelProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+
+  return (
+    <span
+      {...rest}
+      data-scope="ui-group"
+      data-part="label"
+      data-slot="group-label"
+      class={cn("ui-group-label", "font-medium", "text-foreground", local.class)}
+    />
+  );
+}
+
+export function GroupDescription(props: GroupDescriptionProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+
+  return (
+    <span
+      {...rest}
+      data-scope="ui-group"
+      data-part="description"
+      data-slot="group-description"
+      class={cn("ui-group-description", "text-muted-foreground", local.class)}
+    />
+  );
+}

--- a/packages/ui/src/default/ui/nav-list.tsx
+++ b/packages/ui/src/default/ui/nav-list.tsx
@@ -1,0 +1,307 @@
+import { For, Show, splitProps, type JSX } from "solid-js";
+import { Badge } from "@/components/ui/badge";
+import { ShortcutDisplay } from "@/components/ui/shortcut-display";
+import { cn } from "@/lib/cn";
+
+export type NavListItem = {
+  id: string;
+  label: JSX.Element;
+  href?: string;
+  icon?: JSX.Element;
+  badge?: JSX.Element;
+  count?: number | string;
+  current?: boolean;
+  disabled?: boolean;
+  shortcut?: string;
+  status?: JSX.Element;
+  description?: JSX.Element;
+  onSelect?: (item: NavListItem, event: MouseEvent) => void;
+};
+
+export type NavListGroup = {
+  id: string;
+  label?: JSX.Element;
+  items: readonly NavListItem[];
+  defaultOpen?: boolean;
+};
+
+export type NavListState = {
+  current?: boolean;
+  disabled?: boolean;
+};
+
+export type NavListProps = Omit<JSX.HTMLAttributes<HTMLElement>, "children"> & {
+  groups?: readonly NavListGroup[];
+  items?: readonly NavListItem[];
+  getItemState?: (item: NavListItem) => NavListState;
+  orientation?: "horizontal" | "vertical";
+};
+
+export type NavListRootProps = JSX.HTMLAttributes<HTMLElement> & {
+  orientation?: "horizontal" | "vertical";
+};
+export type NavListGroupProps = JSX.HTMLAttributes<HTMLDivElement>;
+export type NavListGroupLabelProps = JSX.HTMLAttributes<HTMLDivElement>;
+export type NavListItemsProps = JSX.HTMLAttributes<HTMLDivElement>;
+export type NavListItemProps = JSX.AnchorHTMLAttributes<HTMLAnchorElement> &
+  JSX.ButtonHTMLAttributes<HTMLButtonElement> & {
+    as?: "a" | "button";
+    current?: boolean;
+  };
+export type NavListItemContentProps = JSX.HTMLAttributes<HTMLSpanElement> & {
+  badge?: JSX.Element;
+  count?: number | string;
+  description?: JSX.Element;
+  icon?: JSX.Element;
+  label: JSX.Element;
+  shortcut?: string;
+  status?: JSX.Element;
+};
+
+const classes = (...tokens: string[]) => tokens.join(" ");
+
+export function NavList(props: NavListProps) {
+  const [local, rest] = splitProps(props, ["groups", "items", "getItemState", "orientation"]);
+  const groups = () =>
+    local.groups ?? [
+      {
+        id: "default",
+        items: local.items ?? [],
+      },
+    ];
+
+  return (
+    <NavListRoot {...rest} orientation={local.orientation}>
+      <For each={groups()}>
+        {(group) => (
+          <NavListGroup>
+            <Show when={group.label}>
+              <NavListGroupLabel>{group.label}</NavListGroupLabel>
+            </Show>
+            <NavListItems>
+              <For each={group.items}>
+                {(item) => {
+                  const state = () => local.getItemState?.(item) ?? {};
+                  const current = () => state().current ?? item.current ?? false;
+                  const disabled = () => state().disabled ?? item.disabled ?? false;
+                  return (
+                    <NavListItem
+                      as={item.href ? "a" : "button"}
+                      aria-current={current() ? "page" : undefined}
+                      current={current()}
+                      disabled={disabled()}
+                      href={item.href}
+                      onClick={(event: MouseEvent) => item.onSelect?.(item, event)}
+                    >
+                      <NavListItemContent
+                        badge={item.badge}
+                        count={item.count}
+                        description={item.description}
+                        icon={item.icon}
+                        label={item.label}
+                        shortcut={item.shortcut}
+                        status={item.status}
+                      />
+                    </NavListItem>
+                  );
+                }}
+              </For>
+            </NavListItems>
+          </NavListGroup>
+        )}
+      </For>
+    </NavListRoot>
+  );
+}
+
+export function NavListRoot(props: NavListRootProps) {
+  const [local, rest] = splitProps(props, ["class", "orientation"]);
+  const orientation = () => local.orientation ?? "vertical";
+
+  return (
+    <nav
+      {...rest}
+      data-scope="ui-nav-list"
+      data-part="root"
+      data-orientation={orientation()}
+      class={cn(
+        classes(
+          "ui-nav-list",
+          "flex",
+          "min-w-0",
+          "data-[orientation=horizontal]:items-center",
+          "data-[orientation=horizontal]:gap-1",
+          "data-[orientation=vertical]:flex-col",
+          "data-[orientation=vertical]:gap-3",
+        ),
+        local.class,
+      )}
+    />
+  );
+}
+
+export function NavListGroup(props: NavListGroupProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return (
+    <div
+      {...rest}
+      data-scope="ui-nav-list"
+      data-part="group"
+      class={cn("ui-nav-list-group flex min-w-0 flex-col gap-1", local.class)}
+    />
+  );
+}
+
+export function NavListGroupLabel(props: NavListGroupLabelProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return (
+    <div
+      {...rest}
+      data-scope="ui-nav-list"
+      data-part="group-label"
+      class={cn(
+        "ui-nav-list-group-label px-2 font-medium text-muted-foreground text-xs",
+        local.class,
+      )}
+    />
+  );
+}
+
+export function NavListItems(props: NavListItemsProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return (
+    <div
+      {...rest}
+      data-scope="ui-nav-list"
+      data-part="items"
+      class={cn("ui-nav-list-items flex min-w-0 flex-col gap-0.5", local.class)}
+    />
+  );
+}
+
+export function NavListItem(props: NavListItemProps) {
+  const [local, rest] = splitProps(props, ["as", "class", "current", "type"]);
+  const itemClass = () =>
+    cn(
+      classes(
+        "ui-nav-list-item",
+        "group/nav-list-item",
+        "flex",
+        "min-h-8",
+        "w-full",
+        "min-w-0",
+        "items-center",
+        "gap-2",
+        "rounded-lg",
+        "px-2",
+        "py-1.5",
+        "text-start",
+        "text-foreground",
+        "text-sm",
+        "outline-none",
+        "transition-[background-color,color,box-shadow]",
+        "hover:bg-accent",
+        "hover:text-accent-foreground",
+        "focus-visible:ring-2",
+        "focus-visible:ring-ring",
+        "disabled:pointer-events-none",
+        "disabled:opacity-56",
+        "aria-disabled:pointer-events-none",
+        "aria-disabled:opacity-56",
+        "data-current:bg-accent",
+        "data-current:text-accent-foreground",
+      ),
+      local.class,
+    );
+
+  if (local.as === "a") {
+    return (
+      <a
+        {...(rest as JSX.AnchorHTMLAttributes<HTMLAnchorElement>)}
+        data-scope="ui-nav-list"
+        data-part="item"
+        data-current={local.current ? "" : undefined}
+        class={itemClass()}
+      />
+    );
+  }
+
+  return (
+    <button
+      {...(rest as JSX.ButtonHTMLAttributes<HTMLButtonElement>)}
+      data-scope="ui-nav-list"
+      data-part="item"
+      data-current={local.current ? "" : undefined}
+      type={local.type ?? "button"}
+      class={itemClass()}
+    />
+  );
+}
+
+export function NavListItemContent(props: NavListItemContentProps) {
+  const [local, rest] = splitProps(props, [
+    "badge",
+    "class",
+    "count",
+    "description",
+    "icon",
+    "label",
+    "shortcut",
+    "status",
+  ]);
+
+  return (
+    <span
+      {...rest}
+      data-scope="ui-nav-list"
+      data-part="item-content"
+      class={cn("ui-nav-list-item-content flex min-w-0 flex-1 items-center gap-2", local.class)}
+    >
+      <Show when={local.icon}>
+        <span
+          aria-hidden="true"
+          data-scope="ui-nav-list"
+          data-part="item-icon"
+          class="flex size-4 shrink-0 items-center justify-center text-muted-foreground group-data-current/nav-list-item:text-current"
+        >
+          {local.icon}
+        </span>
+      </Show>
+      <span data-scope="ui-nav-list" data-part="item-text" class="min-w-0 flex-1">
+        <span data-scope="ui-nav-list" data-part="item-label" class="block truncate">
+          {local.label}
+        </span>
+        <Show when={local.description}>
+          <span
+            data-scope="ui-nav-list"
+            data-part="item-description"
+            class="block truncate text-muted-foreground text-xs"
+          >
+            {local.description}
+          </span>
+        </Show>
+      </span>
+      <Show when={local.status}>
+        <span data-scope="ui-nav-list" data-part="item-status" class="shrink-0">
+          {local.status}
+        </span>
+      </Show>
+      <Show when={local.badge ?? local.count}>
+        <span data-scope="ui-nav-list" data-part="item-badge" class="inline-flex shrink-0">
+          <Badge variant="muted" class="h-5 px-1.5 text-[0.6875rem]">
+            {local.badge ?? local.count}
+          </Badge>
+        </span>
+      </Show>
+      <Show when={local.shortcut}>
+        <span
+          data-scope="ui-nav-list"
+          data-part="item-shortcut"
+          class="hidden shrink-0 md:inline-flex"
+        >
+          <ShortcutDisplay label={local.shortcut} />
+        </span>
+      </Show>
+    </span>
+  );
+}

--- a/packages/ui/src/default/ui/search-input.test.tsx
+++ b/packages/ui/src/default/ui/search-input.test.tsx
@@ -1,0 +1,75 @@
+import { render } from "solid-js/web";
+import { describe, expect, test } from "vitest";
+import { SearchInput } from "./search-input";
+
+describe("SearchInput", () => {
+  test("renders a native search input with stable parts and loading state", () => {
+    const host = document.createElement("div");
+    const dispose = render(
+      () => <SearchInput aria-label="Search projects" loading placeholder="Search" />,
+      host,
+    );
+
+    const input = host.querySelector<HTMLInputElement>("[data-slot='search-input-control']");
+    const status = host.querySelector("[data-slot='search-input-loading-indicator']");
+
+    expect(input?.type).toBe("search");
+    expect(input?.getAttribute("aria-label")).toBe("Search projects");
+    expect(host.querySelector("[data-slot='search-input-icon']")).not.toBeNull();
+    expect(status?.getAttribute("role")).toBe("status");
+    expect(status?.getAttribute("aria-label")).toBe("Searching");
+
+    dispose();
+  });
+
+  test("clears uncontrolled values after user clear handlers run", () => {
+    const host = document.createElement("div");
+    document.body.append(host);
+    const calls: string[] = [];
+    const dispose = render(
+      () => (
+        <SearchInput
+          aria-label="Filter invoices"
+          defaultValue="invoice"
+          onClear={() => calls.push("clear")}
+          onInput={(event) => calls.push(event.currentTarget.value)}
+        />
+      ),
+      host,
+    );
+
+    const input = host.querySelector<HTMLInputElement>("[data-slot='search-input-control']");
+    const clear = host.querySelector<HTMLButtonElement>("[data-slot='search-input-clear']");
+
+    expect(clear).not.toBeNull();
+    clear?.click();
+
+    expect(calls).toEqual(["clear", ""]);
+    expect(input?.value).toBe("");
+    expect(document.activeElement).toBe(input);
+
+    dispose();
+    host.remove();
+  });
+
+  test("honors defaultPrevented clear handlers", () => {
+    const host = document.createElement("div");
+    const dispose = render(
+      () => (
+        <SearchInput
+          aria-label="Filter"
+          defaultValue="keystone"
+          onClear={(event) => event.preventDefault()}
+        />
+      ),
+      host,
+    );
+
+    const input = host.querySelector<HTMLInputElement>("[data-slot='search-input-control']");
+    host.querySelector<HTMLButtonElement>("[data-slot='search-input-clear']")?.click();
+
+    expect(input?.value).toBe("keystone");
+
+    dispose();
+  });
+});

--- a/packages/ui/src/default/ui/search-input.tsx
+++ b/packages/ui/src/default/ui/search-input.tsx
@@ -1,0 +1,280 @@
+import { Show, createSignal, splitProps, type JSX } from "solid-js";
+import { cn } from "@/lib/cn";
+
+export type SearchInputSize = "sm" | "default" | "lg";
+export type SearchInputValue = string | number | readonly string[];
+
+export type SearchInputProps = Omit<JSX.InputHTMLAttributes<HTMLInputElement>, "size" | "type"> & {
+  clearLabel?: string;
+  clearable?: boolean;
+  defaultValue?: SearchInputValue;
+  invalid?: boolean;
+  inputClass?: string;
+  loading?: boolean;
+  loadingLabel?: string;
+  onClear?: (event: MouseEvent) => void;
+  rootClass?: string;
+  searchLabel?: string;
+  size?: SearchInputSize;
+};
+
+const classes = (...tokens: string[]) => tokens.join(" ");
+
+function SearchIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      fill="none"
+      height="24"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      viewBox="0 0 24 24"
+      width="24"
+    >
+      <path d="m21 21-4.34-4.34" />
+      <circle cx="11" cy="11" r="8" />
+    </svg>
+  );
+}
+
+function SpinnerIcon() {
+  return (
+    <svg aria-hidden="true" fill="none" height="24" viewBox="0 0 24 24" width="24">
+      <circle cx="12" cy="12" r="9" stroke="currentColor" stroke-opacity="0.24" stroke-width="3" />
+      <path
+        d="M21 12a9 9 0 0 0-9-9"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-width="3"
+      />
+    </svg>
+  );
+}
+
+function ClearIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      fill="none"
+      height="24"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      viewBox="0 0 24 24"
+      width="24"
+    >
+      <path d="M18 6 6 18" />
+      <path d="m6 6 12 12" />
+    </svg>
+  );
+}
+
+function readValue(value: SearchInputProps["value"] | SearchInputProps["defaultValue"]) {
+  if (Array.isArray(value)) return value.join(",");
+  return value == null ? "" : String(value);
+}
+
+function assignRef<T>(ref: unknown, value: T) {
+  if (typeof ref === "function") {
+    ref(value);
+  }
+}
+
+export function SearchInput(props: SearchInputProps) {
+  const [local, rest] = splitProps(props, [
+    "aria-invalid",
+    "aria-label",
+    "class",
+    "clearLabel",
+    "clearable",
+    "defaultValue",
+    "disabled",
+    "inputClass",
+    "invalid",
+    "loading",
+    "loadingLabel",
+    "onClear",
+    "onInput",
+    "ref",
+    "rootClass",
+    "searchLabel",
+    "size",
+    "value",
+  ]);
+  const [uncontrolledValue, setUncontrolledValue] = createSignal(readValue(local.defaultValue));
+  let inputRef: HTMLInputElement | undefined;
+  const size = () => local.size ?? "default";
+  const value = () => readValue(local.value ?? uncontrolledValue());
+  const invalid = () => Boolean(local.invalid || local["aria-invalid"]);
+  const showClear = () =>
+    local.clearable !== false && !local.disabled && !local.loading && value().length > 0;
+
+  const setInputRef = (element: HTMLInputElement) => {
+    inputRef = element;
+    assignRef(local.ref, element);
+  };
+
+  return (
+    <span
+      data-scope="ui-search-input"
+      data-part="root"
+      data-disabled={local.disabled ? "" : undefined}
+      data-invalid={invalid() ? "" : undefined}
+      data-loading={local.loading ? "" : undefined}
+      data-size={size()}
+      data-slot="search-input"
+      class={cn(
+        classes(
+          "ui-search-input",
+          "relative",
+          "inline-flex",
+          "w-full",
+          "items-center",
+          "rounded-lg",
+          "border",
+          "border-input",
+          "bg-background",
+          "not-dark:bg-clip-padding",
+          "text-base",
+          "text-foreground",
+          "shadow-xs/5",
+          "ring-ring/24",
+          "transition-shadow",
+          "before:pointer-events-none",
+          "before:absolute",
+          "before:inset-0",
+          "before:rounded-[calc(var(--radius-lg)-1px)]",
+          "not-has-disabled:not-has-focus-visible:not-has-aria-invalid:before:shadow-[0_1px_--theme(--color-black/4%)]",
+          "has-focus-visible:has-aria-invalid:border-destructive/64",
+          "has-focus-visible:has-aria-invalid:ring-destructive/16",
+          "has-aria-invalid:border-destructive/36",
+          "has-focus-visible:border-ring",
+          "has-autofill:bg-foreground/4",
+          "has-disabled:opacity-64",
+          "has-[:disabled,:focus-visible,[aria-invalid]]:shadow-none",
+          "has-focus-visible:ring-[3px]",
+          "sm:text-sm",
+          "dark:bg-input/32",
+          "dark:has-autofill:bg-foreground/8",
+          "dark:has-aria-invalid:ring-destructive/24",
+          "dark:not-has-disabled:not-has-focus-visible:not-has-aria-invalid:before:shadow-[0_-1px_--theme(--color-white/6%)]",
+        ),
+        local.rootClass,
+        local.class,
+      )}
+    >
+      <span
+        aria-hidden="true"
+        data-scope="ui-search-input"
+        data-part="icon"
+        data-slot="search-input-icon"
+        class="pointer-events-none absolute left-2.5 z-10 flex size-4.5 items-center justify-center text-muted-foreground/72 sm:size-4"
+      >
+        <SearchIcon />
+      </span>
+      <input
+        {...rest}
+        ref={setInputRef}
+        aria-invalid={invalid() || undefined}
+        aria-label={local.searchLabel ?? local["aria-label"]}
+        data-scope="ui-search-input"
+        data-part="input"
+        data-slot="search-input-control"
+        disabled={local.disabled}
+        type="search"
+        value={local.value ?? uncontrolledValue()}
+        onInput={(event) => {
+          if (typeof local.onInput === "function") {
+            local.onInput(event);
+          }
+          if (event.defaultPrevented) return;
+          setUncontrolledValue(event.currentTarget.value);
+        }}
+        class={cn(
+          classes(
+            "ui-search-input-control",
+            "h-8.5",
+            "w-full",
+            "min-w-0",
+            "rounded-[inherit]",
+            "bg-transparent",
+            "ps-8",
+            "pe-8",
+            "leading-8.5",
+            "outline-none",
+            "[transition:background-color_5000000s_ease-in-out_0s]",
+            "placeholder:text-muted-foreground/72",
+            "sm:h-7.5",
+            "sm:leading-7.5",
+            "[&::-webkit-search-cancel-button]:appearance-none",
+            "[&::-webkit-search-decoration]:appearance-none",
+            "[&::-webkit-search-results-button]:appearance-none",
+            "[&::-webkit-search-results-decoration]:appearance-none",
+          ),
+          size() === "sm" && classes("h-7.5", "leading-7.5", "sm:h-6.5", "sm:leading-6.5"),
+          size() === "lg" && classes("h-9.5", "leading-9.5", "sm:h-8.5", "sm:leading-8.5"),
+          local.inputClass,
+        )}
+      />
+      <Show when={local.loading}>
+        <span
+          aria-label={local.loadingLabel ?? "Searching"}
+          data-scope="ui-search-input"
+          data-part="loading-indicator"
+          data-slot="search-input-loading-indicator"
+          role="status"
+          class="absolute right-2.5 z-10 flex size-4.5 animate-spin items-center justify-center text-muted-foreground/72 sm:size-4"
+        >
+          <SpinnerIcon />
+        </span>
+      </Show>
+      <Show when={showClear()}>
+        <button
+          aria-label={local.clearLabel ?? "Clear search"}
+          data-scope="ui-search-input"
+          data-part="clear"
+          data-slot="search-input-clear"
+          type="button"
+          class={cn(
+            classes(
+              "ui-search-input-clear",
+              "absolute",
+              "right-1.5",
+              "z-10",
+              "inline-flex",
+              "size-6",
+              "items-center",
+              "justify-center",
+              "rounded-md",
+              "text-muted-foreground",
+              "outline-none",
+              "transition-colors",
+              "hover:bg-accent",
+              "hover:text-accent-foreground",
+              "focus-visible:ring-2",
+              "focus-visible:ring-ring",
+              "focus-visible:ring-offset-1",
+              "focus-visible:ring-offset-background",
+              "[&_svg]:size-3.5",
+            ),
+          )}
+          onClick={(event) => {
+            local.onClear?.(event);
+            if (event.defaultPrevented) return;
+            setUncontrolledValue("");
+            if (inputRef) {
+              inputRef.value = "";
+              inputRef.dispatchEvent(new InputEvent("input", { bubbles: true }));
+              inputRef.focus();
+            }
+          }}
+        >
+          <ClearIcon />
+        </button>
+      </Show>
+    </span>
+  );
+}

--- a/packages/ui/src/default/ui/sidebar.test.tsx
+++ b/packages/ui/src/default/ui/sidebar.test.tsx
@@ -1,0 +1,235 @@
+import { createRoot } from "solid-js";
+import { render } from "solid-js/web";
+import { describe, expect, test, vi } from "vitest";
+import { createSidebarStore, mountSidebarStore, SidebarProvider } from "@/stores/sidebar-store";
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarGroup,
+  SidebarGroupAction,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarInput,
+  SidebarInset,
+  SidebarItems,
+  SidebarLayout,
+  SidebarMenu,
+  SidebarMenuAction,
+  SidebarMenuBadge,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarMenuLink,
+  SidebarMenuSkeleton,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
+  SidebarMobile,
+  SidebarNav,
+  SidebarRail,
+  SidebarSeparator,
+  SidebarTrigger,
+} from "./sidebar";
+
+describe("Sidebar", () => {
+  test("renders app-shell anatomy with landmark semantics and stable data attributes", () => {
+    const host = document.createElement("div");
+    const dispose = render(
+      () => (
+        <SidebarProvider defaultOpen>
+          <SidebarLayout width="18rem" collapsedWidth="4rem" mobileWidth="20rem">
+            <Sidebar id="workspace-sidebar" aria-label="Workspace sidebar" variant="floating">
+              <SidebarHeader>
+                Acme
+                <SidebarInput aria-label="Filter navigation" />
+              </SidebarHeader>
+              <SidebarContent>
+                <SidebarGroup>
+                  <SidebarGroupLabel>Workspace</SidebarGroupLabel>
+                  <SidebarGroupAction aria-label="Add workspace">+</SidebarGroupAction>
+                  <SidebarGroupContent>
+                    <SidebarItems
+                      items={[
+                        { id: "overview", href: "/overview", label: "Overview", badge: "3" },
+                        { id: "settings", href: "/settings", label: "Settings" },
+                      ]}
+                    />
+                    <SidebarNav aria-label="Pinned">
+                      <SidebarMenu>
+                        <SidebarMenuItem>
+                          <SidebarMenuButton active tooltip="Pinned">
+                            Pinned
+                          </SidebarMenuButton>
+                          <SidebarMenuAction aria-label="Pin action" showOnHover>
+                            +
+                          </SidebarMenuAction>
+                          <SidebarMenuBadge>9</SidebarMenuBadge>
+                          <SidebarMenuSub>
+                            <SidebarMenuSubItem>
+                              <SidebarMenuSubButton active href="/pinned/child">
+                                Child
+                              </SidebarMenuSubButton>
+                            </SidebarMenuSubItem>
+                          </SidebarMenuSub>
+                        </SidebarMenuItem>
+                      </SidebarMenu>
+                      <SidebarMenuLink active href="/pinned-link">
+                        Pinned link
+                      </SidebarMenuLink>
+                    </SidebarNav>
+                    <SidebarMenuSkeleton showIcon width="80%" />
+                  </SidebarGroupContent>
+                </SidebarGroup>
+              </SidebarContent>
+              <SidebarSeparator />
+              <SidebarRail />
+            </Sidebar>
+            <SidebarInset>Dashboard</SidebarInset>
+          </SidebarLayout>
+        </SidebarProvider>
+      ),
+      host,
+    );
+
+    const sidebar = host.querySelector('[data-scope="ui-sidebar"][data-part="root"]');
+    const nav = host.querySelector("nav");
+    const main = host.querySelector("main");
+
+    expect(sidebar?.getAttribute("aria-label")).toBe("Workspace sidebar");
+    expect(sidebar?.getAttribute("data-state")).toBe("expanded");
+    expect(sidebar?.getAttribute("data-collapsible")).toBe("icon");
+    expect(sidebar?.getAttribute("data-variant")).toBe("floating");
+    expect(nav?.getAttribute("aria-label")).toBe("Sidebar navigation");
+    expect(main?.getAttribute("data-part")).toBe("inset");
+    expect(host.innerHTML).toContain("--sidebar-width: 18rem");
+    expect(host.innerHTML).toContain("--sidebar-width-mobile: 20rem");
+    expect(host.innerHTML).toContain('data-part="menu-badge"');
+    expect(host.innerHTML).toContain('data-part="group-action"');
+    expect(host.innerHTML).toContain('data-part="menu-action"');
+    expect(host.innerHTML).toContain('data-part="menu-skeleton"');
+    expect(host.innerHTML).toContain('data-part="menu-sub"');
+    expect(host.innerHTML).toContain('data-part="rail"');
+    expect(host.querySelector('a[aria-current="page"]')?.textContent).toBe("Child");
+
+    dispose();
+  });
+
+  test("trigger toggles desktop state and respects prevented user handlers", () => {
+    const store = createSidebarStore({ defaultOpen: true });
+    const host = document.createElement("div");
+    const dispose = render(
+      () => (
+        <SidebarProvider store={store} keyboardShortcut={false} storage={null}>
+          <SidebarTrigger controls="workspace-sidebar" onClick={(event) => event.preventDefault()}>
+            Toggle
+          </SidebarTrigger>
+          <Sidebar id="workspace-sidebar">Navigation</Sidebar>
+        </SidebarProvider>
+      ),
+      host,
+    );
+
+    host.querySelector("button")?.click();
+
+    expect(store.open()).toBe(true);
+    expect(host.querySelector("button")?.getAttribute("aria-expanded")).toBe("true");
+
+    dispose();
+  });
+
+  test("menu links set active item, expose aria-current, and close the mobile panel", () => {
+    createRoot((disposeRoot) => {
+      const store = createSidebarStore({ defaultOpen: true });
+      store.setIsMobile(true);
+      store.setOpenMobile(true);
+      const doc = {
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        defaultView: {
+          matchMedia: vi.fn(() => ({
+            matches: true,
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+          })),
+        },
+      } as unknown as Document;
+      const host = document.createElement("div");
+      document.body.append(host);
+      const dispose = render(
+        () => (
+          <SidebarProvider document={doc} store={store} keyboardShortcut={false} storage={null}>
+            <SidebarMobile>
+              <SidebarNav>
+                <SidebarMenuLink href="/reports" itemId="reports">
+                  Reports
+                </SidebarMenuLink>
+              </SidebarNav>
+            </SidebarMobile>
+          </SidebarProvider>
+        ),
+        host,
+      );
+
+      const link = host.querySelector("a");
+      link?.click();
+
+      expect(store.store.get().activeItemId).toBe("reports");
+      expect(store.store.get().openMobile).toBe(false);
+      dispose();
+      host.remove();
+      disposeRoot();
+    });
+  });
+
+  test("mounts browser behavior after render for storage, media, and keyboard", () => {
+    const store = createSidebarStore({ defaultOpen: true });
+    const addEventListener = vi.fn();
+    const removeEventListener = vi.fn();
+    const media = {
+      matches: true,
+      addEventListener,
+      removeEventListener,
+    } as unknown as MediaQueryList;
+    const storage = {
+      getItem: vi.fn(() => "false"),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+      clear: vi.fn(),
+      key: vi.fn(),
+      length: 1,
+    };
+    const doc = {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      defaultView: {
+        localStorage: storage,
+        matchMedia: vi.fn(() => media),
+      },
+    } as unknown as Document;
+
+    const cleanup = mountSidebarStore(store, { document: doc, storage });
+
+    expect(store.mounted()).toBe(true);
+    expect(store.open()).toBe(false);
+    expect(store.isMobile()).toBe(true);
+    expect(addEventListener).toHaveBeenCalledWith("change", expect.any(Function));
+
+    const keyHandler = vi
+      .mocked(doc.addEventListener)
+      .mock.calls.find(([type]) => type === "keydown")?.[1] as
+      | ((event: KeyboardEvent) => void)
+      | undefined;
+    keyHandler?.(
+      new KeyboardEvent("keydown", {
+        key: "b",
+        metaKey: true,
+      }),
+    );
+
+    expect(store.openMobile()).toBe(true);
+
+    cleanup();
+    expect(store.mounted()).toBe(false);
+    expect(removeEventListener).toHaveBeenCalledWith("change", expect.any(Function));
+  });
+});

--- a/packages/ui/src/default/ui/sidebar.tsx
+++ b/packages/ui/src/default/ui/sidebar.tsx
@@ -1,0 +1,719 @@
+import {
+  createMemo,
+  For,
+  Show,
+  splitProps,
+  type ComponentProps,
+  type JSX,
+  type ParentProps,
+} from "solid-js";
+import { Button, type ButtonProps } from "@/components/ui/button";
+import { Input, type InputProps } from "@/components/ui/input";
+import { Separator, type SeparatorProps } from "@/components/ui/separator";
+import {
+  SidebarProvider as SidebarStoreProvider,
+  useSidebarStore,
+  type SidebarProviderProps as SidebarStoreProviderProps,
+} from "@/stores/sidebar-store";
+import { cn } from "@/lib/cn";
+
+export type SidebarItem = {
+  badge?: JSX.Element;
+  description?: JSX.Element;
+  disabled?: boolean;
+  href: string;
+  icon?: JSX.Element;
+  id: string;
+  label: JSX.Element;
+};
+
+export type SidebarProviderProps = SidebarStoreProviderProps;
+export type SidebarLayoutProps = ParentProps<
+  JSX.HTMLAttributes<HTMLDivElement> & {
+    collapsedWidth?: string;
+    mobileWidth?: string;
+    width?: string;
+  }
+>;
+export type SidebarProps = ParentProps<
+  JSX.HTMLAttributes<HTMLElement> & {
+    collapsible?: "icon" | "offcanvas" | "none";
+    side?: "left" | "right";
+    variant?: "floating" | "inset" | "sidebar";
+  }
+>;
+export type SidebarMobileProps = ParentProps<JSX.HTMLAttributes<HTMLDivElement>>;
+export type SidebarHeaderProps = ParentProps<JSX.HTMLAttributes<HTMLDivElement>>;
+export type SidebarContentProps = ParentProps<JSX.HTMLAttributes<HTMLDivElement>>;
+export type SidebarFooterProps = ParentProps<JSX.HTMLAttributes<HTMLDivElement>>;
+export type SidebarGroupProps = ParentProps<JSX.HTMLAttributes<HTMLElement>>;
+export type SidebarGroupLabelProps = ParentProps<JSX.HTMLAttributes<HTMLHeadingElement>>;
+export type SidebarGroupActionProps = ParentProps<JSX.ButtonHTMLAttributes<HTMLButtonElement>>;
+export type SidebarGroupContentProps = ParentProps<JSX.HTMLAttributes<HTMLDivElement>>;
+export type SidebarNavProps = ParentProps<JSX.HTMLAttributes<HTMLElement>>;
+export type SidebarMenuProps = ParentProps<JSX.HTMLAttributes<HTMLUListElement>>;
+export type SidebarMenuItemProps = ParentProps<JSX.LiHTMLAttributes<HTMLLIElement>>;
+export type SidebarMenuLinkProps = ParentProps<
+  JSX.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    active?: boolean;
+    itemId?: string;
+  }
+>;
+export type SidebarMenuButtonProps = ButtonProps & {
+  active?: boolean;
+  itemId?: string;
+  menuSize?: "default" | "lg" | "sm";
+  menuVariant?: "default" | "outline";
+  tooltip?: JSX.Element;
+};
+export type SidebarMenuActionProps = ParentProps<
+  JSX.ButtonHTMLAttributes<HTMLButtonElement> & {
+    showOnHover?: boolean;
+  }
+>;
+export type SidebarMenuBadgeProps = ParentProps<JSX.HTMLAttributes<HTMLDivElement>>;
+export type SidebarMenuSkeletonProps = JSX.HTMLAttributes<HTMLDivElement> & {
+  showIcon?: boolean;
+  width?: string;
+};
+export type SidebarMenuSubProps = ParentProps<JSX.HTMLAttributes<HTMLUListElement>>;
+export type SidebarMenuSubItemProps = ParentProps<JSX.LiHTMLAttributes<HTMLLIElement>>;
+export type SidebarMenuSubButtonProps = ParentProps<
+  JSX.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    active?: boolean;
+    size?: "md" | "sm";
+  }
+>;
+export type SidebarTriggerProps = Omit<ButtonProps, "aria-controls" | "aria-expanded"> & {
+  controls?: string;
+};
+export type SidebarRailProps = JSX.ButtonHTMLAttributes<HTMLButtonElement> & {
+  side?: "left" | "right";
+};
+export type SidebarInsetProps = ParentProps<JSX.HTMLAttributes<HTMLElement>>;
+export type SidebarInputProps = InputProps;
+export type SidebarSeparatorProps = SeparatorProps;
+export type SidebarItemsProps = {
+  ariaLabel?: string;
+  items: SidebarItem[];
+  class?: string;
+};
+
+function stateAttributes() {
+  const store = useSidebarStore();
+
+  return {
+    "data-mobile": store.isMobile() ? "" : undefined,
+    "data-open-mobile": store.openMobile() ? "" : undefined,
+    "data-state": store.state(),
+  };
+}
+
+function callUserFirst<T extends Event>(
+  event: T,
+  handler: JSX.EventHandlerUnion<HTMLElement, T> | undefined,
+) {
+  if (typeof handler === "function") {
+    handler(event as T & { currentTarget: HTMLElement; target: Element });
+  }
+}
+
+export function SidebarProvider(props: SidebarProviderProps) {
+  return <SidebarStoreProvider {...props} />;
+}
+
+export function useSidebar() {
+  return useSidebarStore();
+}
+
+export function SidebarLayout(props: SidebarLayoutProps) {
+  const [local, rest] = splitProps(props, [
+    "children",
+    "class",
+    "collapsedWidth",
+    "mobileWidth",
+    "style",
+    "width",
+  ]);
+  const style = () =>
+    ({
+      "--sidebar-width": local.width ?? "16rem",
+      "--sidebar-width-icon": local.collapsedWidth ?? "3rem",
+      "--sidebar-width-mobile": local.mobileWidth ?? "18rem",
+      ...((typeof local.style === "object" ? local.style : {}) as JSX.CSSProperties),
+    }) as JSX.CSSProperties;
+
+  return (
+    <div
+      {...rest}
+      {...stateAttributes()}
+      class={cn(
+        "ui-sidebar-layout flex min-h-svh w-full bg-background text-foreground",
+        local.class,
+      )}
+      data-scope="ui-sidebar"
+      data-part="layout"
+      style={style()}
+    >
+      {local.children}
+    </div>
+  );
+}
+
+export function Sidebar(props: SidebarProps) {
+  const [local, rest] = splitProps(props, ["children", "class", "collapsible", "side", "variant"]);
+  const collapsible = () => local.collapsible ?? "icon";
+  const variant = () => local.variant ?? "sidebar";
+
+  return (
+    <aside
+      aria-label={rest["aria-label"] ?? "Sidebar"}
+      {...rest}
+      {...stateAttributes()}
+      class={cn(
+        "ui-sidebar group/sidebar relative hidden min-h-svh w-(--sidebar-width) shrink-0 flex-col border-border bg-sidebar text-sidebar-foreground transition-[width,transform] duration-200 ease-linear lg:flex",
+        "data-[state=collapsed]:w-(--sidebar-width-icon)",
+        variant() === "floating" && "m-2 min-h-[calc(100svh-1rem)] rounded-lg border shadow-sm",
+        variant() === "inset" && "m-2 min-h-[calc(100svh-1rem)] rounded-xl border shadow-sm",
+        local.side === "right" ? "order-last border-l" : "border-r",
+        collapsible() === "offcanvas" &&
+          "data-[state=collapsed]:-translate-x-full data-[state=collapsed]:w-(--sidebar-width)",
+        collapsible() === "none" && "w-(--sidebar-width)",
+        local.class,
+      )}
+      data-collapsible={collapsible()}
+      data-part="root"
+      data-side={local.side ?? "left"}
+      data-variant={variant()}
+      data-scope="ui-sidebar"
+    >
+      {local.children}
+    </aside>
+  );
+}
+
+export function SidebarMobile(props: SidebarMobileProps) {
+  const [local, rest] = splitProps(props, ["children", "class"]);
+  const store = useSidebarStore();
+
+  return (
+    <Show when={store.openMobile()}>
+      <div
+        {...rest}
+        aria-modal="true"
+        class={cn(
+          "ui-sidebar-mobile fixed inset-0 z-50 w-(--sidebar-width-mobile) bg-sidebar text-sidebar-foreground lg:hidden",
+          local.class,
+        )}
+        data-open-mobile=""
+        data-part="mobile"
+        data-scope="ui-sidebar"
+        data-state="expanded"
+        role="dialog"
+      >
+        {local.children}
+      </div>
+    </Show>
+  );
+}
+
+export function SidebarHeader(props: SidebarHeaderProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return (
+    <div
+      {...rest}
+      class={cn("ui-sidebar-header flex flex-col gap-2 p-2", local.class)}
+      data-part="header"
+      data-scope="ui-sidebar"
+    />
+  );
+}
+
+export function SidebarContent(props: SidebarContentProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return (
+    <div
+      {...rest}
+      class={cn(
+        "ui-sidebar-content flex min-h-0 flex-1 flex-col gap-0 overflow-auto data-[state=collapsed]:overflow-hidden",
+        local.class,
+      )}
+      data-part="content"
+      data-scope="ui-sidebar"
+      {...stateAttributes()}
+    />
+  );
+}
+
+export function SidebarFooter(props: SidebarFooterProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return (
+    <div
+      {...rest}
+      class={cn("ui-sidebar-footer flex flex-col gap-2 p-2", local.class)}
+      data-part="footer"
+      data-scope="ui-sidebar"
+    />
+  );
+}
+
+export function SidebarGroup(props: SidebarGroupProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return (
+    <section
+      {...rest}
+      class={cn("ui-sidebar-group relative flex w-full min-w-0 flex-col p-2", local.class)}
+      data-part="group"
+      data-scope="ui-sidebar"
+    />
+  );
+}
+
+export function SidebarGroupLabel(props: SidebarGroupLabelProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return (
+    <h2
+      {...rest}
+      class={cn(
+        "ui-sidebar-group-label flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium text-sidebar-foreground/70 outline-none transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 focus-visible:ring-sidebar-ring data-[state=collapsed]:-mt-8 data-[state=collapsed]:opacity-0",
+        local.class,
+      )}
+      data-part="group-label"
+      data-scope="ui-sidebar"
+      {...stateAttributes()}
+    />
+  );
+}
+
+export function SidebarGroupAction(props: SidebarGroupActionProps) {
+  const [local, rest] = splitProps(props, ["class", "type"]);
+  return (
+    <button
+      {...rest}
+      class={cn(
+        "ui-sidebar-group-action absolute right-3 top-3.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground outline-none transition-transform after:absolute after:-inset-2 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 focus-visible:ring-sidebar-ring data-[state=collapsed]:hidden md:after:hidden",
+        local.class,
+      )}
+      data-part="group-action"
+      data-scope="ui-sidebar"
+      {...stateAttributes()}
+      type={local.type ?? "button"}
+    />
+  );
+}
+
+export function SidebarGroupContent(props: SidebarGroupContentProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return (
+    <div
+      {...rest}
+      class={cn("ui-sidebar-group-content w-full text-sm", local.class)}
+      data-part="group-content"
+      data-scope="ui-sidebar"
+    />
+  );
+}
+
+export function SidebarNav(props: SidebarNavProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return (
+    <nav
+      aria-label={rest["aria-label"] ?? "Sidebar navigation"}
+      {...rest}
+      class={cn("ui-sidebar-nav", local.class)}
+      data-part="nav"
+      data-scope="ui-sidebar"
+    />
+  );
+}
+
+export function SidebarMenu(props: SidebarMenuProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return (
+    <ul
+      {...rest}
+      class={cn("ui-sidebar-menu flex w-full min-w-0 flex-col gap-0", local.class)}
+      data-part="menu"
+      data-scope="ui-sidebar"
+    />
+  );
+}
+
+export function SidebarMenuItem(props: SidebarMenuItemProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return (
+    <li
+      {...rest}
+      class={cn("ui-sidebar-menu-item group/menu-item relative", local.class)}
+      data-part="menu-item"
+      data-scope="ui-sidebar"
+    />
+  );
+}
+
+export function SidebarMenuLink(props: SidebarMenuLinkProps) {
+  const [local, rest] = splitProps(props, ["active", "children", "class", "itemId", "onClick"]);
+  const store = useSidebarStore();
+  const isActive = () => local.active ?? store.activeItemId() === local.itemId;
+
+  function handleClick(event: MouseEvent) {
+    callUserFirst(event, local.onClick as JSX.EventHandlerUnion<HTMLElement, MouseEvent>);
+    if (event.defaultPrevented) return;
+    if (local.itemId) {
+      store.setActiveItemId(local.itemId);
+    }
+    if (store.isMobile()) {
+      store.setOpenMobile(false, { reason: "trigger" });
+    }
+  }
+
+  return (
+    <a
+      {...rest}
+      aria-current={isActive() ? "page" : undefined}
+      class={cn(
+        "ui-sidebar-menu-link flex min-h-9 items-center gap-2 rounded-md px-2 py-1.5 text-sm outline-none transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 focus-visible:ring-sidebar-ring",
+        "data-[active]:bg-sidebar-accent data-[active]:font-medium data-[active]:text-sidebar-accent-foreground",
+        "data-[state=collapsed]:size-8 data-[state=collapsed]:justify-center data-[state=collapsed]:p-2",
+        local.class,
+      )}
+      data-active={isActive() ? "" : undefined}
+      data-part="menu-link"
+      data-scope="ui-sidebar"
+      {...stateAttributes()}
+      onClick={handleClick}
+    >
+      {local.children}
+    </a>
+  );
+}
+
+export function SidebarMenuButton(props: SidebarMenuButtonProps) {
+  const [local, rest] = splitProps(props, [
+    "active",
+    "children",
+    "class",
+    "itemId",
+    "menuSize",
+    "menuVariant",
+    "onClick",
+    "tooltip",
+  ]);
+  const store = useSidebarStore();
+  const isActive = () => local.active ?? store.activeItemId() === local.itemId;
+  const menuSize = () => local.menuSize ?? "default";
+  const showTooltip = () =>
+    Boolean(local.tooltip && store.state() === "collapsed" && !store.isMobile());
+
+  function handleClick(event: MouseEvent) {
+    callUserFirst(event, local.onClick as JSX.EventHandlerUnion<HTMLElement, MouseEvent>);
+    if (event.defaultPrevented) return;
+    if (local.itemId) {
+      store.setActiveItemId(local.itemId);
+    }
+  }
+
+  const button = (
+    <Button
+      {...rest}
+      class={cn(
+        "ui-sidebar-menu-button peer/menu-button w-full justify-start overflow-hidden rounded-md p-2 text-left outline-none transition-[width,height,padding] data-[state=collapsed]:size-8 data-[state=collapsed]:justify-center data-[state=collapsed]:p-2",
+        menuSize() === "sm" && "h-7 text-xs",
+        menuSize() === "default" && "h-8 text-sm",
+        menuSize() === "lg" && "h-12 text-sm data-[state=collapsed]:p-0",
+        local.menuVariant === "outline" &&
+          "border border-sidebar-border bg-background shadow-xs hover:border-sidebar-accent",
+        local.class,
+      )}
+      data-active={isActive() ? "" : undefined}
+      data-part="menu-button"
+      data-scope="ui-sidebar"
+      data-size={menuSize()}
+      {...stateAttributes()}
+      onClick={handleClick}
+      pressed={isActive()}
+      variant={rest.variant ?? "ghost"}
+    >
+      {local.children}
+    </Button>
+  );
+
+  return (
+    <>
+      {button}
+      <Show when={showTooltip()}>
+        <span
+          class="ui-sidebar-menu-tooltip pointer-events-none absolute left-full top-1/2 z-50 ml-2 -translate-y-1/2 rounded-md border bg-popover px-2 py-1 text-xs text-popover-foreground shadow-sm"
+          data-part="menu-tooltip"
+          data-scope="ui-sidebar"
+          role="tooltip"
+        >
+          {local.tooltip}
+        </span>
+      </Show>
+    </>
+  );
+}
+
+export function SidebarMenuAction(props: SidebarMenuActionProps) {
+  const [local, rest] = splitProps(props, ["class", "showOnHover", "type"]);
+  return (
+    <button
+      {...rest}
+      class={cn(
+        "ui-sidebar-menu-action absolute right-1 top-1.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground outline-none transition-[opacity,transform] after:absolute after:-inset-2 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 focus-visible:ring-sidebar-ring data-[state=collapsed]:hidden md:after:hidden",
+        local.showOnHover &&
+          "opacity-100 md:opacity-0 md:group-focus-within/menu-item:opacity-100 md:group-hover/menu-item:opacity-100",
+        local.class,
+      )}
+      data-part="menu-action"
+      data-scope="ui-sidebar"
+      {...stateAttributes()}
+      type={local.type ?? "button"}
+    />
+  );
+}
+
+export function SidebarMenuBadge(props: SidebarMenuBadgeProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return (
+    <div
+      {...rest}
+      class={cn(
+        "ui-sidebar-menu-badge pointer-events-none absolute right-1 top-1.5 flex h-5 min-w-5 select-none items-center justify-center rounded-md px-1 text-xs font-medium tabular-nums text-sidebar-foreground/70 data-[state=collapsed]:hidden",
+        local.class,
+      )}
+      data-part="menu-badge"
+      data-scope="ui-sidebar"
+      {...stateAttributes()}
+    />
+  );
+}
+
+export function SidebarMenuSkeleton(props: SidebarMenuSkeletonProps) {
+  const [local, rest] = splitProps(props, ["class", "showIcon", "style", "width"]);
+  const style = createMemo(
+    () =>
+      ({
+        "--sidebar-skeleton-width": local.width ?? "72%",
+        ...((typeof local.style === "object" ? local.style : {}) as JSX.CSSProperties),
+      }) as JSX.CSSProperties,
+  );
+
+  return (
+    <div
+      {...rest}
+      class={cn(
+        "ui-sidebar-menu-skeleton flex h-8 items-center gap-2 rounded-md px-2",
+        local.class,
+      )}
+      data-part="menu-skeleton"
+      data-scope="ui-sidebar"
+      style={style()}
+    >
+      <Show when={local.showIcon}>
+        <span
+          class="size-4 shrink-0 rounded-md bg-sidebar-accent"
+          data-part="menu-skeleton-icon"
+          data-scope="ui-sidebar"
+        />
+      </Show>
+      <span
+        class="h-4 max-w-(--sidebar-skeleton-width) flex-1 rounded-md bg-sidebar-accent"
+        data-part="menu-skeleton-text"
+        data-scope="ui-sidebar"
+      />
+    </div>
+  );
+}
+
+export function SidebarMenuSub(props: SidebarMenuSubProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return (
+    <ul
+      {...rest}
+      class={cn(
+        "ui-sidebar-menu-sub mx-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-l border-sidebar-border px-2.5 py-0.5 data-[state=collapsed]:hidden",
+        local.class,
+      )}
+      data-part="menu-sub"
+      data-scope="ui-sidebar"
+      {...stateAttributes()}
+    />
+  );
+}
+
+export function SidebarMenuSubItem(props: SidebarMenuSubItemProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return (
+    <li
+      {...rest}
+      class={cn("ui-sidebar-menu-sub-item group/menu-sub-item relative", local.class)}
+      data-part="menu-sub-item"
+      data-scope="ui-sidebar"
+    />
+  );
+}
+
+export function SidebarMenuSubButton(props: SidebarMenuSubButtonProps) {
+  const [local, rest] = splitProps(props, ["active", "class", "size"]);
+  return (
+    <a
+      {...rest}
+      aria-current={local.active ? "page" : undefined}
+      class={cn(
+        "ui-sidebar-menu-sub-button flex h-7 min-w-0 items-center gap-2 overflow-hidden rounded-md px-2 text-sidebar-foreground outline-none hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 focus-visible:ring-sidebar-ring data-[active]:bg-sidebar-accent data-[active]:text-sidebar-accent-foreground data-[state=collapsed]:hidden",
+        (local.size ?? "md") === "md" ? "text-sm" : "text-xs",
+        local.class,
+      )}
+      data-active={local.active ? "" : undefined}
+      data-part="menu-sub-button"
+      data-scope="ui-sidebar"
+      data-size={local.size ?? "md"}
+      {...stateAttributes()}
+    />
+  );
+}
+
+export function SidebarTrigger(props: SidebarTriggerProps) {
+  const [local, rest] = splitProps(props, ["children", "class", "controls", "onClick"]);
+  const store = useSidebarStore();
+
+  function handleClick(event: MouseEvent) {
+    callUserFirst(event, local.onClick as JSX.EventHandlerUnion<HTMLElement, MouseEvent>);
+    if (event.defaultPrevented) return;
+    store.toggle({ reason: "trigger" });
+  }
+
+  return (
+    <Button
+      aria-controls={local.controls}
+      aria-expanded={store.isMobile() ? store.openMobile() : store.open()}
+      aria-label={rest["aria-label"] ?? "Toggle sidebar"}
+      {...rest}
+      class={cn("ui-sidebar-trigger", local.class)}
+      data-part="trigger"
+      data-scope="ui-sidebar"
+      {...stateAttributes()}
+      onClick={handleClick}
+      type={rest.type ?? "button"}
+      variant={rest.variant ?? "ghost"}
+    >
+      {local.children}
+    </Button>
+  );
+}
+
+export function SidebarRail(props: SidebarRailProps) {
+  const [local, rest] = splitProps(props, ["class", "onClick", "side", "title", "type"]);
+  const store = useSidebarStore();
+
+  function handleClick(event: MouseEvent) {
+    callUserFirst(event, local.onClick as JSX.EventHandlerUnion<HTMLElement, MouseEvent>);
+    if (event.defaultPrevented) return;
+    store.toggle({ reason: "trigger" });
+  }
+
+  return (
+    <button
+      aria-label={rest["aria-label"] ?? "Toggle sidebar"}
+      {...rest}
+      class={cn(
+        "ui-sidebar-rail absolute inset-y-0 z-20 hidden w-4 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-px hover:after:bg-sidebar-border data-[side=left]:-right-4 data-[side=right]:left-0 sm:flex",
+        local.class,
+      )}
+      data-part="rail"
+      data-scope="ui-sidebar"
+      data-side={local.side ?? "left"}
+      onClick={handleClick}
+      tabIndex={-1}
+      title={local.title ?? "Toggle sidebar"}
+      type={local.type ?? "button"}
+    />
+  );
+}
+
+export function SidebarInset(props: SidebarInsetProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return (
+    <main
+      {...rest}
+      class={cn(
+        "ui-sidebar-inset relative flex min-w-0 flex-1 flex-col bg-background data-[variant=inset]:m-2 data-[variant=inset]:ml-0 data-[variant=inset]:rounded-xl data-[variant=inset]:shadow-sm",
+        local.class,
+      )}
+      data-part="inset"
+      data-scope="ui-sidebar"
+    />
+  );
+}
+
+export function SidebarInput(props: SidebarInputProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return (
+    <Input
+      {...rest}
+      class={cn("ui-sidebar-input h-8 w-full bg-background shadow-none", local.class)}
+      data-part="input"
+      data-scope="ui-sidebar"
+    />
+  );
+}
+
+export function SidebarSeparator(props: SidebarSeparatorProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return (
+    <Separator
+      {...rest}
+      class={cn("ui-sidebar-separator mx-2 w-auto bg-sidebar-border", local.class)}
+      data-part="separator"
+      data-scope="ui-sidebar"
+    />
+  );
+}
+
+export function SidebarItems(props: SidebarItemsProps) {
+  return (
+    <SidebarNav aria-label={props.ariaLabel} class={props.class}>
+      <SidebarMenu>
+        <For each={props.items}>
+          {(item) => (
+            <SidebarMenuItem>
+              <SidebarMenuLink
+                aria-disabled={item.disabled ? "true" : undefined}
+                href={item.disabled ? undefined : item.href}
+                itemId={item.id}
+                onClick={(event) => {
+                  if (item.disabled) {
+                    event.preventDefault();
+                  }
+                }}
+              >
+                <Show when={item.icon}>
+                  <span aria-hidden="true" data-part="menu-icon" data-scope="ui-sidebar">
+                    {item.icon}
+                  </span>
+                </Show>
+                <span class="truncate data-[state=collapsed]:sr-only" {...stateAttributes()}>
+                  {item.label}
+                </span>
+                <Show when={item.badge}>
+                  <span
+                    class="ml-auto text-xs text-sidebar-foreground/70 data-[state=collapsed]:hidden"
+                    data-part="menu-badge"
+                    data-scope="ui-sidebar"
+                    {...stateAttributes()}
+                  >
+                    {item.badge}
+                  </span>
+                </Show>
+              </SidebarMenuLink>
+            </SidebarMenuItem>
+          )}
+        </For>
+      </SidebarMenu>
+    </SidebarNav>
+  );
+}
+
+export type SidebarComponentProps = ComponentProps<typeof Sidebar>;

--- a/packages/ui/src/default/ui/topbar.tsx
+++ b/packages/ui/src/default/ui/topbar.tsx
@@ -1,0 +1,207 @@
+import { Show, splitProps, type JSX, type ParentProps } from "solid-js";
+import { Button } from "@/components/ui/button";
+import { ShortcutDisplay } from "@/components/ui/shortcut-display";
+import { cn } from "@/lib/cn";
+
+export type TopbarProps = ParentProps<
+  JSX.HTMLAttributes<HTMLElement> & {
+    actions?: JSX.Element;
+    brand?: JSX.Element;
+    commandLabel?: JSX.Element;
+    commandShortcut?: string;
+    navigation?: JSX.Element;
+    search?: JSX.Element;
+    status?: JSX.Element;
+    title?: JSX.Element;
+    onCommand?: JSX.EventHandler<HTMLButtonElement, MouseEvent>;
+  }
+>;
+
+export type TopbarRootProps = JSX.HTMLAttributes<HTMLElement>;
+export type TopbarBrandProps = JSX.HTMLAttributes<HTMLDivElement>;
+export type TopbarTitleProps = JSX.HTMLAttributes<HTMLDivElement>;
+export type TopbarNavigationProps = JSX.HTMLAttributes<HTMLDivElement>;
+export type TopbarSearchProps = JSX.HTMLAttributes<HTMLDivElement>;
+export type TopbarCommandTriggerProps = JSX.ButtonHTMLAttributes<HTMLButtonElement> & {
+  shortcut?: string;
+};
+export type TopbarActionsProps = JSX.HTMLAttributes<HTMLDivElement>;
+export type TopbarStatusProps = JSX.HTMLAttributes<HTMLDivElement>;
+
+const classes = (...tokens: string[]) => tokens.join(" ");
+
+export function Topbar(props: TopbarProps) {
+  const [local, rest] = splitProps(props, [
+    "actions",
+    "brand",
+    "children",
+    "commandLabel",
+    "commandShortcut",
+    "navigation",
+    "onCommand",
+    "search",
+    "status",
+    "title",
+  ]);
+
+  return (
+    <TopbarRoot {...rest}>
+      <Show when={local.brand ?? local.title}>
+        <TopbarBrand>
+          <Show when={local.brand}>
+            <span data-scope="ui-topbar" data-part="brand-mark" class="shrink-0">
+              {local.brand}
+            </span>
+          </Show>
+          <Show when={local.title}>
+            <TopbarTitle>{local.title}</TopbarTitle>
+          </Show>
+        </TopbarBrand>
+      </Show>
+      <Show when={local.navigation}>
+        <TopbarNavigation>{local.navigation}</TopbarNavigation>
+      </Show>
+      <Show when={local.search}>
+        <TopbarSearch>{local.search}</TopbarSearch>
+      </Show>
+      <Show when={local.onCommand}>
+        <TopbarCommandTrigger onClick={local.onCommand} shortcut={local.commandShortcut}>
+          {local.commandLabel ?? "Search"}
+        </TopbarCommandTrigger>
+      </Show>
+      <Show when={local.status}>
+        <TopbarStatus>{local.status}</TopbarStatus>
+      </Show>
+      <Show when={local.actions}>
+        <TopbarActions>{local.actions}</TopbarActions>
+      </Show>
+      {local.children}
+    </TopbarRoot>
+  );
+}
+
+export function TopbarRoot(props: TopbarRootProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return (
+    <header
+      {...rest}
+      data-scope="ui-topbar"
+      data-part="root"
+      class={cn(
+        classes(
+          "ui-topbar",
+          "sticky",
+          "top-0",
+          "z-30",
+          "flex",
+          "min-h-14",
+          "min-w-0",
+          "flex-wrap",
+          "items-center",
+          "gap-2",
+          "border-b",
+          "bg-background/92",
+          "px-3",
+          "backdrop-blur",
+          "supports-[backdrop-filter]:bg-background/72",
+          "md:flex-nowrap",
+        ),
+        local.class,
+      )}
+    />
+  );
+}
+
+export function TopbarBrand(props: TopbarBrandProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return (
+    <div
+      {...rest}
+      data-scope="ui-topbar"
+      data-part="brand"
+      class={cn("ui-topbar-brand flex min-w-0 shrink-0 items-center gap-2", local.class)}
+    />
+  );
+}
+
+export function TopbarTitle(props: TopbarTitleProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return (
+    <div
+      {...rest}
+      data-scope="ui-topbar"
+      data-part="title"
+      class={cn("ui-topbar-title truncate font-semibold text-sm", local.class)}
+    />
+  );
+}
+
+export function TopbarNavigation(props: TopbarNavigationProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return (
+    <div
+      {...rest}
+      data-scope="ui-topbar"
+      data-part="navigation"
+      class={cn("ui-topbar-navigation min-w-0 flex-1 overflow-x-auto", local.class)}
+    />
+  );
+}
+
+export function TopbarSearch(props: TopbarSearchProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return (
+    <div
+      {...rest}
+      data-scope="ui-topbar"
+      data-part="search"
+      class={cn("ui-topbar-search min-w-40 flex-1 md:max-w-sm", local.class)}
+    />
+  );
+}
+
+export function TopbarCommandTrigger(props: TopbarCommandTriggerProps) {
+  const [local, rest] = splitProps(props, ["children", "class", "shortcut"]);
+  return (
+    <span data-scope="ui-topbar" data-part="command-trigger" class="inline-flex min-w-0">
+      <Button
+        {...rest}
+        variant="outline"
+        size="sm"
+        class={cn(
+          "ui-topbar-command-trigger min-w-0 justify-between text-muted-foreground md:min-w-56",
+          local.class,
+        )}
+      >
+        <span class="truncate">{local.children}</span>
+        <Show when={local.shortcut}>
+          <ShortcutDisplay label={local.shortcut} class="ms-3 hidden md:inline-flex" />
+        </Show>
+      </Button>
+    </span>
+  );
+}
+
+export function TopbarActions(props: TopbarActionsProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return (
+    <div
+      {...rest}
+      data-scope="ui-topbar"
+      data-part="actions"
+      class={cn("ui-topbar-actions ms-auto flex shrink-0 items-center gap-1.5", local.class)}
+    />
+  );
+}
+
+export function TopbarStatus(props: TopbarStatusProps) {
+  const [local, rest] = splitProps(props, ["class"]);
+  return (
+    <div
+      {...rest}
+      data-scope="ui-topbar"
+      data-part="status"
+      class={cn("ui-topbar-status flex shrink-0 items-center gap-1.5", local.class)}
+    />
+  );
+}

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -10,6 +10,7 @@
       "@/*": ["src/default/*"],
       "@/components/ui/*": ["src/default/ui/*"],
       "@/components/data-table/*": ["src/default/components/data-table/*"],
+      "@/hooks/*": ["src/default/hooks/*"],
       "@/lib/*": ["src/default/lib/*"]
     },
     "types": []

--- a/registry/default/items/app-shell.json
+++ b/registry/default/items/app-shell.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://mason.build/schema/registry-item.json",
+  "name": "app-shell",
+  "type": "registry:ui",
+  "title": "AppShell",
+  "description": "Central app composition surface for topbar, sidebar navigation, main content, inspector rail, and command menu integration.",
+  "version": "0.1.0",
+  "compatibility": {
+    "mason": ">=0.1.0 <0.2.0",
+    "solid": ">=1.9.9 <2.0.0"
+  },
+  "categories": ["layout", "app-shell", "workspace"],
+  "keywords": ["app-shell", "topbar", "sidebar", "inspector", "command-menu", "workspace"],
+  "docs": "https://keystone-ui.dev/docs/ui/app-shell",
+  "registryDependencies": [
+    "topbar",
+    "nav-list",
+    "command-menu",
+    "sidebar-store",
+    "use-media-query",
+    "cn"
+  ],
+  "meta": {
+    "install": "mason add app-shell",
+    "api": "Exports AppShell plus root, topbar, sidebar, main, inspector, and command-surface parts. High-level AppShell accepts topbar, sidebar, main/children, inspector, commandMenu, and sidebarState slots.",
+    "anatomy": ["root", "topbar", "sidebar", "main", "inspector", "command-surface"],
+    "stateOwnership": "Layout state remains UI/app-owned. Pair sidebarState with SidebarStore, route state with the app/router, command state with CommandMenu/CommandStore, and responsive decisions with useMediaQuery.",
+    "accessibility": "Uses header/topbar slot, aside landmarks for sidebar and inspector, and a main landmark. NavList owns native link/button navigation semantics, while CommandMenu owns its combobox/dialog-like command behavior through existing UI/Core composition.",
+    "responsive": "Mobile stacks topbar, main, sidebar, and inspector in document flow. Large screens use a three-column shell with an optional collapsed sidebar track and independently scrollable main/sidebar/inspector regions.",
+    "customization": "Slots are intentionally broad so apps can compose Topbar, NavList, SidebarStore triggers, CommandMenu, inspector panels, and router-aware content without AppShell owning routing or domain data.",
+    "sourceFiles": ["packages/ui/src/default/ui/app-shell.tsx"],
+    "parity": {
+      "shadcn": "Follows source-owned shell composition and editable classes while avoiding a hard dependency on any single router.",
+      "dataDenseWorkspace": "Covers the central composition surface required by developer consoles, admin control planes, and workspace examples: topbar, sidebar/nav, main content, inspector, and command integration.",
+      "tanstack": "Pairs with app-layer TanStack Store/Router/Hotkeys code through slots and state props while keeping Core independent from TanStack libraries.",
+      "keystoneCore": "Does not introduce Core app-shell APIs. It composes existing UI source and app state."
+    }
+  },
+  "files": [
+    {
+      "path": "packages/ui/src/default/ui/app-shell.tsx",
+      "type": "registry:ui"
+    }
+  ]
+}

--- a/registry/default/items/breadcrumb.json
+++ b/registry/default/items/breadcrumb.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://mason.build/schema/registry-item.json",
+  "name": "breadcrumb",
+  "type": "registry:ui",
+  "title": "Breadcrumb",
+  "description": "Source-owned Solid breadcrumb navigation for docs, app routes, and dense topbar composition.",
+  "version": "0.1.0",
+  "compatibility": {
+    "mason": ">=0.1.0 <0.2.0",
+    "solid": ">=1.9.0 <2.0.0"
+  },
+  "categories": ["navigation", "base"],
+  "keywords": ["breadcrumb", "navigation", "route", "topbar", "docs"],
+  "docs": "https://keystone-ui.dev/docs/ui/breadcrumb",
+  "registryDependencies": ["cn"],
+  "meta": {
+    "install": "mason add breadcrumb",
+    "customization": "Use ui-breadcrumb classes and data-slot hooks for root, list, item, link, page, separator, and ellipsis styling. Pass items for simple route trails or compose parts directly for menus and app topbars.",
+    "sourceFiles": ["packages/ui/src/default/ui/breadcrumb.tsx"],
+    "dependencies": ["cn"],
+    "api": "Breadcrumb accepts items, label, separator, listClass, linkClass, pageClass, and separatorClass for route-generated trails. BreadcrumbList, BreadcrumbItem, BreadcrumbLink, BreadcrumbPage, BreadcrumbSeparator, and BreadcrumbEllipsis are exported for source-owned composition.",
+    "accessibility": "Breadcrumb renders a nav landmark with aria-label and an ordered list. Links remain anchors, separators are presentation-only, the current page uses aria-current=page, and ellipsis is a named button suitable for a menu trigger.",
+    "anatomy": ["root", "list", "item", "link", "page", "separator", "ellipsis"],
+    "limitations": "Breadcrumb is display/navigation source and has no Core dependency because it owns no intrinsic state. Route matching, truncation menus, and responsive collapse policy stay in app code or composed menu source.",
+    "parity": {
+      "visualReference": "Matches shadcn-style source-owned breadcrumb ergonomics in Solid form: nav root, ordered list, item/link/page/separator parts, current page semantics, customizable separator, and ellipsis trigger for collapsed trails.",
+      "baseUi": "Base UI has no dedicated Breadcrumb primitive, so parity is scoped to native landmark/list/link semantics and accessible current-page state.",
+      "kobalte": "Comparable to Kobalte-style Solid composition through explicit parts and data attributes. Keystone intentionally keeps route state and collapse behavior outside this display component."
+    }
+  },
+  "files": [
+    {
+      "path": "packages/ui/src/default/ui/breadcrumb.tsx",
+      "type": "registry:ui"
+    }
+  ]
+}

--- a/registry/default/items/code-block.json
+++ b/registry/default/items/code-block.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://mason.build/schema/registry-item.json",
+  "name": "code-block",
+  "type": "registry:ui",
+  "title": "CodeBlock",
+  "description": "Source-owned Solid code block for docs and product surfaces with caption metadata, copy action, wrapping, and stable anatomy hooks.",
+  "version": "0.1.0",
+  "compatibility": {
+    "mason": ">=0.1.0 <0.2.0",
+    "solid": ">=1.9.0 <2.0.0"
+  },
+  "categories": ["base", "docs", "content"],
+  "keywords": ["code-block", "code", "pre", "docs", "copy"],
+  "docs": "https://keystone-ui.dev/docs/ui/code-block",
+  "registryDependencies": ["cn", "copy-button"],
+  "meta": {
+    "install": "mason add code-block",
+    "customization": "Use ui-code-block classes and data-slot hooks for root, header, title, description, actions, pre, and code. Compose extra actions beside the generated CopyButton.",
+    "sourceFiles": ["packages/ui/src/default/ui/code-block.tsx"],
+    "dependencies": ["cn", "copy-button"],
+    "api": "CodeBlock accepts code, language, title, description, copy, copyLabel, actions, wrap, preClass, codeClass, and copyClass. It also exports CodeBlockHeader, CodeBlockTitle, CodeBlockDescription, CodeBlockActions, CodeBlockPre, and CodeBlockCode.",
+    "accessibility": "Renders a figure with optional figcaption, pre/code text semantics, language metadata as data-language, and a native CopyButton action. Syntax highlighting is intentionally caller/tooling-owned.",
+    "anatomy": ["root", "header", "title", "description", "actions", "pre", "code"],
+    "limitations": "CodeBlock does not parse markdown, tokenize syntax, virtualize long files, or own a syntax highlighter. Add highlighted markup or build-time transforms in docs/app code when needed.",
+    "parity": {
+      "visualReference": "Matches shadcn-style code block source ergonomics in Solid form: framed pre/code surface, header metadata, copy affordance, wrapping option, and stable data hooks.",
+      "baseUi": "No Core/Base UI primitive is needed because native figure/pre/code/button semantics cover the behavior. Copy behavior is delegated to CopyButton and the UI clipboard hook.",
+      "kobalte": "Comparable to Solid display composition rather than a primitive. Keystone intentionally keeps syntax highlighting and docs routing outside this base component."
+    }
+  },
+  "files": [
+    {
+      "path": "packages/ui/src/default/ui/code-block.tsx",
+      "type": "registry:ui"
+    }
+  ]
+}

--- a/registry/default/items/copy-button.json
+++ b/registry/default/items/copy-button.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://mason.build/schema/registry-item.json",
+  "name": "copy-button",
+  "type": "registry:ui",
+  "title": "CopyButton",
+  "description": "Accessible Solid button for copying text with copied/error visual state and UI-owned clipboard helper behavior.",
+  "version": "0.1.0",
+  "compatibility": {
+    "mason": ">=0.1.0 <0.2.0",
+    "solid": ">=1.9.0 <2.0.0"
+  },
+  "categories": ["base", "feedback", "docs"],
+  "keywords": ["copy", "clipboard", "button", "code", "docs"],
+  "docs": "https://keystone-ui.dev/docs/ui/copy-button",
+  "registryDependencies": ["cn", "use-copy-to-clipboard"],
+  "meta": {
+    "install": "mason add copy-button",
+    "customization": "Use ui-copy-button classes and data-slot/data-copied/data-error hooks to style icon-only or labelled copy controls.",
+    "sourceFiles": ["packages/ui/src/default/ui/copy-button.tsx"],
+    "dependencies": ["cn", "use-copy-to-clipboard"],
+    "api": "CopyButton accepts value, label, copiedLabel, errorLabel, copiedDuration, showLabel, onCopy, onCopyError, and normal button attributes. User onClick runs before copying and event.preventDefault cancels internal copy behavior.",
+    "accessibility": "Renders a native button with dynamic aria-label/title text, visible or screen-reader-only status label, and data state hooks for copied/error/unsupported feedback.",
+    "anatomy": ["root"],
+    "limitations": "CopyButton copies plain text only and does not render a tooltip or toast by itself. Compose those surfaces in app/docs code when persistent feedback is needed.",
+    "parity": {
+      "visualReference": "Matches shadcn-style source-owned copy button behavior in Solid form: icon button default, optional visible label, copied/error state, and data attributes for styling.",
+      "baseUi": "No Core/Base UI primitive is needed because the native button and generated clipboard hook cover the intrinsic semantics and browser boundary.",
+      "kobalte": "Comparable to a Kobalte button composition while remaining UI-owned source. Keystone keeps clipboard state out of Core and exposes cancellable user-first click handling."
+    }
+  },
+  "files": [
+    {
+      "path": "packages/ui/src/default/ui/copy-button.tsx",
+      "type": "registry:ui"
+    }
+  ]
+}

--- a/registry/default/items/frame.json
+++ b/registry/default/items/frame.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://mason.build/schema/registry-item.json",
+  "name": "frame",
+  "type": "registry:ui",
+  "title": "Frame",
+  "description": "Source-owned framed preview and embedded panel container with header, viewport, status, and aspect-ratio anatomy.",
+  "version": "0.1.0",
+  "compatibility": {
+    "mason": ">=0.1.0 <0.2.0",
+    "solid": ">=1.9.9 <2.0.0"
+  },
+  "categories": ["layout", "preview", "panel"],
+  "keywords": ["frame", "preview", "demo", "embed", "inspector", "viewport"],
+  "docs": "https://keystone-ui.dev/docs/ui/frame",
+  "registryDependencies": ["button", "card", "separator", "cn"],
+  "meta": {
+    "install": "mason add frame",
+    "api": "Exports Frame plus root, header, title, description, actions, viewport, content, footer, status, loading, empty, and error parts. High-level Frame accepts title, description, actions, footer, loading, empty, error, variant, and aspect props.",
+    "anatomy": [
+      "root",
+      "header",
+      "title",
+      "description",
+      "actions",
+      "separator",
+      "viewport",
+      "content",
+      "footer",
+      "status",
+      "loading-indicator"
+    ],
+    "variants": "variant supports bordered, elevated, flush, and inset. aspect supports auto, square, video, wide, and portrait for fixed preview constraints while preserving responsive width.",
+    "accessibility": "Frame is presentational by default and renders a section without inventing widget behavior. Consumers own heading levels and labels. Loading and empty states use role=status; error uses role=alert. Actions are native buttons or links supplied by the app.",
+    "composition": "The high-level source composes existing UI Card for the framed surface, Separator for header/footer boundaries, Button for retry actions, and source-owned status parts for loading, empty, and error states. Standalone Skeleton, Empty, and Alert items can replace these slots once those registry items exist.",
+    "customization": "Use data-scope=\"ui-frame\" and data-part hooks for frame root, header, title, description, actions, separator, viewport, content, footer, status, and loading-indicator. Override slots for screenshots, demos, embedded panels, inspector surfaces, loading skeletons, empty states, or alert/callout errors.",
+    "limitations": "Frame does not implement iframe sandboxing, screenshot capture, resizing, focus trapping, drawer behavior, route state, or app-shell layout. Those remain app composition or future specialized UI block concerns.",
+    "sourceFiles": ["packages/ui/src/default/ui/frame.tsx"],
+    "parity": {
+      "coss": "Maps to the Coss Frame concept as a reusable container for framed previews, embedded content, screenshots, demos, device/browser-like panels, and inspectable surfaces.",
+      "shadcn": "Follows source-owned composition with editable classes, stable data hooks, Card-like surface treatment, and slot-based loading/empty/error replacement.",
+      "keystoneUi": "Builds from existing UI Button, Card, Separator, and cn source instead of introducing a Core primitive or app shell abstraction.",
+      "keystoneCore": "No Core behavior is introduced because Frame is a styled layout/presentation container."
+    }
+  },
+  "files": [
+    {
+      "path": "packages/ui/src/default/ui/frame.tsx",
+      "type": "registry:ui"
+    }
+  ]
+}

--- a/registry/default/items/group.json
+++ b/registry/default/items/group.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://mason.build/schema/registry-item.json",
+  "name": "group",
+  "type": "registry:ui",
+  "title": "Group",
+  "description": "Source-owned grouped control and content container for compact horizontal, vertical, attached, and inset UI composition.",
+  "version": "0.1.0",
+  "compatibility": {
+    "mason": ">=0.1.0 <0.2.0",
+    "solid": ">=1.9.0 <2.0.0"
+  },
+  "categories": ["layout", "base", "actions"],
+  "keywords": ["group", "button-group", "control-group", "attached", "inset", "dense"],
+  "docs": "https://keystone-ui.dev/docs/ui/group",
+  "registryDependencies": ["cn"],
+  "meta": {
+    "install": "mason add group",
+    "customization": "Customize the generated source through ui-group classes, data-variant, data-orientation, data-size, data-slot values, and stable data-scope/data-part hooks. Attached styling targets child button, input-control, and group-item slots without owning child behavior.",
+    "sourceFiles": ["packages/ui/src/default/ui/group.tsx"],
+    "dependencies": ["cn"],
+    "api": "Group exports Group, GroupItem, GroupLabel, and GroupDescription. Group accepts orientation horizontal/vertical, variant default/attached/inset, size sm/default/lg, and disabled/invalid/selected props that project data attributes for styling only.",
+    "accessibility": "Group is presentational by default and does not create keyboard, focus, label, or form semantics. Add role=group with aria-label or aria-labelledby when the grouping needs an accessible name. Labels and descriptions are visual composition parts unless the consumer wires them with native ARIA attributes.",
+    "anatomy": ["root", "item", "label", "description"],
+    "variants": {
+      "orientation": ["horizontal", "vertical"],
+      "variant": ["default", "attached", "inset"],
+      "size": ["sm", "default", "lg"]
+    },
+    "statePassThrough": "disabled, invalid, and selected project data-disabled, data-invalid, and data-selected on the root for parent-state styling. They do not disable, validate, select, or change nested controls; child Button, Input, Field, Toolbar, or custom controls own their native and ARIA behavior.",
+    "composition": "Use Group for compact related controls, segmented metadata, attached buttons and inputs, and small inset clusters. Use FieldGroup for form labelling/validation structure, Toolbar for roving-focus toolbars, and Card for larger content surfaces with header/content/footer anatomy.",
+    "cssVariables": [
+      "--color-accent",
+      "--color-background",
+      "--color-border",
+      "--color-destructive",
+      "--color-foreground",
+      "--color-muted",
+      "--color-muted-foreground",
+      "--color-ring"
+    ],
+    "limitations": "Group intentionally introduces no Core primitive behavior, no roving focus, no form-control context, no fieldset/legend semantics, no card surface anatomy, and no validation or selection state machine.",
+    "parity": {
+      "visualReference": "Maps the Coss Group concept into Solid source: a compact grouped container with root/item/label/description anatomy, horizontal and vertical orientation, inset grouping, attached control grouping, stable styling hooks, and source-owned customization. Keystone keeps it smaller than Card, FieldGroup, or Toolbar.",
+      "baseUi": "Base UI has no direct Group primitive. Keystone treats Group as presentational UI source, with native prop pass-through and optional consumer-owned role=group naming when semantics are needed. Runtime behavior stays in nested controls or Core-backed components.",
+      "kobalte": "Kobalte has no direct generic Group primitive. Solid parity is simple component composition with stable data attributes and no invented context, focus management, or form semantics."
+    }
+  },
+  "files": [
+    {
+      "path": "packages/ui/src/default/ui/group.tsx",
+      "type": "registry:ui"
+    }
+  ]
+}

--- a/registry/default/items/nav-list.json
+++ b/registry/default/items/nav-list.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://mason.build/schema/registry-item.json",
+  "name": "nav-list",
+  "type": "registry:ui",
+  "title": "NavList",
+  "description": "Simple app navigation list source for route-aware sidebar and topbar links without menu semantics.",
+  "version": "0.1.0",
+  "compatibility": {
+    "mason": ">=0.1.0 <0.2.0",
+    "solid": ">=1.9.9 <2.0.0"
+  },
+  "categories": ["navigation", "app-shell", "sidebar"],
+  "keywords": ["nav-list", "nav-item", "sidebar", "topbar", "route"],
+  "docs": "https://keystone-ui.dev/docs/ui/nav-list",
+  "registryDependencies": ["badge", "shortcut-display", "cn"],
+  "meta": {
+    "install": "mason add nav-list",
+    "api": "Exports NavList, NavListRoot, NavListGroup, NavListGroupLabel, NavListItems, NavListItem, NavListItemContent, and item/group/state types. High-level NavList accepts items or groups plus getItemState for app/router-owned active and disabled state.",
+    "anatomy": [
+      "root",
+      "group",
+      "group-label",
+      "items",
+      "item",
+      "item-content",
+      "item-icon",
+      "item-text",
+      "item-label",
+      "item-description",
+      "item-status",
+      "item-badge",
+      "item-shortcut"
+    ],
+    "activeState": "Route matching remains app/router-owned through item.current or getItemState. The component only projects aria-current and data-current when the caller marks an item current.",
+    "accessibility": "Uses native anchor elements for href items and native buttons for action items. It intentionally avoids menu, menubar, and navigation-menu roles because persistent app navigation is not a composite menu.",
+    "keyboard": "Native links and buttons own tab reachability and activation. Use Core NavigationMenu/Menu only for true composite menu surfaces that need roving focus, typeahead, or submenu behavior.",
+    "customization": "Use stable data-scope=\"ui-nav-list\" and data-part hooks for styling dense sidebar and horizontal topbar variants. Badge/count, shortcut, status, icon, label, and description slots are source-owned and replaceable.",
+    "sourceFiles": ["packages/ui/src/default/ui/nav-list.tsx"],
+    "parity": {
+      "shadcn": "Follows source-owned app navigation ergonomics with readable link/button rows, icon/label/badge/shortcut slots, and route-active data hooks.",
+      "baseUi": "Deliberately does not copy Menu or NavigationMenu behavior because the target surface is persistent app navigation, not a composite popup/menu widget.",
+      "kobalte": "Keeps Solid-first JSX data and component composition while avoiding primitive roles that would overstate the interaction model."
+    }
+  },
+  "files": [
+    {
+      "path": "packages/ui/src/default/ui/nav-list.tsx",
+      "type": "registry:ui"
+    }
+  ]
+}

--- a/registry/default/items/realtime-data-table.json
+++ b/registry/default/items/realtime-data-table.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://mason.build/schema/registry-item.json",
+  "name": "realtime-data-table",
+  "type": "registry:block",
+  "title": "RealtimeDataTableBlock",
+  "description": "TanStack-backed realtime data table pattern for frequent row and cell updates.",
+  "version": "0.1.0",
+  "dependencies": ["@tanstack/solid-table@^8.21.3"],
+  "compatibility": {
+    "mason": ">=0.1.0 <0.2.0",
+    "solid": ">=1.9.9 <2.0.0",
+    "tanstack-table": ">=8.21.0 <9.0.0"
+  },
+  "categories": ["table", "tanstack", "data-dense", "block"],
+  "keywords": [
+    "realtime-data-table",
+    "data-table",
+    "tanstack",
+    "sorting",
+    "loading",
+    "empty-state"
+  ],
+  "docs": "https://keystone-ui.dev/docs/blocks/realtime-data-table",
+  "registryDependencies": ["badge", "button", "data-table"],
+  "meta": {
+    "install": "mason add realtime-data-table",
+    "fileTree": "Installs realtime-data-table.tsx, realtime-data-table-columns.tsx, and realtime-data-table-data.ts as user-owned source under src/components/blocks/realtime-data-table/.",
+    "dependencies": ["@tanstack/solid-table", "badge", "button", "data-table"],
+    "realtimeBehavior": "Rows are held in a Solid signal and passed to useDataTable as an accessor, so frequent row/cell updates flow through TanStack Table without replacing the table kit. The sample tick mutates latency, throughput, error-rate, status, and updated-at cells while preserving row object IDs.",
+    "sorting": "Initial sorting orders by latency descending and sortable numeric headers use DataTableColumnHeader, proving sort state remains available during repeated row updates.",
+    "rowIdentity": "The block passes getRowId: row.id to avoid array-index identity when data reorders, filters, clears, reloads, or updates frequently.",
+    "states": "Keyboard-reachable controls toggle live updates, apply a manual tick, show skeleton loading rows, clear to the DataTable empty state, and reset the source rows.",
+    "accessibility": "Controls are native buttons in a labelled group, update status is aria-live=polite, loading is delegated to DataTable aria-busy/status semantics, and sorting/filter/view controls remain keyboard reachable through the DataTable kit.",
+    "customization": "Replace realtime-data-table-data.ts with route loader, websocket, SSE, polling, or TanStack Store data. Keep stable row IDs and pass loading from the host app's fetch/subscription lifecycle.",
+    "sourceFiles": [
+      "packages/ui/src/default/blocks/realtime-data-table/realtime-data-table.tsx",
+      "packages/ui/src/default/blocks/realtime-data-table/realtime-data-table-columns.tsx",
+      "packages/ui/src/default/blocks/realtime-data-table/realtime-data-table-data.ts"
+    ],
+    "parity": {
+      "tanstackTable": "Uses TanStack Solid Table state, ColumnDef definitions, getRowId, sorting, filtering, pagination, and reactive data accessors. Gaps: no virtualization, server streaming contract, optimistic mutation queue, or persisted view state.",
+      "dataDenseWorkspace": "Targets dense operational tables where values update frequently and users need stable scanning, keyboard-reachable controls, explicit loading/empty states, and row identity that survives updates. Gaps: domain-specific formatting and alert workflows belong in later blocks.",
+      "shadcn": "Follows copy-paste block ownership over an installed data-table source kit, with app-specific sample data isolated into companion files. Gaps: no generated schema or backend loader convention."
+    }
+  },
+  "files": [
+    {
+      "path": "packages/ui/src/default/blocks/realtime-data-table/realtime-data-table.tsx",
+      "type": "registry:block",
+      "target": "src/components/blocks/realtime-data-table/realtime-data-table.tsx"
+    },
+    {
+      "path": "packages/ui/src/default/blocks/realtime-data-table/realtime-data-table-columns.tsx",
+      "type": "registry:block",
+      "target": "src/components/blocks/realtime-data-table/realtime-data-table-columns.tsx"
+    },
+    {
+      "path": "packages/ui/src/default/blocks/realtime-data-table/realtime-data-table-data.ts",
+      "type": "registry:block",
+      "target": "src/components/blocks/realtime-data-table/realtime-data-table-data.ts"
+    }
+  ]
+}

--- a/registry/default/items/search-input.json
+++ b/registry/default/items/search-input.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://mason.build/schema/registry-item.json",
+  "name": "search-input",
+  "type": "registry:ui",
+  "title": "SearchInput",
+  "description": "Native Solid search input with search icon, optional clear button, loading state, and input-control styling hooks.",
+  "version": "0.1.0",
+  "compatibility": {
+    "mason": ">=0.1.0 <0.2.0",
+    "solid": ">=1.9.0 <2.0.0"
+  },
+  "categories": ["form", "base", "navigation"],
+  "keywords": ["search-input", "search", "filter", "input", "topbar", "command"],
+  "docs": "https://keystone-ui.dev/docs/ui/search-input",
+  "registryDependencies": ["cn"],
+  "meta": {
+    "install": "mason add search-input",
+    "customization": "Use ui-search-input classes and data-slot hooks for root, icon, input, loading-indicator, and clear button styling. Compose it into command triggers, table filters, topbars, and docs search without adopting a command primitive.",
+    "sourceFiles": ["packages/ui/src/default/ui/search-input.tsx"],
+    "dependencies": ["cn"],
+    "api": "SearchInput is a native type=search input with size sm/default/lg, invalid, loading, loadingLabel, clearable, clearLabel, onClear, rootClass, and inputClass. It accepts normal input attributes except type and native size.",
+    "accessibility": "SearchInput preserves the native input as the focus target, keeps the icon decorative, exposes loading as role=status, gives the clear button an accessible name, and runs onClear before internal clearing so event.preventDefault can take over.",
+    "anatomy": ["root", "icon", "input", "loading-indicator", "clear"],
+    "cssVariables": [
+      "--radius-lg",
+      "--color-input",
+      "--color-background",
+      "--color-foreground",
+      "--color-muted-foreground",
+      "--color-destructive",
+      "--color-ring"
+    ],
+    "limitations": "SearchInput does not filter data, open command palettes, or own query routing. Pair it with app state, TanStack Table filters, CommandMenu, or router search params for behavior.",
+    "parity": {
+      "visualReference": "Matches shadcn-style search input composition in Solid source form: native search input, leading icon, optional clear affordance, loading indicator, invalid/focus/disabled hooks, and search-decoration resets.",
+      "baseUi": "No Core/Base UI primitive is needed because native search input semantics cover the intrinsic behavior. User handlers run before internal clear behavior and can prevent default.",
+      "kobalte": "Comparable to Kobalte TextField input composition when used with labels/descriptions externally. Keystone intentionally keeps SearchInput separate from command, autocomplete, and field registration behavior."
+    }
+  },
+  "files": [
+    {
+      "path": "packages/ui/src/default/ui/search-input.tsx",
+      "type": "registry:ui"
+    }
+  ]
+}

--- a/registry/default/items/sidebar-store.json
+++ b/registry/default/items/sidebar-store.json
@@ -24,7 +24,7 @@
     "keyboard": "mountSidebarStore registers Mod+B by default, following shadcn sidebar ergonomics. The shortcut is app-level behavior and can be disabled with keyboardShortcut=false or changed with a custom key.",
     "dataAttributes": "The store does not render DOM. Generated sidebar UI should project state through stable data-scope/data-part hooks and data-state values such as expanded/collapsed.",
     "ssr": "No browser globals are read while creating the store. mountSidebarStore performs localStorage, matchMedia, and keydown registration after mount.",
-    "limitations": "This item intentionally owns shared app shell state only. It does not implement a visual Sidebar component, focus trapping, drawer dismissal, or navigation semantics; those belong in future UI sidebar source built on Core overlays and navigation primitives where appropriate.",
+    "limitations": "This item intentionally owns shared app shell state only. The visual Sidebar registry item composes this store for source-owned aside/nav/button/link anatomy. Focus trapping and drawer dismissal remain app composition concerns unless future Core overlay composition is explicitly needed.",
     "sourceFiles": ["packages/ui/src/default/stores/sidebar-store.tsx"],
     "dependencies": ["@tanstack/solid-store"],
     "parity": {

--- a/registry/default/items/sidebar.json
+++ b/registry/default/items/sidebar.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://mason.build/schema/registry-item.json",
+  "name": "sidebar",
+  "type": "registry:ui",
+  "title": "Sidebar",
+  "description": "Source-owned Solid app sidebar with desktop collapse state, mobile panel state, navigation anatomy, active item tracking, and stable styling hooks.",
+  "version": "0.1.0",
+  "dependencies": ["@tanstack/solid-store@^0.11.0"],
+  "compatibility": {
+    "mason": ">=0.1.0 <0.2.0",
+    "solid": ">=1.9.9 <2.0.0"
+  },
+  "categories": ["layout", "sidebar", "navigation", "app-shell"],
+  "keywords": ["sidebar", "app-shell", "navigation", "tanstack-store", "solid"],
+  "docs": "https://keystone-ui.dev/docs/ui/sidebar",
+  "registryDependencies": ["button", "cn", "input", "separator", "sidebar-store"],
+  "meta": {
+    "install": "mason add sidebar",
+    "fileTree": "Installs sidebar.tsx as user-owned source under src/components/ui/sidebar.tsx and composes the sidebar-store registry item.",
+    "dependencies": [
+      "@tanstack/solid-store",
+      "button",
+      "cn",
+      "input",
+      "separator",
+      "sidebar-store"
+    ],
+    "api": "Exports SidebarProvider, useSidebar, SidebarLayout, Sidebar, SidebarMobile, SidebarHeader, SidebarContent, SidebarFooter, SidebarGroup, SidebarGroupLabel, SidebarGroupAction, SidebarGroupContent, SidebarNav, SidebarMenu, SidebarMenuItem, SidebarMenuLink, SidebarMenuButton, SidebarMenuAction, SidebarMenuBadge, SidebarMenuSkeleton, SidebarMenuSub, SidebarMenuSubItem, SidebarMenuSubButton, SidebarTrigger, SidebarRail, SidebarInset, SidebarInput, SidebarSeparator, and SidebarItems.",
+    "anatomy": "The desktop sidebar is an aside inside SidebarLayout. Content uses header/content/footer, group, group action, nav, menu, menu item, link/button, menu action, badge, skeleton, submenu, trigger, rail, input, separator, mobile dialog panel, and inset parts. SidebarItems is a convenience renderer for simple source-owned navigation arrays.",
+    "behavior": "Desktop open state collapses or expands the sidebar. Mobile state opens a dialog-like panel. SidebarTrigger and SidebarRail toggle the current desktop or mobile target through the shared store. Menu links can mark an item active and close the mobile panel after navigation.",
+    "controlled": "Controlled and uncontrolled desktop state are inherited from SidebarProvider and sidebar-store: pass open/onOpenChange for controlled desktop state, defaultOpen for uncontrolled state, and onOpenMobileChange for mobile panel changes.",
+    "accessibility": "The root renders as an aside with an aria-label, navigation renders as nav, the trigger is a button with aria-expanded and optional aria-controls, active links expose aria-current=page, disabled generated links use aria-disabled and prevent navigation, and the mobile panel renders role=dialog with aria-modal.",
+    "keyboard": "Keyboard interaction is native button/link behavior plus the sidebar-store app shortcut. mountSidebarStore registers Mod+B by default and can be disabled with keyboardShortcut=false.",
+    "focus": "No roving focus or selection primitive is introduced. Sidebar navigation remains ordinary document navigation so tab order and screen-reader behavior follow native links/buttons. Mobile focus trapping is intentionally deferred to app composition with Sheet/Dialog when the product needs modal enforcement.",
+    "dataAttributes": "Stable hooks use data-scope=\"ui-sidebar\" and data-part values for layout, root, mobile, header, content, footer, group, group-label, group-action, group-content, nav, menu, menu-item, menu-link, menu-button, menu-action, menu-badge, menu-skeleton, menu-sub, menu-sub-item, menu-sub-button, trigger, rail, inset, input, separator, menu-icon, and menu-badge. State hooks include data-state=expanded|collapsed, data-mobile, data-open-mobile, data-active, data-side, data-variant, data-size, and data-collapsible.",
+    "cssVariables": "SidebarLayout sets --sidebar-width, --sidebar-width-icon, and --sidebar-width-mobile, defaulting to 16rem, 3rem, and 18rem. Consumers may override these props or classes in generated source.",
+    "ssr": "The visual component reads only Solid store accessors during render. Browser-only localStorage, matchMedia, and keydown wiring remain inside mountSidebarStore after mount.",
+    "primitiveBoundary": "Sidebar remains UI source because it is app layout, navigation presentation, app state, and generated-source ergonomics. It should not become a Core layout primitive unless a later ADR identifies reusable intrinsic accessibility behavior beyond native landmarks/buttons/links.",
+    "limitations": "This item does not implement route integration, animated width measurement, tooltip-on-collapsed labels, persisted nested menu state, or enforced mobile focus trapping. Those belong in app composition, future blocks, or Core overlay composition where needed.",
+    "sourceFiles": ["packages/ui/src/default/ui/sidebar.tsx"],
+    "tests": ["packages/ui/src/default/ui/sidebar.test.tsx"],
+    "parity": {
+      "shadcn": "Matches shadcn-style source ownership, provider/hook ergonomics through sidebar-store, desktop/mobile open state, variants, rail, group action, menu action, badge, skeleton, submenus, sidebar input/separator, active item source helpers, CSS variable widths, data-state hooks, and Mod+B shortcut behavior. Keystone differs by keeping visual Sidebar and TanStack Store state as separate registry items and using Solid-native components instead of React asChild/useRender.",
+      "tanstackStore": "Uses TanStack Store only for app-shell state coordination, not intrinsic widget behavior. This keeps Core independent from TanStack app libraries.",
+      "coreBoundary": "No Core primitive is added because the shipped behavior is layout/navigation composition over native aside/nav/button/link semantics."
+    }
+  },
+  "files": [
+    {
+      "path": "packages/ui/src/default/ui/sidebar.tsx",
+      "type": "registry:ui"
+    }
+  ]
+}

--- a/registry/default/items/topbar.json
+++ b/registry/default/items/topbar.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://mason.build/schema/registry-item.json",
+  "name": "topbar",
+  "type": "registry:ui",
+  "title": "Topbar",
+  "description": "Generic app header surface for brand, title, navigation, search, command trigger, status, and actions.",
+  "version": "0.1.0",
+  "compatibility": {
+    "mason": ">=0.1.0 <0.2.0",
+    "solid": ">=1.9.9 <2.0.0"
+  },
+  "categories": ["layout", "app-shell", "navigation"],
+  "keywords": ["topbar", "header", "command-trigger", "app-shell", "navigation"],
+  "docs": "https://keystone-ui.dev/docs/ui/topbar",
+  "registryDependencies": ["button", "shortcut-display", "cn"],
+  "meta": {
+    "install": "mason add topbar",
+    "api": "Exports Topbar plus root, brand, title, navigation, search, command trigger, status, and actions parts. High-level Topbar accepts slots for brand/title/navigation/search/command/status/actions and an onCommand handler.",
+    "anatomy": [
+      "root",
+      "brand",
+      "brand-mark",
+      "title",
+      "navigation",
+      "search",
+      "command-trigger",
+      "status",
+      "actions"
+    ],
+    "accessibility": "Renders a header landmark. Command trigger is a native button built from UI Button. Navigation, breadcrumbs, search, and actions are caller-provided so their labels and route semantics stay app-owned.",
+    "responsive": "The root wraps at narrow widths and switches to a single-line toolbar on medium screens. Navigation can scroll horizontally, search can shrink, and action/status zones stay keyboard reachable.",
+    "customization": "Compose NavList, Breadcrumb, SearchInput, CommandMenu triggers, Badge, ShortcutDisplay, and Button source through the exposed slots. Style with data-scope=\"ui-topbar\" and data-part hooks.",
+    "sourceFiles": ["packages/ui/src/default/ui/topbar.tsx"],
+    "parity": {
+      "shadcn": "Matches source-owned app header composition rather than a sealed primitive: teams edit slots and classes after install.",
+      "keystoneUi": "Composes existing UI Button and ShortcutDisplay and is intended to host NavList, Breadcrumb, SearchInput, CommandMenu, Badge, and app actions.",
+      "keystoneCore": "Introduces no Core layout behavior; landmark and slot composition stay in generated UI source."
+    }
+  },
+  "files": [
+    {
+      "path": "packages/ui/src/default/ui/topbar.tsx",
+      "type": "registry:ui"
+    }
+  ]
+}

--- a/registry/default/items/use-copy-to-clipboard.json
+++ b/registry/default/items/use-copy-to-clipboard.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://mason.build/schema/registry-item.json",
+  "name": "use-copy-to-clipboard",
+  "type": "registry:hook",
+  "title": "useCopyToClipboard",
+  "description": "UI-owned Solid clipboard helper with copied/error state, callbacks, timer reset, and SSR-safe capability checks.",
+  "version": "0.1.0",
+  "compatibility": {
+    "mason": ">=0.1.0 <0.2.0",
+    "solid": ">=1.9.0 <2.0.0"
+  },
+  "categories": ["hook", "clipboard", "feedback"],
+  "keywords": ["clipboard", "copy", "hook", "solid", "use-copy-to-clipboard"],
+  "docs": "https://keystone-ui.dev/docs/hooks/use-copy-to-clipboard",
+  "filesRoot": "packages/ui/src/default/hooks",
+  "targetRoot": "src/hooks",
+  "meta": {
+    "install": "mason add use-copy-to-clipboard",
+    "api": "Exports createCopyToClipboard with copied, status, error, isSupported, reset, and async copy(value). Options include copiedDuration, onCopy, onError, and test/embed window injection.",
+    "accessibility": "The hook is state only. Components using it should expose copied/error feedback with accessible names or live regions appropriate to the surface.",
+    "behavior": "Uses navigator.clipboard.writeText when available, returns false instead of throwing when unsupported or rejected, stores error state, and clears copied state after the configured duration.",
+    "ssr": "Does not touch window or navigator until copy/isSupported is called. A window option supports tests and embedded document contexts.",
+    "limitations": "This generated UI hook is not a Core primitive and does not include legacy execCommand fallback. Clipboard permission behavior remains browser-owned.",
+    "sourceFiles": ["packages/ui/src/default/hooks/use-copy-to-clipboard.ts"],
+    "parity": {
+      "coss": "Covers the tracked useCopyToClipboard gap with Solid-native accessors, temporary copied state, failure state, callbacks, and browser capability guards.",
+      "solid": "Uses createSignal/onCleanup and an explicit createCopyToClipboard factory instead of React hook state/effects.",
+      "keystoneCore": "Intentionally remains in UI generated source because clipboard feedback is app/documentation behavior, not intrinsic Core primitive behavior."
+    }
+  },
+  "files": [
+    {
+      "path": "packages/ui/src/default/hooks/use-copy-to-clipboard.ts",
+      "type": "registry:hook"
+    }
+  ]
+}

--- a/registry/default/items/use-media-query.json
+++ b/registry/default/items/use-media-query.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://mason.build/schema/registry-item.json",
+  "name": "use-media-query",
+  "type": "registry:hook",
+  "title": "useMediaQuery",
+  "description": "SSR-safe Solid media query hook with string, breakpoint, pointer, orientation, and preference helpers.",
+  "version": "0.1.0",
+  "compatibility": {
+    "mason": ">=0.1.0 <0.2.0",
+    "solid": ">=1.9.9 <2.0.0"
+  },
+  "categories": ["hook", "responsive", "media-query"],
+  "keywords": ["use-media-query", "create-media-query", "responsive", "breakpoint", "solid"],
+  "docs": "https://keystone-ui.dev/docs/hooks/use-media-query",
+  "filesRoot": "packages/ui/src/default/hooks",
+  "targetRoot": "src/hooks",
+  "meta": {
+    "install": "mason add use-media-query",
+    "api": "Exports useMediaQuery/createMediaQuery accessors, normalizeMediaQuery, createBreakpointQuery, createPointerQuery, mediaQueryBreakpoints, and related option/input types.",
+    "ssr": "The accessor starts from defaultValue and does not read window or matchMedia until Solid onMount runs. Pass a window option for tests or embedded documents.",
+    "behavior": "Supports raw media query strings or structured min/max/orientation/pointer/preference objects. Listener cleanup handles modern addEventListener and legacy addListener MediaQueryList APIs.",
+    "limitations": "This hook is UI generated source. It is not a Core utility, does not observe container queries, and does not persist responsive state.",
+    "sourceFiles": ["packages/ui/src/default/hooks/use-media-query.ts"],
+    "parity": {
+      "coss": "Covers the tracked Coss useMediaQuery gap with Solid-native accessors, breakpoint helpers, pointer helpers, and SSR-safe defaults.",
+      "solid": "Uses createSignal and onMount instead of React effect/state conventions.",
+      "keystoneCore": "Intentionally remains in UI source because responsive shell behavior is app-owned and does not require a Core primitive or kernel export."
+    }
+  },
+  "files": [
+    {
+      "path": "packages/ui/src/default/hooks/use-media-query.ts",
+      "type": "registry:hook"
+    }
+  ]
+}

--- a/registry/default/registry.json
+++ b/registry/default/registry.json
@@ -28,6 +28,12 @@
       "description": "Keyboard-first workspace command surface composed from CommandMenu and ShortcutDisplay source."
     },
     {
+      "name": "realtime-data-table",
+      "type": "registry:block",
+      "title": "RealtimeDataTableBlock",
+      "description": "TanStack-backed realtime data table pattern for frequent row and cell updates."
+    },
+    {
       "name": "resizable-workspace-shell",
       "type": "registry:block",
       "title": "ResizableWorkspaceShellBlock",
@@ -68,6 +74,12 @@
       "type": "registry:ui",
       "title": "Input",
       "description": "Solid text input component with invalid state styling hooks."
+    },
+    {
+      "name": "search-input",
+      "type": "registry:ui",
+      "title": "SearchInput",
+      "description": "Native Solid search input with search icon, clear affordance, loading state, and styling hooks."
     },
     {
       "name": "textarea",
@@ -214,6 +226,36 @@
       "description": "Command palette source built from Keystone Combobox behavior, TanStack Store command state, and preview TanStack Hotkeys shortcuts."
     },
     {
+      "name": "app-shell",
+      "type": "registry:ui",
+      "title": "AppShell",
+      "description": "Central app composition surface for topbar, sidebar navigation, main content, inspector rail, and command menu integration."
+    },
+    {
+      "name": "topbar",
+      "type": "registry:ui",
+      "title": "Topbar",
+      "description": "Generic app header surface for brand, title, navigation, search, command trigger, status, and actions."
+    },
+    {
+      "name": "nav-list",
+      "type": "registry:ui",
+      "title": "NavList",
+      "description": "Simple app navigation list source for route-aware sidebar and topbar links without menu semantics."
+    },
+    {
+      "name": "use-media-query",
+      "type": "registry:hook",
+      "title": "useMediaQuery",
+      "description": "SSR-safe Solid media query hook with string, breakpoint, pointer, orientation, and preference helpers."
+    },
+    {
+      "name": "use-copy-to-clipboard",
+      "type": "registry:hook",
+      "title": "useCopyToClipboard",
+      "description": "UI-owned Solid clipboard helper with copied/error state, callbacks, timer reset, and SSR-safe capability checks."
+    },
+    {
       "name": "command-store",
       "type": "registry:ui",
       "title": "CommandStore",
@@ -236,6 +278,12 @@
       "type": "registry:ui",
       "title": "SidebarStore",
       "description": "TanStack Store-backed Solid sidebar app state with desktop/mobile open state, active item tracking, persistence, media-query sync, and keyboard toggling."
+    },
+    {
+      "name": "sidebar",
+      "type": "registry:ui",
+      "title": "Sidebar",
+      "description": "Source-owned Solid app sidebar with desktop collapse state, mobile panel state, navigation anatomy, active item tracking, and stable styling hooks."
     },
     {
       "name": "keyboard-shortcuts",
@@ -292,10 +340,34 @@
       "description": "Composable card parts for grouped content."
     },
     {
+      "name": "group",
+      "type": "registry:ui",
+      "title": "Group",
+      "description": "Compact grouped control and content container for horizontal, vertical, attached, and inset UI composition."
+    },
+    {
+      "name": "code-block",
+      "type": "registry:ui",
+      "title": "CodeBlock",
+      "description": "Source-owned Solid code block for docs and product surfaces with caption metadata and copy action."
+    },
+    {
+      "name": "frame",
+      "type": "registry:ui",
+      "title": "Frame",
+      "description": "Source-owned framed preview and embedded panel container with header, viewport, status, and aspect-ratio anatomy."
+    },
+    {
       "name": "badge",
       "type": "registry:ui",
       "title": "Badge",
       "description": "Inline status badge with UI variant styling hooks."
+    },
+    {
+      "name": "copy-button",
+      "type": "registry:ui",
+      "title": "CopyButton",
+      "description": "Accessible Solid button for copying text with copied and error state."
     },
     {
       "name": "separator",
@@ -356,6 +428,12 @@
       "type": "registry:ui",
       "title": "NavigationMenu",
       "description": "Styled Solid navigation menu backed by Keystone menu navigation, typeahead, and overlay behavior."
+    },
+    {
+      "name": "breadcrumb",
+      "type": "registry:ui",
+      "title": "Breadcrumb",
+      "description": "Source-owned Solid breadcrumb navigation for docs, app routes, and dense topbar composition."
     },
     {
       "name": "toast",


### PR DESCRIPTION
## Summary

Adds source-owned UI registry items for the docs-foundation/app-shell surface and a realtime DataTable block, with matching registry metadata, focused tests, and agent vertical notes.

This keeps the new surfaces in UI/Mason source rather than Core primitives.

## Core changes

- Added UI source for AppShell, Topbar, NavList, Sidebar, Frame, Group, Breadcrumb, SearchInput, CodeBlock, and CopyButton.
- Added UI hooks for `useMediaQuery` and `useCopyToClipboard`.
- Added a TanStack-backed realtime data table block with stable row IDs, update controls, loading and empty states, and DataTable composition.
- Added registry item metadata for the new components, hooks, and block, and updated the default registry index.
- Expanded Mason registry validation coverage for new default items and source contracts.
- Updated the end-state inventory and added vertical notes for the new UI surfaces.

## Behavior / invariants

- Clipboard and media-query behavior remains UI-owned generated source, not Core behavior.
- Sidebar visual source composes `sidebar-store`; app-shell layout state stays in UI/app source.
- Realtime table behavior builds on the existing TanStack DataTable source kit instead of adding a custom table engine.

## Known limitations

- These are source registry items, not docs-app pages.
- Mobile sidebar focus trapping and dismissal remain app composition concerns unless a future Core overlay need is explicitly identified.
- CodeBlock does not include syntax highlighting or markdown parsing.

## Validation

- `bun run check`
- `bun run check-types`
- `bun --filter @keystone-ui/mason-registry test`
- `bun --filter @keystone-ui/ui test`
- `bun run verify:example-app`
- `bun run verify:release`
