### PR TITLE
Refine accordion transitions and docs rendering

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -3,8 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="icon" href="/favicon.ico" />
-    <meta name="theme-color" content="#000000" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="theme-color" content="#FAF9F5" />
   </head>
   <body>
     <div id="app"></div>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,8 +19,11 @@
     "@tanstack/solid-router": "^1.168.20",
     "@tanstack/solid-router-devtools": "^1.166.13",
     "@tanstack/solid-start": "^1.167.58",
+    "clsx": "^2.1.1",
     "lucide-solid": "^1.8.0",
+    "shiki": "^4.0.2",
     "solid-js": "^1.9.12",
+    "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {

--- a/apps/web/public/favicon.svg
+++ b/apps/web/public/favicon.svg
@@ -1,5 +1,8 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <rect width="64" height="64" fill="#17201c"/>
-  <path d="M16 18h32v8H16zM16 30h32v8H16zM16 42h32v8H16z" fill="#fff8e9"/>
-  <path d="M20 22h24M20 34h24M20 46h24" stroke="#c94638" stroke-width="3"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Keystone favicon">
+  <rect x="0" y="0" width="64" height="64" rx="14" fill="#FAF9F5" />
+  <path
+    fill="#111111"
+    transform="translate(32 32) scale(1.12) translate(-32 -32)"
+    d="M12 14h40L41 50H23L12 14z"
+  />
 </svg>

--- a/apps/web/public/site.webmanifest
+++ b/apps/web/public/site.webmanifest
@@ -1,0 +1,14 @@
+{
+  "name": "Keystone",
+  "short_name": "Keystone",
+  "icons": [
+    {
+      "src": "/favicon.svg",
+      "sizes": "64x64",
+      "type": "image/svg+xml"
+    }
+  ],
+  "theme_color": "#FAF9F5",
+  "background_color": "#FAF9F5",
+  "display": "standalone"
+}

--- a/apps/web/src/components/component-preview.tsx
+++ b/apps/web/src/components/component-preview.tsx
@@ -26,6 +26,24 @@ import { Input } from "@keystone-ui/ui/default/ui/input.tsx";
 import { Badge } from "@/components/docs-shell";
 import type { RegistryDocItem } from "@/lib/registry-docs.gen";
 
+const accordionItems = [
+  {
+    content: "Keystone UI is source-owned Solid component source backed by Core behavior.",
+    id: "item-1",
+    title: "What is Keystone UI?",
+  },
+  {
+    content: "Install components with Mason, then edit the generated source in your app.",
+    id: "item-2",
+    title: "How do I get started?",
+  },
+  {
+    content: "Yes. The wrappers keep behavior in Core and styling in the UI layer.",
+    id: "item-3",
+    title: "Can I use it for my project?",
+  },
+];
+
 export function ComponentPreview(props: Readonly<{ item: RegistryDocItem }>) {
   return (
     <div class="overflow-hidden rounded-lg border border-border bg-card shadow-xs">
@@ -37,24 +55,12 @@ export function ComponentPreview(props: Readonly<{ item: RegistryDocItem }>) {
         <Switch fallback={<GenericPreview item={props.item} />}>
           <Match when={props.item.name === "accordion"}>
             <Accordion defaultValue={["item-3"]} class="w-full max-w-md">
-              <AccordionItem value="item-1">
-                <AccordionTrigger>What is Keystone UI?</AccordionTrigger>
-                <AccordionContent>
-                  Keystone UI is source-owned Solid component source backed by Core behavior.
-                </AccordionContent>
-              </AccordionItem>
-              <AccordionItem value="item-2">
-                <AccordionTrigger>How do I get started?</AccordionTrigger>
-                <AccordionContent>
-                  Install components with Mason, then edit the generated source in your app.
-                </AccordionContent>
-              </AccordionItem>
-              <AccordionItem value="item-3">
-                <AccordionTrigger>Can I use it for my project?</AccordionTrigger>
-                <AccordionContent>
-                  Yes. The wrappers keep behavior in Core and styling in the UI layer.
-                </AccordionContent>
-              </AccordionItem>
+              {accordionItems.map((item) => (
+                <AccordionItem value={item.id}>
+                  <AccordionTrigger>{item.title}</AccordionTrigger>
+                  <AccordionContent>{item.content}</AccordionContent>
+                </AccordionItem>
+              ))}
             </Accordion>
           </Match>
           <Match when={props.item.name === "button"}>

--- a/apps/web/src/components/docs-shell.tsx
+++ b/apps/web/src/components/docs-shell.tsx
@@ -1,5 +1,6 @@
 import { Check, ChevronDown, Clipboard, FileText, Menu, Package, X } from "lucide-solid";
-import { createSignal, For, type JSX, Show, splitProps } from "solid-js";
+import { codeToHtml, type ShikiTransformer } from "shiki";
+import { createResource, createSignal, For, type JSX, Show, splitProps } from "solid-js";
 import { useRouterState } from "@tanstack/solid-router";
 
 import {
@@ -138,6 +139,14 @@ export function CodeBlock(
     title?: string;
   }>,
 ) {
+  const [highlightedCode] = createResource(
+    () => `${props.language}\u0000${props.code}`,
+    async (key) => {
+      const separator = key.indexOf("\u0000");
+      return highlightCode(key.slice(separator + 1), key.slice(0, separator));
+    },
+  );
+
   return (
     <figure data-rehype-pretty-code-figure="">
       <Show when={props.title}>
@@ -153,84 +162,43 @@ export function CodeBlock(
       <Show when={props.copy ?? true}>
         <CopyButton value={props.code} />
       </Show>
-      <pre class="m-0 max-h-[450px] overflow-auto p-4 font-mono text-[13px] leading-snug">
-        <code data-line-numbers="">
-          <HighlightedCode code={props.code} language={props.language} lineNumbers />
-        </code>
-      </pre>
+      <Show when={highlightedCode()}>{(html) => <div class="contents" innerHTML={html()} />}</Show>
     </figure>
   );
 }
 
-function HighlightedCode(
-  props: Readonly<{ code: string; language: string; lineNumbers?: boolean }>,
-) {
-  const lines = () => props.code.split("\n");
+const highlightedCodeCache = new Map<string, Promise<string>>();
 
-  return (
-    <For each={lines()}>
-      {(line, index) => (
-        <>
-          <span data-line={props.lineNumbers ? "" : undefined}>
-            <For each={highlightLine(line, props.language)}>
-              {(token) => <span style={token.style}>{token.value}</span>}
-            </For>
-          </span>
-          <Show when={index() < lines().length - 1}>{"\n"}</Show>
-        </>
-      )}
-    </For>
-  );
+function highlightCode(code: string, language: string) {
+  const key = `${language}\u0000${code}`;
+  const cached = highlightedCodeCache.get(key);
+  if (cached) return cached;
+
+  const highlighted = codeToHtml(code, {
+    lang: language,
+    themes: {
+      dark: "github-dark",
+      light: "github-light",
+    },
+    transformers: [codeBlockTransformer],
+  });
+
+  highlightedCodeCache.set(key, highlighted);
+  return highlighted;
 }
 
-type HighlightToken = {
-  style?: JSX.CSSProperties;
-  value: string;
+const codeBlockTransformer: ShikiTransformer = {
+  code(node) {
+    node.properties["data-line-numbers"] = "";
+  },
+  line(node) {
+    node.properties["data-line"] = "";
+  },
+  pre(node) {
+    node.properties.class =
+      "m-0 max-h-[450px] min-w-0 w-max overflow-auto px-4 py-3.5 font-mono text-[.8125rem] leading-snug outline-none has-data-[highlighted-line]:px-0 has-data-[line-numbers]:ps-0 !bg-transparent";
+  },
 };
-
-function highlightLine(line: string, language: string): HighlightToken[] {
-  const tokens: HighlightToken[] = [];
-  const pattern =
-    language === "shell" || language === "bash"
-      ? /(\s+|#.*|--[\w-]+|"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|\b(?:bunx|bun|npm|npx|pnpm|yarn|mason|add|cp)\b|[^\s]+)/g
-      : /(\s+|\/\/.*|"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|`(?:[^`\\]|\\.)*`|<\/?[A-Z][\w.]*|<\/?[a-z][\w.-]*|\b(?:import|from|const|let|return|function|export|type|true|false|undefined)\b|\b[A-Z][\w.]*\b|[{}()[\].,;:=<>/]|[^\s{}()[\].,;:=<>/]+)/g;
-
-  for (const match of line.matchAll(pattern)) {
-    const value = match[0];
-    tokens.push({ value, style: highlightStyle(value, language) });
-  }
-
-  return tokens;
-}
-
-function highlightStyle(value: string, language: string): JSX.CSSProperties | undefined {
-  if (/^\s+$/.test(value)) return undefined;
-  if (value.startsWith("#") || value.startsWith("//")) return shiki("#6a737d", "#8b949e");
-  if (/^["'`]/.test(value)) return shiki("#032f62", "#a5d6ff");
-  if (language === "shell" || language === "bash") {
-    if (value.startsWith("--")) return shiki("#005cc5", "#79c0ff");
-    if (/^(bunx|bun|npm|npx|pnpm|yarn|mason|add|cp)$/.test(value)) {
-      return shiki("#d73a49", "#ff7b72");
-    }
-    return undefined;
-  }
-  if (/^(import|from|const|let|return|function|export|type|true|false|undefined)$/.test(value)) {
-    return shiki("#d73a49", "#ff7b72");
-  }
-  if (/^<\/?[A-Z]/.test(value) || /^[A-Z][\w.]*$/.test(value)) {
-    return shiki("#6f42c1", "#d2a8ff");
-  }
-  if (/^<\/?[a-z]/.test(value)) return shiki("#22863a", "#7ee787");
-  if (/^[{}()[\].,;:=<>/]$/.test(value)) return shiki("#24292e", "#c9d1d9");
-  return undefined;
-}
-
-function shiki(light: string, dark: string): JSX.CSSProperties {
-  return {
-    "--shiki-light": light,
-    "--shiki-dark": dark,
-  } as JSX.CSSProperties;
-}
 
 export function MobileNav(props: Readonly<{ groups: readonly NavGroup[] }>) {
   const [open, setOpen] = createSignal(false);
@@ -364,7 +332,7 @@ export function DocsSidebar(props: Readonly<{ groups: readonly NavGroup[] }>) {
   const pathname = useRouterState({ select: (state) => state.location.pathname });
   const isActive = (href: string) => {
     const path = href.split("#")[0] || "/docs";
-    return pathname() === path || (pathname() === "/" && path === "/docs");
+    return pathname() === path;
   };
 
   return (

--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -17,7 +17,7 @@ export default function Header() {
 
   return (
     <header class="sticky top-0 z-40 w-full bg-sidebar/80 backdrop-blur-sm before:absolute before:inset-x-0 before:bottom-0 before:h-px before:bg-border/64">
-      <div class="relative mx-auto flex h-(--header-height) w-full max-w-[1416px] items-center justify-between gap-2 px-4 sm:px-6">
+      <div class="relative mx-auto flex h-(--header-height) w-full max-w-[1416px] items-center justify-between gap-2 px-4 lg:px-6">
         <div class="flex min-w-0 items-center gap-2">
           <MobileNav groups={navGroups} />
           <Link to="/docs" class="flex min-w-0 items-center gap-2.5" aria-label="Keystone UI home">

--- a/apps/web/src/components/registry-doc-page.tsx
+++ b/apps/web/src/components/registry-doc-page.tsx
@@ -64,6 +64,7 @@ import {
 } from "@/docs/examples/accordion";
 
 type CodeExample = {
+  align?: PreviewAlign;
   code: string;
   description: string;
   id: string;
@@ -78,6 +79,7 @@ type ApiReferenceItem = {
 };
 
 type PreviewVariant = "centered" | "dense" | "full" | "inline";
+type PreviewAlign = "center" | "end" | "start";
 
 type ComponentDocsBlueprint = {
   apiItems?: readonly ApiReferenceItem[];
@@ -89,6 +91,7 @@ type ComponentDocsBlueprint = {
   heroVariant?: PreviewVariant;
   keyboardInteractions?: readonly string[];
   maturity?: string;
+  previewAlign?: PreviewAlign;
   usageCode: string;
   cssVariables?: readonly (readonly [string, string])[];
 };
@@ -597,13 +600,9 @@ function RegistryDocContent(
           </div>
         </PageHeader>
 
-        <DocSection
-          id="preview"
-          title="Preview"
-          description="Interactive example from the shipped component source."
-        >
+        <section id="preview" class="mt-8 scroll-mt-24">
           <HeroPreviewSection item={props.item} docsBlueprint={props.docsBlueprint} />
-        </DocSection>
+        </section>
 
         <DocSection
           id="installation"
@@ -643,6 +642,7 @@ function RegistryDocContent(
                     <PreviewCodeTabs
                       preview={example.preview}
                       code={example.code}
+                      align={example.align ?? props.docsBlueprint.previewAlign}
                       variant={example.variant ?? props.docsBlueprint.heroVariant ?? "centered"}
                     />
                   </article>
@@ -924,28 +924,35 @@ function HeroPreviewSection(
     <PreviewCodeTabs
       preview={() => heroExample().preview()}
       code={firstCode()}
+      align={heroExample().align ?? props.docsBlueprint.previewAlign}
       variant={heroExample().variant ?? props.docsBlueprint.heroVariant ?? "centered"}
     />
   );
 }
 
 function PreviewCodeTabs(
-  props: Readonly<{ preview: () => JSX.Element; code: string; variant?: PreviewVariant }>,
+  props: Readonly<{
+    align?: PreviewAlign;
+    preview: () => JSX.Element;
+    code: string;
+    variant?: PreviewVariant;
+  }>,
 ) {
   const [tab, setTab] = createSignal<"preview" | "code">("preview");
   const selectTab = (value: string) => {
     if (value === "preview" || value === "code") setTab(value);
   };
+  const align = () => props.align ?? "start";
 
   return (
     <div class="group relative mt-4 mb-12 flex flex-col gap-2">
       <Tabs onValueChange={selectTab} value={tab()}>
         <div class="flex items-center justify-between">
           <TabsList class="bg-transparent! p-0! *:data-[slot=tab-indicator]:rounded-lg *:data-[slot=tab-indicator]:bg-accent *:data-[slot=tab-indicator]:shadow-none">
-            <TabsTrigger class="rounded-lg data-selected:text-accent-foreground" value="preview">
+            <TabsTrigger class="rounded-lg" value="preview">
               Preview
             </TabsTrigger>
-            <TabsTrigger class="rounded-lg data-selected:text-accent-foreground" value="code">
+            <TabsTrigger class="rounded-lg" value="code">
               Code
             </TabsTrigger>
           </TabsList>
@@ -954,10 +961,13 @@ function PreviewCodeTabs(
       <div class="relative rounded-xl border not-dark:bg-card" data-tab={tab()}>
         <div class="invisible data-[active=true]:visible" data-active={tab() === "preview"}>
           <div
-            class="flex h-[450px] w-full justify-center overflow-y-auto p-10 data-[align=center]:items-center data-[align=end]:items-end data-[align=start]:items-start max-sm:px-6"
-            data-align="center"
+            class="flex h-[450px] w-full justify-center overflow-y-auto p-10 data-[align=start]:items-start data-[align=end]:items-end data-[align=center]:items-center max-sm:px-6"
+            data-align={align()}
           >
-            <div class={previewFrameClass(props.variant ?? "centered")} data-slot="preview">
+            <div
+              class={previewFrameClass(props.variant ?? "centered", align())}
+              data-slot="preview"
+            >
               {props.preview()}
             </div>
           </div>
@@ -1020,17 +1030,29 @@ function ApiReference(props: Readonly<{ items: readonly ApiReferenceItem[] }>) {
   );
 }
 
-function previewFrameClass(variant: PreviewVariant) {
+function previewFrameClass(variant: PreviewVariant, align: PreviewAlign) {
   const base = "flex w-full justify-center";
+  const aligned = `${base} ${previewFrameAlignClass(align)}`;
   switch (variant) {
     case "inline":
-      return `${base} items-center`;
+      return aligned;
     case "full":
       return `${base} items-stretch`;
     case "dense":
       return `${base} items-stretch`;
     case "centered":
-      return `${base} items-center`;
+      return aligned;
+  }
+}
+
+function previewFrameAlignClass(align: PreviewAlign) {
+  switch (align) {
+    case "center":
+      return "items-center";
+    case "end":
+      return "items-end";
+    case "start":
+      return "items-start";
   }
 }
 

--- a/apps/web/src/docs/examples/accordion.tsx
+++ b/apps/web/src/docs/examples/accordion.tsx
@@ -51,27 +51,34 @@ import {
   TooltipTrigger,
 } from "@keystone-ui/ui/default/ui/tooltip.tsx";
 
+const accordionItems = [
+  {
+    content:
+      "Keystone UI is a source-owned Solid component system for design systems and web apps.",
+    id: "item-1",
+    title: "What is Keystone UI?",
+  },
+  {
+    content: "Install components with Mason, then own the generated source in your application.",
+    id: "item-2",
+    title: "How do I get started?",
+  },
+  {
+    content: "Yes. Components are copy-paste source backed by Keystone Core.",
+    id: "item-3",
+    title: "Can I use it for my project?",
+  },
+];
+
 export function SingleAccordionExample() {
   return (
     <Accordion defaultValue={["item-3"]} class="w-full">
-      <AccordionItem value="item-1">
-        <AccordionTrigger>What is Keystone UI?</AccordionTrigger>
-        <AccordionContent>
-          Keystone UI is a source-owned Solid component system for design systems and web apps.
-        </AccordionContent>
-      </AccordionItem>
-      <AccordionItem value="item-2">
-        <AccordionTrigger>How do I get started?</AccordionTrigger>
-        <AccordionContent>
-          Install components with Mason, then own the generated source in your application.
-        </AccordionContent>
-      </AccordionItem>
-      <AccordionItem value="item-3">
-        <AccordionTrigger>Can I use it for my project?</AccordionTrigger>
-        <AccordionContent>
-          Yes. Components are copy-paste source backed by Keystone Core.
-        </AccordionContent>
-      </AccordionItem>
+      {accordionItems.map((item) => (
+        <AccordionItem value={item.id}>
+          <AccordionTrigger>{item.title}</AccordionTrigger>
+          <AccordionContent>{item.content}</AccordionContent>
+        </AccordionItem>
+      ))}
     </Accordion>
   );
 }
@@ -156,20 +163,45 @@ export function DisabledItemAccordionExample() {
   );
 }
 
-export const singleAccordionCode = `<Accordion defaultValue={["item-3"]} class="w-full">
-  <AccordionItem value="item-1">
-    <AccordionTrigger>What is Keystone UI?</AccordionTrigger>
-    <AccordionContent>Keystone UI is a source-owned Solid component system for design systems and web apps.</AccordionContent>
-  </AccordionItem>
-  <AccordionItem value="item-2">
-    <AccordionTrigger>How do I get started?</AccordionTrigger>
-    <AccordionContent>Install components with Mason, then own the generated source in your application.</AccordionContent>
-  </AccordionItem>
-  <AccordionItem value="item-3">
-    <AccordionTrigger>Can I use it for my project?</AccordionTrigger>
-    <AccordionContent>Yes. Components are copy-paste source backed by Keystone Core.</AccordionContent>
-  </AccordionItem>
-</Accordion>`;
+export const singleAccordionCode = `import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+
+export default function Component() {
+  const items = [
+    {
+      content:
+        "Keystone UI is a source-owned Solid component system for design systems and web apps.",
+      id: "item-1",
+      title: "What is Keystone UI?",
+    },
+    {
+      content:
+        "Install components with Mason, then own the generated source in your application.",
+      id: "item-2",
+      title: "How do I get started?",
+    },
+    {
+      content: "Yes. Components are copy-paste source backed by Keystone Core.",
+      id: "item-3",
+      title: "Can I use it for my project?",
+    },
+  ];
+
+  return (
+    <Accordion defaultValue={["item-3"]} class="w-full">
+      {items.map((item) => (
+        <AccordionItem value={item.id}>
+          <AccordionTrigger>{item.title}</AccordionTrigger>
+          <AccordionContent>{item.content}</AccordionContent>
+        </AccordionItem>
+      ))}
+    </Accordion>
+  );
+}`;
 
 export const multipleAccordionCode = `<Accordion defaultValue={["item-1", "item-2"]} class="w-full" multiple>
   <AccordionItem value="item-1">

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -1,0 +1,40 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}
+
+export const seo = ({
+  title,
+  description,
+  keywords,
+  image,
+}: {
+  title: string;
+  description?: string;
+  image?: string;
+  keywords?: string;
+}) => {
+  const tags = [
+    { title },
+    { name: "description", content: description },
+    { name: "keywords", content: keywords },
+    { name: "twitter:title", content: title },
+    { name: "twitter:description", content: description },
+    { name: "twitter:creator", content: "@erik_drastic" },
+    { name: "twitter:site", content: "@erik_drastic" },
+    { name: "og:type", content: "website" },
+    { name: "og:title", content: title },
+    { name: "og:description", content: description },
+    ...(image
+      ? [
+          { name: "twitter:image", content: image },
+          { name: "twitter:card", content: "summary_large_image" },
+          { name: "og:image", content: image },
+        ]
+      : []),
+  ];
+
+  return tags;
+};

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -6,27 +6,54 @@ import { Suspense } from "solid-js";
 import { HydrationScript } from "solid-js/web";
 
 import Header from "@/components/header";
+import { seo } from "@/lib/utils";
 import stylesUrl from "@/styles.css?url";
 
 export interface RouterContext {}
 
 export const Route = createRootRouteWithContext<RouterContext>()({
+  component: RootComponent,
   head: () => ({
-    links: [{ rel: "stylesheet", href: stylesUrl }],
     meta: [
-      { charSet: "utf-8" },
-      { name: "viewport", content: "width=device-width, initial-scale=1" },
-      { title: "Keystone UI" },
-      { rel: "icon", href: "/favicon.svg" },
+      {
+        charSet: "utf-8",
+      },
+      {
+        name: "viewport",
+        content: "width=device-width, initial-scale=1",
+      },
+      ...seo({
+        title: "Keystone",
+        description: "Keystone UI",
+      }),
+    ],
+    links: [
+      { rel: "stylesheet", href: stylesUrl },
+      {
+        rel: "icon",
+        type: "image/svg+xml",
+        href: "/favicon.svg",
+      },
+      {
+        rel: "manifest",
+        href: "/site.webmanifest",
+      },
     ],
   }),
-  component: RootComponent,
 });
 
 function RootComponent() {
   return (
     <RootDocument>
-      <div class="min-h-svh">
+      <div class="relative isolate flex min-h-svh flex-col overflow-clip bg-sidebar text-foreground [--header-height:4rem]">
+        <div
+          aria-hidden="true"
+          class="pointer-events-none absolute inset-0 z-45 mx-auto hidden w-full max-w-[1416px] px-4 before:absolute before:inset-y-0 before:-left-3 before:w-px before:bg-border/64 after:absolute after:inset-y-0 after:-right-3 after:w-px after:bg-border/64 lg:block lg:px-6"
+        />
+        <div
+          aria-hidden="true"
+          class="pointer-events-none fixed inset-0 z-45 mx-auto hidden w-full max-w-[1416px] px-4 before:absolute before:top-[calc(var(--header-height)-4.5px)] before:-left-[11.5px] before:z-1 before:-ml-1 before:size-2 before:rounded-[2px] before:border before:border-border before:bg-popover before:bg-clip-padding before:shadow-xs/5 after:absolute after:top-[calc(var(--header-height)-4.5px)] after:-right-[11.5px] after:z-1 after:-mr-1 after:size-2 after:rounded-[2px] after:border after:border-border after:bg-background after:bg-clip-padding after:shadow-xs/5 dark:before:bg-clip-border dark:after:bg-clip-border lg:block lg:px-6"
+        />
         <Header />
         <Outlet />
       </div>

--- a/bun.lock
+++ b/bun.lock
@@ -24,8 +24,11 @@
         "@tanstack/solid-router": "^1.168.20",
         "@tanstack/solid-router-devtools": "^1.166.13",
         "@tanstack/solid-start": "^1.167.58",
+        "clsx": "^2.1.1",
         "lucide-solid": "^1.8.0",
+        "shiki": "^4.0.2",
         "solid-js": "^1.9.12",
+        "tailwind-merge": "^3.5.0",
         "tailwindcss": "^4.2.2",
       },
       "devDependencies": {
@@ -330,6 +333,22 @@
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.17", "", {}, "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg=="],
 
+    "@shikijs/core": ["@shikijs/core@4.0.2", "", { "dependencies": { "@shikijs/primitive": "4.0.2", "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw=="],
+
+    "@shikijs/engine-javascript": ["@shikijs/engine-javascript@4.0.2", "", { "dependencies": { "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.4" } }, "sha512-7PW0Nm49DcoUIQEXlJhNNBHyoGMjalRETTCcjMqEaMoJRLljy1Bi/EGV3/qLBgLKQejdspiiYuHGQW6dX94Nag=="],
+
+    "@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@4.0.2", "", { "dependencies": { "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-UpCB9Y2sUKlS9z8juFSKz7ZtysmeXCgnRF0dlhXBkmQnek7lAToPte8DkxmEYGNTMii72zU/lyXiCB6StuZeJg=="],
+
+    "@shikijs/langs": ["@shikijs/langs@4.0.2", "", { "dependencies": { "@shikijs/types": "4.0.2" } }, "sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg=="],
+
+    "@shikijs/primitive": ["@shikijs/primitive@4.0.2", "", { "dependencies": { "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-M6UMPrSa3fN5ayeJwFVl9qWofl273wtK1VG8ySDZ1mQBfhCpdd8nEx7nPZ/tk7k+TYcpqBZzj/AnwxT9lO+HJw=="],
+
+    "@shikijs/themes": ["@shikijs/themes@4.0.2", "", { "dependencies": { "@shikijs/types": "4.0.2" } }, "sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA=="],
+
+    "@shikijs/types": ["@shikijs/types@4.0.2", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg=="],
+
+    "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
+
     "@solid-devtools/debugger": ["@solid-devtools/debugger@0.28.1", "", { "dependencies": { "@nothing-but/utils": "~0.17.0", "@solid-devtools/shared": "^0.20.0", "@solid-primitives/bounds": "^0.1.1", "@solid-primitives/event-listener": "^2.4.1", "@solid-primitives/keyboard": "^1.3.1", "@solid-primitives/rootless": "^1.5.1", "@solid-primitives/scheduled": "^1.5.1", "@solid-primitives/static-store": "^0.1.1", "@solid-primitives/utils": "^6.3.1" }, "peerDependencies": { "solid-js": "^1.9.0" } }, "sha512-6qIUI6VYkXoRnL8oF5bvh2KgH71qlJ18hNw/mwSyY6v48eb80ZR48/5PDXufUa3q+MBSuYa1uqTMwLewpay9eg=="],
 
     "@solid-devtools/logger": ["@solid-devtools/logger@0.9.11", "", { "dependencies": { "@nothing-but/utils": "~0.17.0", "@solid-devtools/debugger": "^0.28.1", "@solid-devtools/shared": "^0.20.0", "@solid-primitives/utils": "^6.3.1" }, "peerDependencies": { "solid-js": "^1.9.0" } }, "sha512-THbiY1iQlieL6vdgJc4FIsLe7V8a57hod/Thm8zdKrTkWL88UPZjkBBfM+mVNGusd4OCnAN20tIFBhNnuT1Dew=="],
@@ -478,11 +497,19 @@
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
+    "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
+
+    "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
+
     "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
+    "@ungap/structured-clone": ["@ungap/structured-clone@1.3.1", "", {}, "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ=="],
 
     "@vitest/expect": ["@vitest/expect@4.1.5", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.5", "@vitest/utils": "4.1.5", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw=="],
 
@@ -526,7 +553,13 @@
 
     "caniuse-lite": ["caniuse-lite@1.0.30001791", "", {}, "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ=="],
 
+    "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
+
     "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
+
+    "character-entities-html4": ["character-entities-html4@2.1.0", "", {}, "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="],
+
+    "character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
 
     "cheerio": ["cheerio@1.2.0", "", { "dependencies": { "cheerio-select": "^2.1.0", "dom-serializer": "^2.0.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "encoding-sniffer": "^0.2.1", "htmlparser2": "^10.1.0", "parse5": "^7.3.0", "parse5-htmlparser2-tree-adapter": "^7.1.0", "parse5-parser-stream": "^7.1.2", "undici": "^7.19.0", "whatwg-mimetype": "^4.0.0" } }, "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg=="],
 
@@ -535,6 +568,8 @@
     "chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
+
+    "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
@@ -550,7 +585,11 @@
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
     "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
 
@@ -602,7 +641,13 @@
 
     "happy-dom": ["happy-dom@20.9.0", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.18.3" } }, "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ=="],
 
+    "hast-util-to-html": ["hast-util-to-html@9.0.5", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-whitespace": "^3.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "stringify-entities": "^4.0.0", "zwitch": "^2.0.4" } }, "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw=="],
+
+    "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
+
     "html-entities": ["html-entities@2.3.3", "", {}, "sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA=="],
+
+    "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
 
     "htmlparser2": ["htmlparser2@10.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "entities": "^7.0.1" } }, "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ=="],
 
@@ -660,7 +705,19 @@
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
+    "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
+
     "merge-anything": ["merge-anything@5.1.7", "", { "dependencies": { "is-what": "^4.1.8" } }, "sha512-eRtbOb1N5iyH0tkQDAoQ4Ipsp/5qSR79Dzrz8hEPxRX10RWWR/iQXdoKmBSRCThY1Fh5EhISDtpSc93fpxUniQ=="],
+
+    "micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
+
+    "micromark-util-encode": ["micromark-util-encode@2.0.1", "", {}, "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw=="],
+
+    "micromark-util-sanitize-uri": ["micromark-util-sanitize-uri@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ=="],
+
+    "micromark-util-symbol": ["micromark-util-symbol@2.0.1", "", {}, "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="],
+
+    "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
@@ -673,6 +730,10 @@
     "nth-check": ["nth-check@2.1.1", "", { "dependencies": { "boolbase": "^1.0.0" } }, "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="],
 
     "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
+
+    "oniguruma-parser": ["oniguruma-parser@0.12.2", "", {}, "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw=="],
+
+    "oniguruma-to-es": ["oniguruma-to-es@4.3.6", "", { "dependencies": { "oniguruma-parser": "^0.12.2", "regex": "^6.1.0", "regex-recursion": "^6.0.2" } }, "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA=="],
 
     "oxfmt": ["oxfmt@0.46.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.46.0", "@oxfmt/binding-android-arm64": "0.46.0", "@oxfmt/binding-darwin-arm64": "0.46.0", "@oxfmt/binding-darwin-x64": "0.46.0", "@oxfmt/binding-freebsd-x64": "0.46.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.46.0", "@oxfmt/binding-linux-arm-musleabihf": "0.46.0", "@oxfmt/binding-linux-arm64-gnu": "0.46.0", "@oxfmt/binding-linux-arm64-musl": "0.46.0", "@oxfmt/binding-linux-ppc64-gnu": "0.46.0", "@oxfmt/binding-linux-riscv64-gnu": "0.46.0", "@oxfmt/binding-linux-riscv64-musl": "0.46.0", "@oxfmt/binding-linux-s390x-gnu": "0.46.0", "@oxfmt/binding-linux-x64-gnu": "0.46.0", "@oxfmt/binding-linux-x64-musl": "0.46.0", "@oxfmt/binding-openharmony-arm64": "0.46.0", "@oxfmt/binding-win32-arm64-msvc": "0.46.0", "@oxfmt/binding-win32-ia32-msvc": "0.46.0", "@oxfmt/binding-win32-x64-msvc": "0.46.0" }, "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-CopwJOwPAjZ9p76fCvz+mSOJTw9/NY3cSksZK3VO/bUQ8UoEcketNgUuYS0UB3p+R9XnXe7wGGXUmyFxc7QxJA=="],
 
@@ -694,11 +755,19 @@
 
     "prettier": ["prettier@3.8.3", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw=="],
 
+    "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
+
     "react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
 
     "react-dom": ["react-dom@19.2.5", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.5" } }, "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag=="],
 
     "readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
+
+    "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
+
+    "regex-recursion": ["regex-recursion@6.0.2", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg=="],
+
+    "regex-utilities": ["regex-utilities@2.3.0", "", {}, "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="],
 
     "rolldown": ["rolldown@1.0.0-rc.17", "", { "dependencies": { "@oxc-project/types": "=0.127.0", "@rolldown/pluginutils": "1.0.0-rc.17" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.17", "@rolldown/binding-darwin-arm64": "1.0.0-rc.17", "@rolldown/binding-darwin-x64": "1.0.0-rc.17", "@rolldown/binding-freebsd-x64": "1.0.0-rc.17", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA=="],
 
@@ -714,6 +783,8 @@
 
     "seroval-plugins": ["seroval-plugins@1.5.2", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-qpY0Cl+fKYFn4GOf3cMiq6l72CpuVaawb6ILjubOQ+diJ54LfOWaSSPsaswN8DRPIPW4Yq+tE1k5aKd7ILyaFg=="],
 
+    "shiki": ["shiki@4.0.2", "", { "dependencies": { "@shikijs/core": "4.0.2", "@shikijs/engine-javascript": "4.0.2", "@shikijs/engine-oniguruma": "4.0.2", "@shikijs/langs": "4.0.2", "@shikijs/themes": "4.0.2", "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ=="],
+
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
 
     "solid-js": ["solid-js@1.9.12", "", { "dependencies": { "csstype": "^3.1.0", "seroval": "~1.5.0", "seroval-plugins": "~1.5.0" } }, "sha512-QzKaSJq2/iDrWR1As6MHZQ8fQkdOBf8GReYb7L5iKwMGceg7HxDcaOHk0at66tNgn9U2U7dXo8ZZpLIAmGMzgw=="],
@@ -724,11 +795,17 @@
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
+    "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
+
     "srvx": ["srvx@0.11.15", "", { "bin": { "srvx": "bin/srvx.mjs" } }, "sha512-iXsux0UcOjdvs0LCMa2Ws3WwcDUozA3JN3BquNXkaFPP7TpRqgunKdEgoZ/uwb1J6xaYHfxtz9Twlh6yzwM6Tg=="],
 
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
 
     "std-env": ["std-env@4.1.0", "", {}, "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ=="],
+
+    "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
+
+    "tailwind-merge": ["tailwind-merge@3.5.0", "", {}, "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A=="],
 
     "tailwindcss": ["tailwindcss@4.2.4", "", {}, "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA=="],
 
@@ -746,6 +823,8 @@
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
+    "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
+
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "turbo": ["turbo@2.9.8", "", { "optionalDependencies": { "@turbo/darwin-64": "2.9.8", "@turbo/darwin-arm64": "2.9.8", "@turbo/linux-64": "2.9.8", "@turbo/linux-arm64": "2.9.8", "@turbo/windows-64": "2.9.8", "@turbo/windows-arm64": "2.9.8" }, "bin": { "turbo": "bin/turbo" } }, "sha512-REEB2rVTVDTf4hav1gJ5dIsGylWZrNonvjXFtk1dCi8gND3PhZtnYkyry1bra/Fo+iP6ctTEZbg6vWfdfHq/1A=="],
@@ -758,11 +837,25 @@
 
     "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
+    "unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
+
+    "unist-util-position": ["unist-util-position@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA=="],
+
+    "unist-util-stringify-position": ["unist-util-stringify-position@4.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ=="],
+
+    "unist-util-visit": ["unist-util-visit@5.1.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg=="],
+
+    "unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
+
     "unplugin": ["unplugin@3.0.0", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "picomatch": "^4.0.3", "webpack-virtual-modules": "^0.6.2" } }, "sha512-0Mqk3AT2TZCXWKdcoaufeXNukv2mTrEZExeXlHIOZXdqYoHHr4n51pymnwV8x2BOVxwXbK2HLlI7usrqMpycdg=="],
 
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
+
+    "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
+
+    "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
     "vite": ["vite@8.0.10", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.10", "rolldown": "1.0.0-rc.17", "tinyglobby": "^0.2.16" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw=="],
 
@@ -791,6 +884,8 @@
     "yaml": ["yaml@2.8.4", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog=="],
 
     "zod": ["zod@4.4.2", "", {}, "sha512-IynmDyxsEsb9RKzO3J9+4SxXnl2FTFSzNBaKKaMV6tsSk0rw9gYw9gs+JFCq/qk2LCZ78KDwyj+Z289TijSkUw=="],
+
+    "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 

--- a/packages/core/src/accordion/index.tsx
+++ b/packages/core/src/accordion/index.tsx
@@ -341,6 +341,9 @@ function Content(props: AccordionContentProps) {
     ...others,
     hiddenUntilFound: local.hiddenUntilFound,
   });
+  // Accordion owns close presence so panels can animate before becoming hidden.
+  delete contentProps.hidden;
+  delete contentProps["attr:hidden"];
   const [present, setPresent] = createSignal(
     local.forceMount || local.hiddenUntilFound || item.open(),
   );
@@ -394,20 +397,31 @@ function Content(props: AccordionContentProps) {
     if (!present()) return;
 
     measurePanel();
-    setTransitionState("ending");
-    fallbackTimer = setTimeout(() => {
-      setPresent(false);
-      setTransitionState("idle");
-    }, ACCORDION_CONTENT_TRANSITION_MS);
+    setTransitionState("idle");
+    scheduleFrame(() => {
+      if (contentElement) void contentElement.offsetHeight;
+      setTransitionState("ending");
+      fallbackTimer = setTimeout(() => {
+        setPresent(false);
+        setTransitionState("idle");
+      }, ACCORDION_CONTENT_TRANSITION_MS);
+    });
   });
 
   onCleanup(clearTransitionWork);
 
   const hidden = () => {
     if (item.open() || transitionState() !== "idle") return undefined;
-    if (local.hiddenUntilFound) return undefined;
     return local.forceMount ? true : undefined;
   };
+  const hiddenUntilFound = () =>
+    !item.open() && transitionState() === "idle" && local.hiddenUntilFound
+      ? "until-found"
+      : undefined;
+  const visibilityProps = () => ({
+    hidden: hidden(),
+    "attr:hidden": hiddenUntilFound(),
+  });
   const contentStyle = () => {
     const heightVariable = { "--accordion-panel-height": `${panelHeight()}px` };
     if (typeof local.style === "string") {
@@ -425,9 +439,9 @@ function Content(props: AccordionContentProps) {
     <Show when={present()}>
       <div
         {...contentProps}
+        {...visibilityProps()}
         data-ending-style={transitionState() === "ending" ? "" : undefined}
         data-starting-style={transitionState() === "starting" ? "" : undefined}
-        hidden={hidden()}
         onTransitionEnd={(event) => {
           callEventHandler(local.onTransitionEnd, event);
           if (event.target !== contentElement || transitionState() !== "ending") return;

--- a/packages/core/test/disclosure.behavior.test.tsx
+++ b/packages/core/test/disclosure.behavior.test.tsx
@@ -1,8 +1,40 @@
 import { createRoot, createSignal } from "solid-js";
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { Accordion } from "../src/accordion/index";
 import { Collapsible, createCollapsible } from "../src/collapsible/index";
 import { click, getByPart, keyDown, queryByPart, render, settled } from "./harness";
+
+function stubAnimationFrames() {
+  const originalAnimationFrame = globalThis.requestAnimationFrame;
+  const originalCancelAnimationFrame = globalThis.cancelAnimationFrame;
+  const frames = new Map<number, FrameRequestCallback>();
+  let nextFrame = 1;
+
+  vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+    const frame = nextFrame;
+    nextFrame += 1;
+    frames.set(frame, callback);
+    return frame;
+  });
+  vi.stubGlobal("cancelAnimationFrame", (frame: number) => {
+    frames.delete(frame);
+  });
+
+  return {
+    flush: () => {
+      const callbacks = Array.from(frames.values());
+      frames.clear();
+      for (const callback of callbacks) {
+        callback(performance.now());
+      }
+    },
+    reset: () => frames.clear(),
+    restore: () => {
+      vi.stubGlobal("requestAnimationFrame", originalAnimationFrame);
+      vi.stubGlobal("cancelAnimationFrame", originalCancelAnimationFrame);
+    },
+  };
+}
 
 describe("Collapsible behavior", () => {
   test("toggles open state and exposes the core ARIA and part contract", async () => {
@@ -201,5 +233,107 @@ describe("Accordion behavior", () => {
     expect(reasons).toEqual(["browser-find"]);
     expect(trigger.getAttribute("aria-expanded")).toBe("true");
     expect(content.hasAttribute("hidden")).toBe(false);
+  });
+
+  test("keeps the previous single item visible while switching to another item", async () => {
+    const animationFrames = stubAnimationFrames();
+
+    try {
+      render(() => (
+        <Accordion.Root defaultValue={["account"]}>
+          <Accordion.Item value="account">
+            <Accordion.Header>
+              <Accordion.Trigger>Account</Accordion.Trigger>
+            </Accordion.Header>
+            <Accordion.Content>Account settings</Accordion.Content>
+          </Accordion.Item>
+          <Accordion.Item value="billing">
+            <Accordion.Header>
+              <Accordion.Trigger>Billing</Accordion.Trigger>
+            </Accordion.Header>
+            <Accordion.Content>Billing settings</Accordion.Content>
+          </Accordion.Item>
+        </Accordion.Root>
+      ));
+
+      animationFrames.reset();
+
+      const triggers = Array.from(
+        document.body.querySelectorAll<HTMLButtonElement>(
+          '[data-scope="accordion"][data-part="trigger"]',
+        ),
+      );
+      const accountContent = getByPart("accordion", "content");
+
+      click(triggers[1]);
+      await settled();
+
+      expect(triggers[0].getAttribute("aria-expanded")).toBe("false");
+      expect(triggers[1].getAttribute("aria-expanded")).toBe("true");
+      expect(queryByPart("accordion", "content")).toBe(accountContent);
+      expect(accountContent.getAttribute("data-state")).toBe("closed");
+      expect(accountContent.hasAttribute("hidden")).toBe(false);
+
+      animationFrames.flush();
+      await settled();
+
+      expect(accountContent.hasAttribute("data-ending-style")).toBe(true);
+      expect(accountContent.hasAttribute("hidden")).toBe(false);
+
+      accountContent.dispatchEvent(new Event("transitionend", { bubbles: true }));
+      await settled();
+
+      const contents = Array.from(
+        document.body.querySelectorAll<HTMLElement>(
+          '[data-scope="accordion"][data-part="content"]',
+        ),
+      );
+      expect(contents).toHaveLength(1);
+      expect(contents[0].textContent).toBe("Billing settings");
+    } finally {
+      animationFrames.restore();
+    }
+  });
+
+  test("keeps closing content visible while height animates to zero", async () => {
+    const animationFrames = stubAnimationFrames();
+
+    try {
+      render(() => (
+        <Accordion.Root defaultValue={["account"]}>
+          <Accordion.Item value="account">
+            <Accordion.Header>
+              <Accordion.Trigger>Account</Accordion.Trigger>
+            </Accordion.Header>
+            <Accordion.Content>Account settings</Accordion.Content>
+          </Accordion.Item>
+        </Accordion.Root>
+      ));
+
+      animationFrames.reset();
+
+      const trigger = getByPart("accordion", "trigger");
+      const content = getByPart("accordion", "content");
+
+      click(trigger);
+      await settled();
+
+      expect(trigger.getAttribute("aria-expanded")).toBe("false");
+      expect(queryByPart("accordion", "content")).toBe(content);
+      expect(content.hasAttribute("hidden")).toBe(false);
+
+      animationFrames.flush();
+      await settled();
+
+      expect(content.hasAttribute("data-ending-style")).toBe(true);
+      expect(content.hasAttribute("hidden")).toBe(false);
+
+      content.dispatchEvent(new Event("transitionend", { bubbles: true }));
+      await settled();
+
+      expect(queryByPart("accordion", "content")).toBeNull();
+    } finally {
+      animationFrames.restore();
+    }
   });
 });

--- a/packages/ui/src/default/ui/accordion.tsx
+++ b/packages/ui/src/default/ui/accordion.tsx
@@ -94,12 +94,9 @@ export function AccordionPanel(props: AccordionContentProps) {
     <CoreAccordion.Content
       {...rest}
       data-slot="accordion-panel"
-      class={cn(
-        "ui-accordion-panel h-(--accordion-panel-height) overflow-hidden text-muted-foreground text-sm transition-[height] duration-200 ease-in-out data-ending-style:h-0 data-starting-style:h-0",
-        local.class,
-      )}
+      class="ui-accordion-panel h-(--accordion-panel-height) overflow-hidden text-muted-foreground text-sm transition-[height] duration-200 ease-in-out data-ending-style:h-0 data-starting-style:h-0"
     >
-      <div data-scope="ui-accordion" data-part="content-inner" class="pt-0 pb-4">
+      <div data-scope="ui-accordion" data-part="content-inner" class={cn("pt-0 pb-4", local.class)}>
         {local.children}
       </div>
     </CoreAccordion.Content>


### PR DESCRIPTION
## Summary
Refactors accordion content teardown so a collapsing panel stays visible during its closing animation, including single-item switching behavior and a fallback for hidden-until-found visibility.

Migrates docs code rendering to Shiki with cached highlighting plus updated preview layout controls for alignment and better container behavior.

Adds shared app utilities for SEO metadata and class merging, updates header/root shell styling, favicon, manifest, and related docs metadata examples.

Updates accordion example/preview content to use item-driven rendering and adds coverage for new accordion transition behavior in disclosure tests.\n- Includes dependency lockfile updates for shiki, clsx, and tailwind-merge required by the docs and utility refactor.