### PR TITLE
[codex] Polish docs chrome and deploy command

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",
-    "deploy:production": "bun run build && bunx --bun wrangler@4 deploy",
+    "deploy": "bun run build && bunx --bun wrangler@4 deploy",
+    "deploy:production": "bun run deploy",
     "deploy:production:dry-run": "bun run build && bunx --bun wrangler@4 deploy --dry-run",
     "generate:registry-items": "bun ../../scripts/generate-docs-registry-items.ts",
     "serve": "vite preview",

--- a/apps/web/src/components/docs-command-search.tsx
+++ b/apps/web/src/components/docs-command-search.tsx
@@ -50,7 +50,7 @@ export function DocsCommandSearch() {
   return (
     <>
       <button
-        class="relative hidden h-9 w-fit cursor-pointer items-center justify-center gap-2 rounded-lg border border-input bg-popover px-[calc(--spacing(3)-1px)] text-foreground text-sm shadow-xs/5 outline-none transition-shadow before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-lg)-1px)] before:shadow-[0_1px_--theme(--color-black/4%)] hover:bg-accent/50 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background dark:bg-input/32 dark:before:shadow-[0_-1px_--theme(--color-white/6%)] dark:hover:bg-input/64 sm:h-8 md:inline-flex"
+        class="relative hidden h-9 w-fit min-w-52 cursor-text items-center justify-center rounded-full border border-border/80 bg-background px-3.5 text-foreground text-sm outline-none transition-[background-color,border-color,box-shadow] hover:border-border hover:bg-background focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/40 sm:h-8 md:inline-flex lg:min-w-72 dark:border-border/80 dark:bg-background/80 dark:hover:bg-background"
         aria-haspopup="dialog"
         aria-label="Search documentation"
         onFocus={ensureDialog}
@@ -58,14 +58,17 @@ export function DocsCommandSearch() {
         onClick={openDialog}
         type="button"
       >
-        <Search class="size-4 text-muted-foreground/80" aria-hidden="true" />
-        <span class="pointer-events-none inline-flex items-center gap-1" aria-hidden="true">
-          <span class="inline-flex size-4 select-none items-center justify-center rounded bg-muted font-medium text-[0.6875rem] text-muted-foreground leading-none">
-            ⌘
+        <span class="flex min-w-0 grow items-center gap-2">
+          <Search class="-ms-1 size-5 shrink-0 text-muted-foreground" aria-hidden="true" />
+          <span class="min-w-0 grow truncate text-left font-normal text-muted-foreground/70">
+            Quick search...
           </span>
-          <span class="inline-flex size-4 select-none items-center justify-center rounded bg-muted font-medium text-[0.6875rem] text-muted-foreground leading-none">
-            K
-          </span>
+        </span>
+        <span
+          class="pointer-events-none ml-3 inline-flex shrink-0 items-center justify-center font-medium text-muted-foreground text-xs"
+          aria-hidden="true"
+        >
+          <span class="opacity-70">⌘</span>K
         </span>
       </button>
       <Show when={open() ? DialogComponent() : undefined}>

--- a/apps/web/src/components/docs-overview.tsx
+++ b/apps/web/src/components/docs-overview.tsx
@@ -123,7 +123,7 @@ export function DocsOverview() {
         </section>
 
         <section id="own-your-code" class={sectionClass}>
-          <MdxH2 class={sectionHeadingClass}>Own Your Code</MdxH2>
+          <MdxH2 class={sectionHeadingClass}>Own your code</MdxH2>
           <MdxP class={proseClass}>
             Keystone follows the source-owned ethos of{" "}
             <strong class="font-medium text-foreground">shadcn/ui</strong>.
@@ -156,17 +156,16 @@ export function DocsOverview() {
           <MdxP class={proseClass}>
             Keystone source is meant to be{" "}
             <strong class="font-medium text-foreground">
-              read, reviewed, and changed
+              read, reviewed and changed.
             </strong>
-            . Components use explicit Solid code, stable data attributes,
-            predictable files, and registry metadata that records dependencies
-            and parity notes. That keeps the system legible as your team adapts
+            Components use explicit Solid code, stable data attributes and
+            predictable files. That keeps the system legible as your team adapts
             it over time.
           </MdxP>
         </section>
 
         <section id="get-involved" class={sectionClass}>
-          <MdxH2 class={sectionHeadingClass}>Get Involved</MdxH2>
+          <MdxH2 class={sectionHeadingClass}>Get involved</MdxH2>
           <MdxP class={proseClass}>
             Contributions, bug reports, accessibility notes, tests, examples,
             and docs improvements are welcome while Keystone is still forming.

--- a/apps/web/src/components/docs-shell.tsx
+++ b/apps/web/src/components/docs-shell.tsx
@@ -400,10 +400,10 @@ export function ProductDropdown(props: Readonly<{ items: readonly NavItem[] }>) 
 
 export function DocsChrome(props: Readonly<{ children: JSX.Element }>) {
   return (
-    <main class="flex min-h-0 flex-1 flex-col bg-background text-foreground">
+    <main class="flex min-h-0 flex-1 flex-col bg-sidebar text-foreground">
       <div class="mx-auto grid min-h-[calc(100svh-var(--header-height))] w-full max-w-[1416px] grid-cols-1 px-0 [--sidebar-width:220px] [--top-spacing:0px] lg:grid-cols-[var(--sidebar-width)_minmax(0,1fr)] lg:[--sidebar-width:240px] lg:[--top-spacing:calc(var(--spacing)*3)] xl:grid-cols-[var(--sidebar-width)_minmax(0,1fr)_18rem]">
         <aside class="hidden lg:block">
-          <div class="scrollbar-none sticky top-(--header-height) h-[calc(100svh-var(--header-height))] overflow-y-auto py-2 pr-10 pl-4">
+          <div class="scrollbar-none sticky top-(--header-height) h-[calc(100svh-var(--header-height))] overflow-y-auto py-2 pr-6 pl-4">
             <div class="h-(--top-spacing) shrink-0" />
             <DocsSidebar groups={navGroups} />
           </div>

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "dev": "turbo dev",
     "build": "turbo build",
+    "deploy": "bun run --cwd apps/web deploy",
     "check-types": "turbo check-types",
     "test:core": "turbo -F @keystone-ui/core test",
     "test:docs": "bun --filter web test --pass-with-no-tests",


### PR DESCRIPTION
Updates docs chrome/sidebar styling: tighter desktop sidebar gutter, bg-sidebar shell to match the header, revised command search button, and overview copy polish.
Adds `bun run deploy` at root and web app level while keeping `deploy:production` as an alias; existing Wrangler config routes to `keystone-ui.drastic.dev`.
Validated with `bun run check-types`.
