### PR TITLE
[codex] Fix toast stacking and docs maturity metadata

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,7 +1,8 @@
 {
   "ignorePatterns": [
-    "*/routeTree.gen.ts",
+    "**/routeTree.gen.ts",
     "apps/web/src/lib/registry-docs.gen.ts",
+    "registry/default/items/*.json",
     ".context/**",
     ".playwright-mcp/**"
   ]

--- a/apps/web/src/components/docs-mobile-nav.tsx
+++ b/apps/web/src/components/docs-mobile-nav.tsx
@@ -33,7 +33,7 @@ function NewBadge(props: Readonly<{ children: string }>) {
     <UiBadge
       class="h-auto min-h-0 min-w-0 rounded-md px-1.5 py-0.5 text-[0.68rem] leading-none sm:h-auto sm:min-h-0 sm:min-w-0 sm:text-[0.68rem]"
       size="sm"
-      variant={props.children === "Experimental" ? "warning" : "info"}
+      variant={props.children === "Preview" ? "warning" : "info"}
     >
       {props.children}
     </UiBadge>

--- a/apps/web/src/components/docs-shell.tsx
+++ b/apps/web/src/components/docs-shell.tsx
@@ -77,7 +77,7 @@ export function Badge(props: JSX.HTMLAttributes<HTMLSpanElement>) {
 
 export function NewBadge(props: JSX.HTMLAttributes<HTMLSpanElement>) {
   const [local, rest] = splitProps(props, ["class"]);
-  const variant = () => (props.children === "Experimental" ? "warning" : "info");
+  const variant = () => (props.children === "Preview" ? "warning" : "info");
 
   return (
     <UiBadge

--- a/apps/web/src/components/registry-doc-page.tsx
+++ b/apps/web/src/components/registry-doc-page.tsx
@@ -51,9 +51,9 @@ function maturityBadgeClass(maturity: string) {
       return "bg-success/8 text-success-foreground dark:bg-success/16";
     case "beta":
     case "preview":
-      return "bg-warning/8 text-warning-foreground dark:bg-warning/16";
-    case "experimental":
       return "bg-info/8 text-info-foreground dark:bg-info/16";
+    case "experimental":
+      return "bg-warning/8 text-warning-foreground dark:bg-warning/16";
     case "deprecated":
       return "bg-destructive/8 text-destructive-foreground dark:bg-destructive/16";
     case "draft":

--- a/apps/web/src/docs/registry-doc-blueprints.tsx
+++ b/apps/web/src/docs/registry-doc-blueprints.tsx
@@ -131,7 +131,7 @@ export const componentDocsOverrides = {
   },
   collapsible: {
     description: "A disclosure region for showing and hiding a focused panel of content.",
-    maturity: "Experimental",
+    maturity: "Stable",
     usageCode: examples.collapsibleUsageCode,
     apiItems: [
       {
@@ -151,7 +151,7 @@ export const componentDocsOverrides = {
   },
   combobox: {
     description: "A searchable input and listbox popup for selecting an option.",
-    maturity: "Experimental",
+    maturity: "Stable",
     usageCode: examples.comboboxUsageCode,
     apiItems: [
       {
@@ -179,7 +179,7 @@ export const componentDocsOverrides = {
   },
   "date-picker": {
     description: "A trigger and calendar popup for selecting dates.",
-    maturity: "Experimental",
+    maturity: "Stable",
     usageCode: examples.datePickerUsageCode,
     apiItems: [
       {
@@ -286,7 +286,7 @@ export const componentDocsOverrides = {
   },
   "radio-group": {
     description: "A roving-focus group for choosing one option from a small set.",
-    maturity: "Experimental",
+    maturity: "Stable",
     usageCode: examples.radioGroupUsageCode,
     apiItems: [
       {
@@ -370,7 +370,7 @@ export const componentDocsOverrides = {
   },
   toast: {
     description: "A transient message system for confirmations, warnings, and async feedback.",
-    maturity: "Preview",
+    maturity: "Experimental",
     usageCode: examples.toastUsageCode,
     apiItems: [
       {

--- a/apps/web/src/lib/docs-data.ts
+++ b/apps/web/src/lib/docs-data.ts
@@ -70,18 +70,17 @@ const componentMaturityByName: Readonly<Record<string, string>> = {
   button: "Stable",
   card: "Stable",
   checkbox: "Stable",
-  collapsible: "Experimental",
-  combobox: "Experimental",
-  "date-picker": "Experimental",
+  collapsible: "Stable",
+  combobox: "Stable",
+  "date-picker": "Stable",
   dialog: "Stable",
   input: "Stable",
   label: "Stable",
   popover: "Stable",
-  "radio-group": "Experimental",
+  "radio-group": "Stable",
   select: "Stable",
   switch: "Stable",
   tabs: "Stable",
-  toast: "Preview",
   tooltip: "Stable",
 };
 
@@ -94,7 +93,7 @@ const maturityOrder: Readonly<Record<string, number>> = {
 };
 
 export function componentMaturity(item: RegistryDocItem) {
-  return componentMaturityByName[item.name] ?? "Draft";
+  return item.maturity ?? componentMaturityByName[item.name] ?? "Draft";
 }
 
 function componentMaturityKey(item: RegistryDocItem) {

--- a/apps/web/src/lib/registry-docs.gen.ts
+++ b/apps/web/src/lib/registry-docs.gen.ts
@@ -21,6 +21,7 @@ export type RegistryDocItem = {
   install: string;
   keywords: readonly string[];
   limitations?: string;
+  maturity?: string;
   name: string;
   parity: Readonly<Record<string, string>>;
   registryDependencies: readonly string[];
@@ -4800,9 +4801,10 @@ export const registryDocItems = [
       "Swipe gestures, anchored/contextual toasts, a progress-bar part, and cancel-action sugar are intentionally deferred to Core or a later UI helper.",
       "Toast does not participate in focus trapping, outside hiding, inerting, prevent-scroll, or overlay layering."
     ],
+    "maturity": "Experimental",
     "name": "toast",
     "parity": {
-      "baseUi": "Base UI is a first-class reference for the stacked viewport: visible limit defaults to three, render metadata exposes front index/order, UI measures toast height for expanded stack offsets, the root shell carries coss-style stacked transforms plus keyframed entry and status-driven exit motion, and Core owns manager updates, actions, close parts, timer pause/resume, hotkey focus, roles, exit-duration retention, and viewport filtering. Gaps: anchored positioner, swipe dismissal, and progress parts remain later Core work.",
+      "baseUi": "Base UI is a first-class reference for the stacked viewport: visible limit defaults to three, render metadata exposes front index/order, UI measures toast height for expanded stack offsets, the root shell carries coss-style stacked transforms plus interruptible starting transform and status-driven exit motion, and Core owns manager updates, actions, close parts, timer pause/resume, hotkey focus, roles, exit-duration retention, and viewport filtering. Gaps: anchored positioner, swipe dismissal, and progress parts remain later Core work.",
       "kobalte": "Kobalte is a first-class Solid/accessibility reference: Keystone keeps Solid compound composition, region filtering, duration overrides, viewport limits, hover/focus pause, page-idle timer pausing, hotkey access to the notification region, polite/assertive roles, and programmatic update/dismiss. Gaps: progress track/fill and swipe CSS variables remain deferred.",
       "sonner": "Sonner is a first-class ergonomic reference: toaster is callable, typed helpers update by id, promise helpers move loading to success/error, default Toaster shows three visible toasts in the bottom-right corner, enter motion slides from the screen edge with coss/Sonner-style easing, dismissed toasts remain mounted long enough to exit, hover/focus expands the stack, action clicks dismiss unless prevented, close button remains opt-in, tone icons mirror Sonner expectations, and custom render hooks receive toast metadata. Gaps: per-toast position routing, cancel action sugar, rich color mode, and swipe physics remain explicit follow-ups."
     },

--- a/packages/core/test/date-picker.behavior.test.tsx
+++ b/packages/core/test/date-picker.behavior.test.tsx
@@ -275,6 +275,7 @@ describe("DatePicker behavior", () => {
 
     pointerDown(document.querySelector<HTMLElement>('[data-testid="outside"]')!);
     await settled();
+    await animationFrame();
 
     expect(trigger.getAttribute("aria-expanded")).toBe("false");
     expect(queryByPart("date-picker", "content")).toBeNull();

--- a/packages/ui/src/components/toast.test.tsx
+++ b/packages/ui/src/components/toast.test.tsx
@@ -120,6 +120,39 @@ describe("Toaster", () => {
     host.remove();
   });
 
+  test("does not keep a transform animation on rapidly stacked toasts", async () => {
+    vi.useFakeTimers();
+    const host = document.createElement("div");
+    document.body.append(host);
+    const manager = createToastManager();
+    const dispose = render(() => <Toaster manager={manager} />, host);
+
+    manager.success({ id: "one", title: "Saved" });
+    await flushed();
+
+    const firstToast = host.querySelector<HTMLElement>("[data-slot='toast']") as HTMLElement & {
+      __toastMark?: string;
+    };
+    firstToast.__toastMark = "one";
+
+    manager.error({ id: "two", title: "Failed" });
+    await flushed();
+
+    const toasts = host.querySelectorAll<HTMLElement>("[data-slot='toast']");
+    expect(toasts).toHaveLength(2);
+    expect(toasts[0]).toBe(firstToast);
+    expect((toasts[0] as HTMLElement & { __toastMark?: string }).__toastMark).toBe("one");
+    expect(toasts[0]?.style.transform).toContain("scale(0.9)");
+    expect(toasts[0]?.style.transform).not.toContain("100% + var(--toast-offset)");
+    expect([...toasts].some((toast) => toast.hasAttribute("data-entering"))).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(toasts[1]?.style.transform).toContain("scale(1)");
+
+    dispose();
+    host.remove();
+  });
+
   test("keeps dismissed toasts mounted long enough for exit motion", async () => {
     vi.useFakeTimers();
     const host = document.createElement("div");

--- a/packages/ui/src/components/toast.tsx
+++ b/packages/ui/src/components/toast.tsx
@@ -89,32 +89,9 @@ const DEFAULT_VISIBLE_TOASTS = 3;
 const DEFAULT_TOAST_GAP = 12;
 const DEFAULT_TOAST_OFFSET = "2rem";
 const DEFAULT_TOAST_WIDTH = "22.5rem";
-const TOAST_ENTER_DURATION = 500;
 const TOAST_EXIT_DURATION = 360;
 const toastAnimationStyles = `
-@keyframes ui-toast-enter-bottom {
-  from {
-    transform: translateY(calc(100% + var(--toast-offset)));
-  }
-  to {
-    transform: translateX(var(--toast-swipe-movement-x)) translateY(0) scale(1);
-  }
-}
-
-@keyframes ui-toast-enter-top {
-  from {
-    transform: translateY(calc(-100% - var(--toast-offset)));
-  }
-  to {
-    transform: translateX(var(--toast-swipe-movement-x)) translateY(0) scale(1);
-  }
-}
-
 @media (prefers-reduced-motion: reduce) {
-  [data-slot="toast"][data-entering] {
-    animation: none !important;
-  }
-
   [data-slot="toast"] {
     transition-duration: 1ms !important;
   }
@@ -241,7 +218,7 @@ export function Toast(props: ToastProps) {
 
   onMount(() => {
     if (local.stack) {
-      enterTimer = setTimeout(() => setEntering(false), TOAST_ENTER_DURATION);
+      enterTimer = setTimeout(() => setEntering(false), 0);
     }
   });
 
@@ -266,14 +243,17 @@ export function Toast(props: ToastProps) {
       "--toast-stack-offset": `${local.stack.offset}px`,
       "--toast-swipe-movement-x": "0px",
       "--toast-swipe-movement-y": "0px",
-      transform: getToastStackTransform({
-        expanded: local.stack.expanded,
-        height: calcHeightValue,
-        index: local.stack.index,
-        offset: local.stack.offset,
-        position: local.stack.position,
-        scale,
-      }),
+      transform:
+        entering() && local.stack.index === 0 && props.toast?.status !== "closed"
+          ? getToastEnterTransform(local.stack.position)
+          : getToastStackTransform({
+              expanded: local.stack.expanded,
+              height: calcHeightValue,
+              index: local.stack.index,
+              offset: local.stack.offset,
+              position: local.stack.position,
+              scale,
+            }),
       "z-index": String(9999 - local.stack.index),
       height: rootHeight,
     } as JSX.CSSProperties;
@@ -290,11 +270,6 @@ export function Toast(props: ToastProps) {
     <CoreToast.Root
       {...rest}
       data-behind={local.stack && local.stack.index > 0 ? "" : undefined}
-      data-entering={
-        local.stack && local.stack.index === 0 && props.toast?.status !== "closed" && entering()
-          ? ""
-          : undefined
-      }
       data-expanded={local.stack?.expanded ? "" : undefined}
       data-inset={local.inset ? "" : undefined}
       data-position={local.stack?.position}
@@ -343,9 +318,6 @@ export function Toast(props: ToastProps) {
           "data-[stacked]:after:left-0",
           "data-[stacked]:after:h-[calc(var(--toast-gap)+1px)]",
           "data-[stacked]:after:w-full",
-          "data-[entering]:[animation-duration:.5s]",
-          "data-[entering]:[animation-fill-mode:both]",
-          "data-[entering]:[animation-timing-function:cubic-bezier(.22,1,.36,1)]",
           "data-[position*=center]:right-0",
           "data-[position*=center]:left-0",
           "data-[position*=left]:right-auto",
@@ -354,7 +326,6 @@ export function Toast(props: ToastProps) {
           "data-[position*=right]:left-auto",
           "data-[position*=bottom]:bottom-0",
           "data-[position*=bottom]:top-auto",
-          "data-[position*=bottom]:data-[entering]:[animation-name:ui-toast-enter-bottom]",
           "data-[position*=bottom]:origin-[50%_calc(50%+50%*min(var(--toast-index,0),1))]",
           "data-[position*=bottom]:after:bottom-full",
           "data-[position*=bottom]:transform-[translateX(var(--toast-swipe-movement-x))_translateY(calc(var(--toast-swipe-movement-y)-(var(--toast-index)*var(--toast-peek))-(var(--toast-shrink)*var(--toast-height))))_scale(var(--toast-scale))]",
@@ -362,7 +333,6 @@ export function Toast(props: ToastProps) {
           "data-[position*=bottom]:data-[status=closed]:transform-[translateY(calc(100%+var(--toast-offset)))]",
           "data-[position*=top]:top-0",
           "data-[position*=top]:bottom-auto",
-          "data-[position*=top]:data-[entering]:[animation-name:ui-toast-enter-top]",
           "data-[position*=top]:origin-[50%_calc(50%-50%*min(var(--toast-index,0),1))]",
           "data-[position*=top]:after:top-full",
           "data-[position*=top]:transform-[translateX(var(--toast-swipe-movement-x))_translateY(calc(var(--toast-swipe-movement-y)+(var(--toast-index)*var(--toast-peek))+(var(--toast-shrink)*var(--toast-height))))_scale(var(--toast-scale))]",
@@ -751,6 +721,11 @@ function getToastStackTransform(props: {
   const distance = props.index * DEFAULT_TOAST_GAP + shrink * props.height;
   const offset = props.position.startsWith("top") ? distance : distance * -1;
   return `translateX(0px) translateY(${offset}px) scale(${props.scale})`;
+}
+
+function getToastEnterTransform(position: ToastPosition) {
+  const direction = position.startsWith("top") ? "-1" : "1";
+  return `translateX(0px) translateY(calc(${direction} * (100% + var(--toast-offset)))) scale(1)`;
 }
 
 function callEventHandler(handler: unknown, event: Event) {

--- a/registry/default/items/toast.json
+++ b/registry/default/items/toast.json
@@ -104,12 +104,13 @@
       "action",
       "close"
     ],
+    "maturity": "Experimental",
     "limitations": [
       "Swipe gestures, anchored/contextual toasts, a progress-bar part, and cancel-action sugar are intentionally deferred to Core or a later UI helper.",
       "Toast does not participate in focus trapping, outside hiding, inerting, prevent-scroll, or overlay layering."
     ],
     "parity": {
-      "baseUi": "Base UI is a first-class reference for the stacked viewport: visible limit defaults to three, render metadata exposes front index/order, UI measures toast height for expanded stack offsets, the root shell carries coss-style stacked transforms plus keyframed entry and status-driven exit motion, and Core owns manager updates, actions, close parts, timer pause/resume, hotkey focus, roles, exit-duration retention, and viewport filtering. Gaps: anchored positioner, swipe dismissal, and progress parts remain later Core work.",
+      "baseUi": "Base UI is a first-class reference for the stacked viewport: visible limit defaults to three, render metadata exposes front index/order, UI measures toast height for expanded stack offsets, the root shell carries coss-style stacked transforms plus interruptible starting transform and status-driven exit motion, and Core owns manager updates, actions, close parts, timer pause/resume, hotkey focus, roles, exit-duration retention, and viewport filtering. Gaps: anchored positioner, swipe dismissal, and progress parts remain later Core work.",
       "kobalte": "Kobalte is a first-class Solid/accessibility reference: Keystone keeps Solid compound composition, region filtering, duration overrides, viewport limits, hover/focus pause, page-idle timer pausing, hotkey access to the notification region, polite/assertive roles, and programmatic update/dismiss. Gaps: progress track/fill and swipe CSS variables remain deferred.",
       "sonner": "Sonner is a first-class ergonomic reference: toaster is callable, typed helpers update by id, promise helpers move loading to success/error, default Toaster shows three visible toasts in the bottom-right corner, enter motion slides from the screen edge with coss/Sonner-style easing, dismissed toasts remain mounted long enough to exit, hover/focus expands the stack, action clicks dismiss unless prevented, close button remains opt-in, tone icons mirror Sonner expectations, and custom render hooks receive toast metadata. Gaps: per-toast position routing, cancel action sugar, rich color mode, and swipe physics remain explicit follow-ups."
     }

--- a/scripts/generate-docs-registry-items.ts
+++ b/scripts/generate-docs-registry-items.ts
@@ -36,6 +36,7 @@ type RegistryItem = {
     dependencies?: readonly string[];
     install?: string;
     limitations?: string;
+    maturity?: string;
     parity?: Record<string, string>;
     parts?: readonly string[];
     routerAdapter?: string;
@@ -78,6 +79,7 @@ async function main() {
     install: item.meta?.install ?? `shadcn add https://keystone-ui.dev/r/${item.name}.json`,
     keywords: item.keywords ?? [],
     limitations: item.meta?.limitations,
+    maturity: item.meta?.maturity,
     name: item.name,
     parity: item.meta?.parity ?? {},
     registryDependencies: item.registryDependencies ?? [],
@@ -112,6 +114,7 @@ export type RegistryDocItem = {
   install: string;
   keywords: readonly string[];
   limitations?: string;
+  maturity?: string;
   name: string;
   parity: Readonly<Record<string, string>>;
   registryDependencies: readonly string[];


### PR DESCRIPTION
Fixes rapid toast stacking jank by replacing long enter keyframes with an interruptible starting transform and adding regression coverage.

Propagates toast maturity metadata through generated docs, updates component maturity labels and badge colors, and adjusts formatter ignores for generated registry artifacts.

Validated with `bun --filter @keystone-ui/ui test -- src/components/toast.test.tsx`, `bun --filter @keystone-ui/ui check-types`, `bun run check-types`, and targeted `oxlint`.