### PR TITLE
Polish component docs surfaces

### DIFF
--- a/apps/web/src/components/component-preview.tsx
+++ b/apps/web/src/components/component-preview.tsx
@@ -46,79 +46,81 @@ export function ComponentPreview(props: Readonly<{ item: RegistryDocItem }>) {
         <Badge>{props.item.type.replace("registry:", "")}</Badge>
       </div>
       <div class="flex min-h-52 items-center justify-center bg-background/60 p-6">
-        <Switch fallback={<GenericPreview item={props.item} />}>
-          <Match when={props.item.name === "accordion"}>
-            <Accordion class="w-full max-w-md">
-              {accordionItems.map((item) => (
-                <AccordionItem value={item.id}>
-                  <AccordionTrigger>{item.title}</AccordionTrigger>
-                  <AccordionContent>{item.content}</AccordionContent>
-                </AccordionItem>
-              ))}
-            </Accordion>
-          </Match>
-          <Match when={props.item.name === "button"}>
-            <div class="flex flex-wrap items-center gap-3">
-              <Button>Button</Button>
-              <Button variant="outline">Outline</Button>
-              <Button variant="secondary">Secondary</Button>
-            </div>
-          </Match>
-          <Match when={props.item.name === "badge"}>
-            <div class="flex flex-wrap items-center gap-2">
-              <KeystoneBadge>Default</KeystoneBadge>
-              <KeystoneBadge variant="success">Success</KeystoneBadge>
-              <KeystoneBadge variant="warning">Warning</KeystoneBadge>
-              <KeystoneBadge variant="outline">Outline</KeystoneBadge>
-            </div>
-          </Match>
-          <Match when={props.item.name === "card"}>
-            <Card class="w-full max-w-sm">
-              <CardHeader>
-                <CardTitle>Registry Card</CardTitle>
-                <CardDescription>
-                  Keystone card source rendered in the docs preview.
-                </CardDescription>
-              </CardHeader>
-              <CardPanel class="text-muted-foreground text-sm">
-                Component previews use the installable UI source where the web app can import it.
-              </CardPanel>
-            </Card>
-          </Match>
-          <Match when={props.item.name === "input"}>
-            <div class="grid w-full max-w-64 gap-2">
-              <Label for="component-preview-search">Search</Label>
-              <Input
-                id="component-preview-search"
-                placeholder="Search components..."
-                type="search"
-              />
-            </div>
-          </Match>
-          <Match when={props.item.name === "label"}>
-            <div class="grid w-full max-w-64 gap-2">
-              <Label for="component-preview-email">Email</Label>
-              <Input id="component-preview-email" placeholder="name@example.com" type="email" />
-            </div>
-          </Match>
-          <Match when={props.item.name === "switch"}>
-            <Label class="gap-3">
-              <KeystoneSwitch name="component-preview-notifications" />
-              Enable notifications
-            </Label>
-          </Match>
-          <Match when={props.item.name === "alert"}>
-            <Alert class="w-full max-w-md" variant="info">
-              <AlertIcon>
-                <CircleAlert />
-              </AlertIcon>
-              <AlertTitle>Source preview</AlertTitle>
-              <AlertDescription>
-                This alert is rendered from the Keystone UI registry source.
-              </AlertDescription>
-            </Alert>
-          </Match>
-        </Switch>
+        <div class="flex w-full max-w-md justify-center">
+          <Switch fallback={<GenericPreview item={props.item} />}>
+            <Match when={props.item.name === "accordion"}>
+              <Accordion class="w-full max-w-md">
+                {accordionItems.map((item) => (
+                  <AccordionItem value={item.id}>
+                    <AccordionTrigger>{item.title}</AccordionTrigger>
+                    <AccordionContent>{item.content}</AccordionContent>
+                  </AccordionItem>
+                ))}
+              </Accordion>
+            </Match>
+            <Match when={props.item.name === "button"}>
+              <div class="flex flex-wrap items-center gap-3">
+                <Button>Button</Button>
+                <Button variant="outline">Outline</Button>
+                <Button variant="secondary">Secondary</Button>
+              </div>
+            </Match>
+            <Match when={props.item.name === "badge"}>
+              <div class="flex flex-wrap items-center gap-2">
+                <KeystoneBadge>Default</KeystoneBadge>
+                <KeystoneBadge variant="success">Success</KeystoneBadge>
+                <KeystoneBadge variant="warning">Warning</KeystoneBadge>
+                <KeystoneBadge variant="outline">Outline</KeystoneBadge>
+              </div>
+            </Match>
+            <Match when={props.item.name === "card"}>
+              <Card class="w-full max-w-sm">
+                <CardHeader>
+                  <CardTitle>Registry Card</CardTitle>
+                  <CardDescription>
+                    Keystone card source rendered in the docs preview.
+                  </CardDescription>
+                </CardHeader>
+                <CardPanel class="text-muted-foreground text-sm">
+                  Component previews use the installable UI source where the web app can import it.
+                </CardPanel>
+              </Card>
+            </Match>
+            <Match when={props.item.name === "input"}>
+              <div class="grid w-full max-w-64 gap-2">
+                <Label for="component-preview-search">Search</Label>
+                <Input
+                  id="component-preview-search"
+                  placeholder="Search components..."
+                  type="search"
+                />
+              </div>
+            </Match>
+            <Match when={props.item.name === "label"}>
+              <div class="grid w-full max-w-64 gap-2">
+                <Label for="component-preview-email">Email</Label>
+                <Input id="component-preview-email" placeholder="name@example.com" type="email" />
+              </div>
+            </Match>
+            <Match when={props.item.name === "switch"}>
+              <Label class="gap-3">
+                <KeystoneSwitch name="component-preview-notifications" />
+                Enable notifications
+              </Label>
+            </Match>
+            <Match when={props.item.name === "alert"}>
+              <Alert class="w-full max-w-md" variant="info">
+                <AlertIcon>
+                  <CircleAlert />
+                </AlertIcon>
+                <AlertTitle>Source preview</AlertTitle>
+                <AlertDescription>
+                  This alert is rendered from the Keystone UI registry source.
+                </AlertDescription>
+              </Alert>
+            </Match>
+          </Switch>
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/components/registry-doc-page.tsx
+++ b/apps/web/src/components/registry-doc-page.tsx
@@ -539,13 +539,13 @@ function previewFrameClass(variant: PreviewVariant, align: PreviewAlign) {
   const aligned = `${base} ${previewFrameAlignClass(align)}`;
   switch (variant) {
     case "inline":
-      return aligned;
+      return `${aligned} max-w-xl`;
     case "full":
       return `${base} items-stretch`;
     case "dense":
       return `${base} items-stretch`;
     case "centered":
-      return aligned;
+      return `${aligned} max-w-xl`;
   }
 }
 

--- a/apps/web/src/docs/registry-doc-blueprints.tsx
+++ b/apps/web/src/docs/registry-doc-blueprints.tsx
@@ -352,7 +352,7 @@ export const componentDocsOverrides = {
   },
   separator: {
     description: "A decorative or semantic rule for separating compact groups of content.",
-    maturity: "Experimental",
+    maturity: "Stable",
     usageCode: examples.separatorUsageCode,
     apiItems: [
       {
@@ -413,7 +413,7 @@ export const componentDocsOverrides = {
   },
   breadcrumb: {
     description: "A navigation trail for docs, app routes, and dense workspace headers.",
-    maturity: "Experimental",
+    maturity: "Stable",
     usageCode: examples.breadcrumbUsageCode,
     apiItems: [
       {
@@ -448,7 +448,8 @@ export const componentDocsOverrides = {
       },
       {
         name: "Table",
-        description: "Native table root with Keystone density, caption, and tabular-number styling.",
+        description:
+          "Native table root with Keystone density, caption, and tabular-number styling.",
       },
       {
         name: "TableHeader / TableBody / TableFooter",
@@ -510,7 +511,8 @@ export const componentDocsOverrides = {
       },
       {
         name: "TanStackFormErrors",
-        description: "Root error display that renders alert semantics when form errors are present.",
+        description:
+          "Root error display that renders alert semantics when form errors are present.",
       },
       {
         name: "getTanStackFormState / formatFieldError",

--- a/apps/web/src/docs/registry-doc-examples.tsx
+++ b/apps/web/src/docs/registry-doc-examples.tsx
@@ -81,7 +81,11 @@ import {
   TableHeader,
   TableRow,
 } from "@keystone-ui/ui/table";
-import { TanStackForm, TanStackFormErrors, TanStackFormSubmit } from "@keystone-ui/ui/tanstack-form";
+import {
+  TanStackForm,
+  TanStackFormErrors,
+  TanStackFormSubmit,
+} from "@keystone-ui/ui/tanstack-form";
 import { Textarea } from "@keystone-ui/ui/textarea";
 import { Toaster } from "@keystone-ui/ui/toast";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@keystone-ui/ui/tooltip";
@@ -138,7 +142,8 @@ function AccordionItemList() {
   );
 }
 
-const alertPreviewClass = "w-full max-w-xl";
+const alertPreviewClass = "w-full max-w-[25.2rem]";
+const alertActionPreviewClass = "w-full max-w-xl";
 
 export function SingleAccordionExample() {
   return (
@@ -458,6 +463,7 @@ export function Component() {
 }`;
 
 export const collapsibleExample = defineCodeExample({
+  align: "start",
   code: collapsibleExampleCode,
   component: CollapsibleExample,
   description: "A simple Core-backed disclosure region with UI-owned trigger and panel styling.",
@@ -735,7 +741,7 @@ export function ErrorAlertExample() {
 
 export function AlertActionExample() {
   return (
-    <Alert class={alertPreviewClass}>
+    <Alert class={alertActionPreviewClass}>
       <AlertIcon>
         <Info />
       </AlertIcon>
@@ -763,7 +769,7 @@ import { TriangleAlert } from "lucide-solid";
 
 export function Component() {
   return (
-    <Alert variant="warning" class="w-full max-w-xl">
+    <Alert variant="warning" class="w-full max-w-[25.2rem]">
       <AlertIcon>
         <TriangleAlert />
       </AlertIcon>
@@ -783,7 +789,7 @@ import { CircleAlert } from "lucide-solid";
 
 export function Component() {
   return (
-    <Alert variant="error" class="w-full max-w-xl">
+    <Alert variant="error" class="w-full max-w-[25.2rem]">
       <AlertIcon>
         <CircleAlert />
       </AlertIcon>
@@ -833,7 +839,7 @@ import {
 
 export function Component() {
   return (
-    <Alert variant="info" class="w-full max-w-xl">
+    <Alert variant="info" class="w-full max-w-[25.2rem]">
       <AlertIcon>
         <Info />
       </AlertIcon>
@@ -2047,18 +2053,18 @@ export function Component() {
 
 export function SeparatorExample() {
   return (
-    <div class="w-full max-w-sm">
+    <div class="w-full max-w-[22rem]">
       <div class="space-y-1">
-        <h4 class="font-medium text-foreground text-sm leading-none">Workspace</h4>
-        <p class="text-muted-foreground text-sm">Activity, ownership, and deployment metadata.</p>
+        <h4 class="font-medium text-foreground text-sm leading-none">Project Links</h4>
+        <p class="text-muted-foreground text-sm">Related resources grouped in a compact row.</p>
       </div>
       <Separator class="my-4" />
-      <div class="flex h-5 items-center gap-3 text-muted-foreground text-sm">
-        <span>Docs</span>
+      <div class="grid h-6 grid-cols-[1fr_auto_1fr_auto_1fr] items-center text-muted-foreground text-sm">
+        <span class="text-center">Docs</span>
         <Separator orientation="vertical" />
-        <span>Registry</span>
+        <span class="text-center">API</span>
         <Separator orientation="vertical" />
-        <span>Examples</span>
+        <span class="text-center">Examples</span>
       </div>
     </div>
   );
@@ -2068,20 +2074,20 @@ export const separatorExampleCode = `import { Separator } from "@/components/ui/
 
 export function Component() {
   return (
-    <div class="w-full max-w-sm">
+    <div class="w-full max-w-[22rem]">
       <div class="space-y-1">
-        <h4 class="font-medium text-foreground text-sm leading-none">Workspace</h4>
+        <h4 class="font-medium text-foreground text-sm leading-none">Project Links</h4>
         <p class="text-muted-foreground text-sm">
-          Activity, ownership, and deployment metadata.
+          Related resources grouped in a compact row.
         </p>
       </div>
       <Separator class="my-4" />
-      <div class="flex h-5 items-center gap-3 text-muted-foreground text-sm">
-        <span>Docs</span>
+      <div class="grid h-6 grid-cols-[1fr_auto_1fr_auto_1fr] items-center text-muted-foreground text-sm">
+        <span class="text-center">Docs</span>
         <Separator orientation="vertical" />
-        <span>Registry</span>
+        <span class="text-center">API</span>
         <Separator orientation="vertical" />
-        <span>Examples</span>
+        <span class="text-center">Examples</span>
       </div>
     </div>
   );
@@ -2090,7 +2096,7 @@ export function Component() {
 export const separatorExample = defineCodeExample({
   code: separatorExampleCode,
   component: SeparatorExample,
-  description: "Horizontal and vertical separators in a compact metadata group.",
+  description: "Horizontal and vertical separators dividing a compact resource group.",
   id: "basic",
   title: "Basic Separator",
   variant: "centered",

--- a/apps/web/src/lib/docs-data.ts
+++ b/apps/web/src/lib/docs-data.ts
@@ -118,8 +118,8 @@ function compareMaturityGroups(a: NavGroup, b: NavGroup) {
 }
 
 const publicComponentDocs = componentDocs.filter(isPublicComponentDoc);
-const visibleSidebarComponentDocs = sidebarComponentDocs.filter((item) =>
-  isPublicComponentDoc(item) && componentMaturityKey(item) !== "experimental",
+const visibleSidebarComponentDocs = sidebarComponentDocs.filter(
+  (item) => isPublicComponentDoc(item) && componentMaturityKey(item) !== "experimental",
 );
 const sidebarMaturityGroups = Object.values(
   sidebarComponentDocs
@@ -151,6 +151,12 @@ const routableDocs = showFullDocsCatalog ? docsItems : publicComponentDocs;
 export const searchableComponentDocs = showFullDocsCatalog ? componentDocs : publicComponentDocs;
 export const searchableHookDocs = visibleHookDocs;
 
+const newComponentBadges = new Set(["breadcrumb", "separator"]);
+
+function componentBadge(name: string) {
+  return newComponentBadges.has(name) ? "New" : undefined;
+}
+
 export const overviewPage: DocsPage = {
   description:
     "Solid primitives, source-owned UI components, shadcn-compatible registry metadata, and app-layer registry guidance.",
@@ -172,6 +178,7 @@ export const navGroups: readonly NavGroup[] = [
   {
     title: "Components",
     items: visibleSidebarComponentDocs.map((item) => ({
+      badge: componentBadge(item.name),
       href: componentHref(item.name),
       label: docsItemTitle(item),
     })),

--- a/apps/web/src/lib/docs-route-meta.ts
+++ b/apps/web/src/lib/docs-route-meta.ts
@@ -126,12 +126,10 @@ const componentRouteMeta: Readonly<Record<string, DocsRouteMeta>> = {
 };
 
 const experimentalComponentRoutes = new Set([
-  "breadcrumb",
   "command-menu",
   "field",
   "kbd",
   "scroll-area",
-  "separator",
   "table",
   "tanstack-form",
   "toast",

--- a/apps/web/src/lib/registry-docs.gen.ts
+++ b/apps/web/src/lib/registry-docs.gen.ts
@@ -406,7 +406,7 @@ export const registryDocItems = [
     "limitations": "Alert does not manage dismissal, timers, focus, or notification queues. Use Toast or app-owned state for dismissible or time-based feedback.",
     "name": "alert",
     "parity": {
-      "visualReference": "Matches the Keystone design-system Alert contract: grid layout, rounded-xl border surface, compact padding, one-rem icon column, semantic tone variants, description spacing, and responsive action placement.",
+      "visualReference": "Matches the Keystone design-system Alert contract: grid layout, rounded-lg border surface, compact padding, one-rem icon column, semantic tone variants, description spacing, and responsive action placement.",
       "baseUi": "Base UI does not provide a dedicated presentational Alert primitive; parity is intentionally native semantic HTML with stable anatomy and styling hooks. Core behavior is not needed because there is no intrinsic widget state.",
       "kobalte": "Kobalte has no first-class Alert primitive comparable to dialogs/toasts, so Keystone scopes this item to Solid-native composition, live-region defaults, and copy-paste source ownership."
     },
@@ -4159,7 +4159,7 @@ export const registryDocItems = [
       "layout"
     ],
     "limitations": "Separator does not implement resizable splitters or focusable handles. Use a dedicated splitter/resizable primitive for adjustable panes.",
-    "maturity": "Experimental",
+    "maturity": "Stable",
     "name": "separator",
     "parity": {
       "visualReference": "Matches the Keystone base component direction: a compact border-color rule, horizontal h-px/w-full default, vertical h-full/w-px option, and stable data hooks for source-owned customization.",
@@ -4716,7 +4716,7 @@ export const registryDocItems = [
       "docs"
     ],
     "limitations": "Breadcrumb is display/navigation source and has no Core dependency because it owns no intrinsic state. Route matching, truncation menus, and responsive collapse policy stay in app code or composed menu source.",
-    "maturity": "Experimental",
+    "maturity": "Stable",
     "name": "breadcrumb",
     "parity": {
       "visualReference": "Matches shadcn-style source-owned breadcrumb ergonomics in Solid form: nav root, ordered list, item/link/page/separator parts, current page semantics, customizable separator, and ellipsis trigger for collapsed trails.",

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as DocsRouteRouteImport } from './routes/docs/route'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as DocsIndexRouteImport } from './routes/docs/index'
+import { Route as DocsComponentsIndexRouteImport } from './routes/docs/components/index'
 import { Route as DocsComponentsSlugRouteImport } from './routes/docs/components/$slug'
 
 const DocsRouteRoute = DocsRouteRouteImport.update({
@@ -29,6 +30,11 @@ const DocsIndexRoute = DocsIndexRouteImport.update({
   path: '/',
   getParentRoute: () => DocsRouteRoute,
 } as any)
+const DocsComponentsIndexRoute = DocsComponentsIndexRouteImport.update({
+  id: '/components/',
+  path: '/components/',
+  getParentRoute: () => DocsRouteRoute,
+} as any)
 const DocsComponentsSlugRoute = DocsComponentsSlugRouteImport.update({
   id: '/components/$slug',
   path: '/components/$slug',
@@ -40,11 +46,13 @@ export interface FileRoutesByFullPath {
   '/docs': typeof DocsRouteRouteWithChildren
   '/docs/': typeof DocsIndexRoute
   '/docs/components/$slug': typeof DocsComponentsSlugRoute
+  '/docs/components/': typeof DocsComponentsIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/docs': typeof DocsIndexRoute
   '/docs/components/$slug': typeof DocsComponentsSlugRoute
+  '/docs/components': typeof DocsComponentsIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -52,13 +60,25 @@ export interface FileRoutesById {
   '/docs': typeof DocsRouteRouteWithChildren
   '/docs/': typeof DocsIndexRoute
   '/docs/components/$slug': typeof DocsComponentsSlugRoute
+  '/docs/components/': typeof DocsComponentsIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/docs' | '/docs/' | '/docs/components/$slug'
+  fullPaths:
+    | '/'
+    | '/docs'
+    | '/docs/'
+    | '/docs/components/$slug'
+    | '/docs/components/'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/docs' | '/docs/components/$slug'
-  id: '__root__' | '/' | '/docs' | '/docs/' | '/docs/components/$slug'
+  to: '/' | '/docs' | '/docs/components/$slug' | '/docs/components'
+  id:
+    | '__root__'
+    | '/'
+    | '/docs'
+    | '/docs/'
+    | '/docs/components/$slug'
+    | '/docs/components/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -89,6 +109,13 @@ declare module '@tanstack/solid-router' {
       preLoaderRoute: typeof DocsIndexRouteImport
       parentRoute: typeof DocsRouteRoute
     }
+    '/docs/components/': {
+      id: '/docs/components/'
+      path: '/components'
+      fullPath: '/docs/components/'
+      preLoaderRoute: typeof DocsComponentsIndexRouteImport
+      parentRoute: typeof DocsRouteRoute
+    }
     '/docs/components/$slug': {
       id: '/docs/components/$slug'
       path: '/components/$slug'
@@ -102,11 +129,13 @@ declare module '@tanstack/solid-router' {
 interface DocsRouteRouteChildren {
   DocsIndexRoute: typeof DocsIndexRoute
   DocsComponentsSlugRoute: typeof DocsComponentsSlugRoute
+  DocsComponentsIndexRoute: typeof DocsComponentsIndexRoute
 }
 
 const DocsRouteRouteChildren: DocsRouteRouteChildren = {
   DocsIndexRoute: DocsIndexRoute,
   DocsComponentsSlugRoute: DocsComponentsSlugRoute,
+  DocsComponentsIndexRoute: DocsComponentsIndexRoute,
 }
 
 const DocsRouteRouteWithChildren = DocsRouteRoute._addFileChildren(

--- a/apps/web/src/routes/docs/components/index.tsx
+++ b/apps/web/src/routes/docs/components/index.tsx
@@ -1,0 +1,8 @@
+import { createFileRoute, redirect } from "@tanstack/solid-router";
+
+export const Route = createFileRoute("/docs/components/")({
+  ssr: true,
+  beforeLoad: () => {
+    throw redirect({ to: "/docs" });
+  },
+});

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -19,6 +19,19 @@ Avoid:
 - Rounded pill-heavy UI except for intentionally tiny badges or mobile scroll pills.
 - Cards inside cards unless the inner card is a real preview/content surface inside a frame.
 
+## Visual Register
+
+Keystone's component library should feel compact, exact, and quietly distinct. The default posture is not decorative minimalism; it is dense product UI with a few recognizable moves: small tactile shadows, tight radii, crisp type rhythm, thin rules, and status color used as a signal rather than a surface flood.
+
+Apply this register before tuning individual components:
+
+- Prefer compact vertical rhythm: common two-line component rows should sit on `1.25rem` line-height with `0.25rem` to `0.5rem` internal row gaps.
+- Use smaller radii for controls and feedback surfaces than for layout containers. Rounded corners should imply precision, not softness.
+- Keep status surfaces quiet. Use low-alpha semantic backgrounds and borders, then let icons, focus rings, selected states, and destructive actions carry stronger color.
+- Use shadows as tactile edges. Default component shadows should be barely perceptible; avoid stacked elevation or glow effects.
+- Keep padding intentional and dense. Controls, alerts, list items, tabs, and menu rows should feel efficient; larger padding belongs to page sections, cards, dialogs, and preview frames.
+- Preserve strong focus and invalid states even when the resting surface is quiet.
+
 ## Core Layout
 
 ### Root Shell
@@ -280,7 +293,17 @@ Add two Tailwind theme breakpoints:
 | `--radius-lg` | `var(--radius)`             |
 | `--radius-xl` | `calc(var(--radius) + 4px)` |
 
-Use `rounded-lg` for buttons and inputs, `rounded-xl` for alerts/previews, and `rounded-2xl` for cards and frames. Badges use `rounded-sm`; tiny square pins use `2px`.
+Use `rounded-lg` for buttons, inputs, and alerts; use `rounded-xl` for preview surfaces; and use `rounded-2xl` for cards and frames. Badges use `rounded-sm`; tiny square pins use `2px`.
+
+Radius hierarchy:
+
+- `rounded-sm`: badges, dense metadata chips, menu item internals, and tiny framed marks.
+- `rounded-md`: active tab indicators and compact nested affordances inside larger controls.
+- `rounded-lg`: primary control and feedback surface radius for buttons, inputs, selects, alerts, popover/menu surfaces, tabs, sidebar items, and grouped controls.
+- `rounded-xl`: preview surfaces, embedded examples, and medium framed regions that should read as surfaces but not full cards.
+- `rounded-2xl`: cards, dialogs, sheets, high-level frames, and larger page-level containers.
+
+Do not increase radius to make a component feel more polished. If an element feels generic, first tune alignment, typography, border contrast, state treatment, and spacing.
 
 ### Fonts
 
@@ -383,6 +406,35 @@ Use shadows as tactile edges, not elevation drama:
 - Light inset top highlight: black or white alpha in `before` pseudo elements.
 - Dark inset top/bottom highlight: white alpha around `6%`.
 - Borders are usually `border`, `input`, `sidebar-border`, or `border / 64%`.
+- Avoid decorative glow shadows, stacked shadow recipes, or large soft shadows on ordinary product controls.
+- Popover, menu, dialog, and docs frame shadows may be stronger, but should still read as crisp separation rather than depth drama.
+
+### Status Surfaces
+
+Status variants should be recognizable without making the component visually loud:
+
+- Resting status surfaces use semantic background alpha around `3%` to `8%` in light mode and `6%` to `16%` in dark mode.
+- Status borders usually use semantic alpha around `24%` to `36%`, adjusted by component density and surrounding contrast.
+- Icons, leading marks, focus states, selected states, and destructive primary actions may use full semantic color.
+- Body text remains foreground or muted foreground; avoid tinting whole paragraphs with status foreground colors.
+- Reserve saturated fills for active controls, destructive buttons, selected indicators, and compact badges where the color is the main identifier.
+
+### Type And Density
+
+Component typography should preserve scan speed under repeated use:
+
+- Compact component text uses `text-sm` with `1.25rem` line-height.
+- Dense labels, metadata, shortcuts, and table-adjacent controls may use `text-xs` with explicit line-height.
+- Title/body pairs inside compact surfaces use a one-step hierarchy: foreground `font-medium` title, muted body, matching line-height, and a `0.25rem` to `0.5rem` row gap.
+- Buttons, inputs, tabs, menu items, alerts, and selection controls should avoid hero-scale type and avoid viewport-scaled font sizes.
+- Favor stable heights and explicit padding over letting dynamic content resize controls.
+
+Compact padding defaults:
+
+- Small controls and dense rows: about `0.375rem` to `0.5rem` block padding.
+- Default controls and alerts: about `0.625rem` block padding.
+- Menu, listbox, and command items: compact rows with enough height for pointer and keyboard use.
+- Cards, dialogs, sheets, and docs content may use larger padding because they frame work areas rather than individual controls.
 
 ## Component Contracts
 
@@ -549,18 +601,19 @@ Textarea uses the same wrapper shell as Input:
 
 ### Alert
 
-- Grid layout.
-- Radius `xl`.
-- Border.
-- Padding `0.875rem 0.75rem`.
-- Text `sm`.
-- Icon column width `1rem`.
+- Presentational live-region surface with stable `data-scope="ui-alert"`, `data-part`, `data-slot`, and `data-variant` hooks.
+- Grid layout with compact two-line rhythm.
+- Radius `lg`.
+- Border plus `shadow-xs/5`.
+- Padding `0.625rem 0.75rem`.
+- Text `sm`, with title and description line-height `1.25rem`.
+- Icon column width `1rem`; icons align to the title line and use semantic tone color.
 - Variants:
-  - Default transparent, dark input overlay.
-  - Info/success/warning/error use semantic border alpha `32%`, background alpha `4%`, and icon semantic color.
-- Title: `font-medium`.
-- Description: flex column, gap `0.625rem`, muted foreground.
-- Action: responsive grid placement, inline flex gap `0.25rem`.
+  - Default uses a faint card surface in light mode and input overlay in dark mode.
+  - Info/success/warning/error use semantic border alpha around `28%`, background alpha around `3%` light and `6%` dark, and icon semantic color.
+- Title: foreground, `font-medium`, line-height `1.25rem`.
+- Description: flex column, gap `0.5rem`, muted foreground, line-height `1.25rem`.
+- Action: responsive grid placement, inline flex gap `0.25rem`, tucked closer to body copy on mobile.
 
 ### Selection Controls
 

--- a/packages/mason/src/registry/registry-validation.test.ts
+++ b/packages/mason/src/registry/registry-validation.test.ts
@@ -393,8 +393,8 @@ describe("Mason registry validation tracer", () => {
     expect(source).toContain(
       '"has-data-[slot=alert-icon]:has-data-[slot=alert-action]:grid-cols-[calc(var(--spacing)*4)_1fr_auto]"',
     );
-    expect(source).toContain('"border-success/32"');
-    expect(source).toContain('"border-warning/32"');
+    expect(source).toContain('"border-success/28"');
+    expect(source).toContain('"border-warning/28"');
   });
 
   test("validates docs-ready metadata on the real default separator item", async () => {

--- a/packages/ui/src/components/alert.tsx
+++ b/packages/ui/src/components/alert.tsx
@@ -15,18 +15,34 @@ const classes = (...tokens: string[]) => tokens.join(" ");
 
 const alertVariantClass: Record<AlertVariant, string> = {
   default: classes(
-    "bg-transparent",
-    "dark:bg-input/32",
+    "bg-card/48",
+    "dark:bg-input/20",
     "*:data-[slot=alert-icon]:text-muted-foreground",
   ),
   error: classes(
-    "border-destructive/32",
-    "bg-destructive/4",
+    "border-destructive/28",
+    "bg-destructive/3",
+    "dark:bg-destructive/6",
     "*:data-[slot=alert-icon]:text-destructive",
   ),
-  info: classes("border-info/32", "bg-info/4", "*:data-[slot=alert-icon]:text-info"),
-  success: classes("border-success/32", "bg-success/4", "*:data-[slot=alert-icon]:text-success"),
-  warning: classes("border-warning/32", "bg-warning/4", "*:data-[slot=alert-icon]:text-warning"),
+  info: classes(
+    "border-info/28",
+    "bg-info/3",
+    "dark:bg-info/6",
+    "*:data-[slot=alert-icon]:text-info",
+  ),
+  success: classes(
+    "border-success/28",
+    "bg-success/3",
+    "dark:bg-success/6",
+    "*:data-[slot=alert-icon]:text-success",
+  ),
+  warning: classes(
+    "border-warning/28",
+    "bg-warning/3",
+    "dark:bg-warning/6",
+    "*:data-[slot=alert-icon]:text-warning",
+  ),
 };
 
 function alertPart(part: string, className: string, props: AlertPartProps) {
@@ -63,12 +79,13 @@ export function Alert(props: AlertProps) {
         "grid",
         "w-full",
         "items-start",
-        "gap-x-2",
-        "gap-y-0.5",
-        "rounded-xl",
+        "gap-x-2.5",
+        "gap-y-1",
+        "rounded-lg",
         "border",
-        "px-3.5",
-        "py-3",
+        "px-3",
+        "py-2.5",
+        "shadow-xs/5",
         "text-card-foreground",
         "text-sm",
         "has-data-[slot=alert-action]:grid-cols-[1fr_auto]",
@@ -97,6 +114,7 @@ export function AlertIcon(props: AlertPartProps) {
       "w-4",
       "items-center",
       "justify-center",
+      "pt-px",
     ),
     props,
   );
@@ -108,7 +126,9 @@ export function AlertTitle(props: AlertPartProps) {
     classes(
       "ui-alert-title",
       "[[data-slot=alert]:has(>[data-slot=alert-icon])>_&]:col-start-2",
+      "text-foreground",
       "font-medium",
+      "leading-5",
     ),
     props,
   );
@@ -122,8 +142,9 @@ export function AlertDescription(props: AlertPartProps) {
       "[[data-slot=alert]:has(>[data-slot=alert-icon])>_&]:col-start-2",
       "flex",
       "flex-col",
-      "gap-2.5",
+      "gap-2",
       "text-muted-foreground",
+      "leading-5",
       "[&_a:hover]:text-primary",
       "[&_a]:underline",
       "[&_a]:underline-offset-4",
@@ -141,7 +162,7 @@ export function AlertAction(props: AlertPartProps) {
       "gap-1",
       "[[data-slot=alert]:has(>[data-slot=alert-icon])>_&]:col-start-3",
       "max-sm:col-start-2",
-      "max-sm:mt-2",
+      "max-sm:mt-1.5",
       "sm:row-end-3",
       "sm:row-start-1",
       "sm:self-center",

--- a/registry/default/items/alert.json
+++ b/registry/default/items/alert.json
@@ -50,7 +50,7 @@
     "cssVariables": "No component-specific CSS variables are required; styling uses Keystone semantic Tailwind tokens for border, background, foreground, and tone colors.",
     "limitations": "Alert does not manage dismissal, timers, focus, or notification queues. Use Toast or app-owned state for dismissible or time-based feedback.",
     "parity": {
-      "visualReference": "Matches the Keystone design-system Alert contract: grid layout, rounded-xl border surface, compact padding, one-rem icon column, semantic tone variants, description spacing, and responsive action placement.",
+      "visualReference": "Matches the Keystone design-system Alert contract: grid layout, rounded-lg border surface, compact padding, one-rem icon column, semantic tone variants, description spacing, and responsive action placement.",
       "baseUi": "Base UI does not provide a dedicated presentational Alert primitive; parity is intentionally native semantic HTML with stable anatomy and styling hooks. Core behavior is not needed because there is no intrinsic widget state.",
       "kobalte": "Kobalte has no first-class Alert primitive comparable to dialogs/toasts, so Keystone scopes this item to Solid-native composition, live-region defaults, and copy-paste source ownership."
     }

--- a/registry/default/items/breadcrumb.json
+++ b/registry/default/items/breadcrumb.json
@@ -27,7 +27,7 @@
   ],
   "meta": {
     "install": "shadcn add https://keystone-ui.dev/r/breadcrumb.json",
-    "maturity": "Experimental",
+    "maturity": "Stable",
     "customization": "Use ui-breadcrumb classes and data-slot hooks for root, list, item, link, page, separator, and ellipsis styling. Pass items for simple route trails or compose parts directly for menus and app topbars.",
     "sourceFiles": [
       "packages/ui/src/components/breadcrumb.tsx"

--- a/registry/default/items/separator.json
+++ b/registry/default/items/separator.json
@@ -25,7 +25,7 @@
   ],
   "meta": {
     "install": "shadcn add https://keystone-ui.dev/r/separator.json",
-    "maturity": "Experimental",
+    "maturity": "Stable",
     "customization": "Use separatorClass, data-orientation, data-decorative, and ui-separator classes to style horizontal and vertical separators.",
     "sourceFiles": [
       "packages/ui/src/components/separator.tsx"


### PR DESCRIPTION
Polishes the component docs surfaces by tightening preview widths, alert density, and the shared design-system guidance for compact status UI.
Promotes breadcrumb and separator to stable maturity in registry metadata and docs navigation, with new sidebar badges for discoverability.
Adds a docs components index redirect so the generated route tree has an explicit `/docs/components/` route.

Validation: `bun run check`; `bun run check-types`.