### PR TITLE
[codex] Update docs routing and table docs

### DIFF
--- a/apps/web/src/components/docs-mobile-nav.tsx
+++ b/apps/web/src/components/docs-mobile-nav.tsx
@@ -7,7 +7,7 @@ import type { NavGroup } from "@/lib/docs-data";
 
 let navGroupsPromise: Promise<readonly NavGroup[]> | undefined;
 
-const menuItems = [{ href: "/docs", label: "Home" }] as const;
+const menuItems = [{ href: "/docs/introduction", label: "Home" }] as const;
 
 function MenuIcon() {
   return (

--- a/apps/web/src/components/docs-shell.tsx
+++ b/apps/web/src/components/docs-shell.tsx
@@ -165,8 +165,10 @@ export function CopyPageButton(
 export function CodeBlock(
   props: Readonly<{
     code: string;
+    colorScheme?: CodeColorScheme;
     copy?: boolean;
     language: string;
+    lineNumbers?: boolean;
     title?: string;
   }>,
 ) {
@@ -187,21 +189,31 @@ export function CodeBlock(
       <Show when={props.copy ?? true}>
         <CopyButton value={props.code} />
       </Show>
-      <div class="contents" innerHTML={renderCodeBlock(props.code)} />
+      <div
+        class="contents"
+        innerHTML={renderCodeBlock(props.code, {
+          colorScheme: props.colorScheme ?? "default",
+          lineNumbers: props.lineNumbers ?? true,
+        })}
+      />
     </figure>
   );
 }
 
 const codePreClass =
   "m-0 max-h-[450px] min-w-0 w-full overflow-auto px-4 py-3.5 font-mono text-[.8125rem] leading-snug outline-none has-data-[highlighted-line]:px-0 has-data-[line-numbers]:ps-0 !bg-transparent";
+type CodeColorScheme = "default" | "reference";
 
-function renderCodeBlock(code: string) {
+function renderCodeBlock(
+  code: string,
+  options: { colorScheme: CodeColorScheme; lineNumbers: boolean },
+) {
   const lines = code.split("\n");
 
-  return `<pre class="${codePreClass}" tabindex="0"><code data-line-numbers="">${lines
+  return `<pre class="${codePreClass}" tabindex="0"><code${options.lineNumbers ? ' data-line-numbers=""' : ""}>${lines
     .map(
       (line) =>
-        `<span class="line" data-line="">${highlightCodeLine(line) || tokenSpan(" ")}</span>`,
+        `<span class="line" data-line="">${highlightCodeLine(line, options.colorScheme) || tokenSpan(" ", colorSet(options.colorScheme).text)}</span>`,
     )
     .join("\n")}</code></pre>`;
 }
@@ -222,30 +234,44 @@ const keywordTokens = new Set([
   "satisfies",
   "type",
 ]);
-const keywordColor = ["#D73A49", "#F97583"] as const;
-const stringColor = ["#032F62", "#9ECBFF"] as const;
-const numberColor = ["#005CC5", "#79B8FF"] as const;
-const functionColor = ["#6F42C1", "#B392F0"] as const;
-const tagColor = ["#22863A", "#85E89D"] as const;
-const textColor = ["#24292E", "#E1E4E8"] as const;
-const commentColor = ["#6A737D", "#8B949E"] as const;
+const defaultCodeColors = {
+  keyword: ["#D73A49", "#F97583"],
+  string: ["#032F62", "#9ECBFF"],
+  number: ["#005CC5", "#79B8FF"],
+  function: ["#6F42C1", "#B392F0"],
+  tag: ["#22863A", "#85E89D"],
+  text: ["#24292E", "#E1E4E8"],
+  comment: ["#6A737D", "#8B949E"],
+} as const;
 
-function highlightCodeLine(line: string) {
+const referenceCodeColors = {
+  ...defaultCodeColors,
+  tag: ["#005CC5", "#79B8FF"],
+  function: ["#6F42C1", "#B392F0"],
+  text: ["#24292E", "#C9D1D9"],
+} as const;
+
+function colorSet(scheme: CodeColorScheme) {
+  return scheme === "reference" ? referenceCodeColors : defaultCodeColors;
+}
+
+function highlightCodeLine(line: string, scheme: CodeColorScheme) {
   let index = 0;
   let html = "";
+  const colors = colorSet(scheme);
 
   while (index < line.length) {
     const rest = line.slice(index);
 
     if (rest.startsWith("//")) {
-      html += tokenSpan(rest, commentColor);
+      html += tokenSpan(rest, colors.comment);
       break;
     }
 
     const quote = line[index];
     if (quote === '"' || quote === "'" || quote === "`") {
       const end = findStringEnd(line, index, quote);
-      html += tokenSpan(line.slice(index, end), stringColor);
+      html += tokenSpan(line.slice(index, end), colors.string);
       index = end;
       continue;
     }
@@ -256,19 +282,19 @@ function highlightCodeLine(line: string) {
       const before = line.slice(0, index);
       const after = line.slice(index + word.length);
 
-      html += tokenSpan(word, tokenColorForWord(word, before, after));
+      html += tokenSpan(word, tokenColorForWord(word, before, after, colors));
       index += word.length;
       continue;
     }
 
     const numberMatch = /^\d+(?:\.\d+)?/.exec(rest);
     if (numberMatch) {
-      html += tokenSpan(numberMatch[0], numberColor);
+      html += tokenSpan(numberMatch[0], colors.number);
       index += numberMatch[0].length;
       continue;
     }
 
-    html += tokenSpan(line[index] ?? "", textColor);
+    html += tokenSpan(line[index] ?? "", colors.text);
     index += 1;
   }
 
@@ -287,19 +313,24 @@ function findStringEnd(line: string, start: number, quote: string) {
   return line.length;
 }
 
-function tokenColorForWord(word: string, before: string, after: string) {
-  if (keywordTokens.has(word)) return keywordColor;
+function tokenColorForWord(
+  word: string,
+  before: string,
+  after: string,
+  colors: ReturnType<typeof colorSet>,
+) {
+  if (keywordTokens.has(word)) return colors.keyword;
   if (word === "true" || word === "false" || word === "null" || word === "undefined") {
-    return numberColor;
+    return colors.number;
   }
-  if (/<\/?$/.test(before.trimEnd())) return tagColor;
-  if (/^\s*=/.test(after)) return functionColor;
-  if (/^\s*\(/.test(after)) return functionColor;
+  if (/<\/?$/.test(before.trimEnd())) return colors.tag;
+  if (/^\s*=/.test(after)) return colors.function;
+  if (/^\s*\(/.test(after)) return colors.function;
 
-  return textColor;
+  return colors.text;
 }
 
-function tokenSpan(value: string, colors: readonly [string, string] = textColor) {
+function tokenSpan(value: string, colors: readonly [string, string] = defaultCodeColors.text) {
   return `<span style="--shiki-light:${colors[0]};--shiki-dark:${colors[1]}">${escapeHtml(
     value,
   )}</span>`;

--- a/apps/web/src/components/registry-doc-page.tsx
+++ b/apps/web/src/components/registry-doc-page.tsx
@@ -4,7 +4,6 @@ import { For, Show, createSignal, type JSX } from "solid-js";
 import { ComponentPreview } from "@/components/component-preview";
 import {
   ActionLink,
-  Badge,
   CodeBlock,
   CopyPageButton,
   DocsPageFrame,
@@ -36,6 +35,7 @@ import {
   type DocsPage,
 } from "@/lib/docs-data";
 import type { RegistryDocItem } from "@/lib/registry-docs.gen";
+import { Badge, type BadgeVariant } from "@keystone-ui/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@keystone-ui/ui/tabs";
 
 const pageHeaderActionClass =
@@ -45,25 +45,29 @@ const previewSectionClass = "mt-6 scroll-mt-24";
 
 const showInstallationSection = false;
 
-function maturityBadgeClass(maturity: string) {
+function maturityBadgeVariant(maturity: string): BadgeVariant {
   switch (maturity.toLowerCase()) {
     case "stable":
-      return "bg-success/8 text-success-foreground dark:bg-success/16";
+      return "success";
     case "beta":
     case "preview":
-      return "bg-info/8 text-info-foreground dark:bg-info/16";
+      return "info";
     case "experimental":
-      return "bg-warning/8 text-warning-foreground dark:bg-warning/16";
+      return "warning";
     case "deprecated":
-      return "bg-destructive/8 text-destructive-foreground dark:bg-destructive/16";
+      return "error";
     case "draft":
     default:
-      return "bg-muted text-muted-foreground dark:bg-muted/64";
+      return "muted";
   }
 }
 
 function maturityLabel(maturity: string | undefined) {
   return (maturity ?? "Draft").toLowerCase();
+}
+
+function isStableMaturity(maturity: string) {
+  return maturity === "stable";
 }
 
 export function RegistryDocPage(props: Readonly<{ slug: string }>) {
@@ -114,9 +118,12 @@ function RegistryDocContent(
           <div class="flex flex-col gap-2">
             <div class="flex flex-wrap items-center justify-between gap-x-3 gap-y-2">
               <PageHeaderHeading>{displayTitle()}</PageHeaderHeading>
-              <Badge class={`translate-y-0.5 ${maturityBadgeClass(maturity())}`}>
-                {maturity()}
-              </Badge>
+              <div class="flex translate-y-0.5 flex-wrap items-center gap-1.5">
+                <Show when={isStableMaturity(maturity())}>
+                  <Badge variant="info">unreleased</Badge>
+                </Show>
+                <Badge variant={maturityBadgeVariant(maturity())}>{maturity()}</Badge>
+              </div>
             </div>
             <PageHeaderDescription>{description()}</PageHeaderDescription>
           </div>

--- a/apps/web/src/components/registry-doc-page.tsx
+++ b/apps/web/src/components/registry-doc-page.tsx
@@ -18,6 +18,7 @@ import { componentDocsOverrides, hookDocsOverrides } from "../docs/registry-doc-
 import { InlineCode } from "../docs/hook-doc-widgets";
 import type {
   ApiReferenceItem,
+  ApiReferenceProp,
   CodeExample,
   ComponentDocsBlueprint,
   HookDocsBlueprint,
@@ -489,7 +490,7 @@ function DocSection(
 
 function ApiReference(props: Readonly<{ items: readonly ApiReferenceItem[] }>) {
   return (
-    <div class="mt-3 grid gap-10">
+    <div class="mt-3 grid gap-12">
       <For each={props.items}>
         {(item) => (
           <article class="scroll-mt-24">
@@ -505,6 +506,30 @@ function ApiReference(props: Readonly<{ items: readonly ApiReferenceItem[] }>) {
               </a>
             </h3>
             <ApiReferenceDescription text={item.description} />
+            <Show when={(item.props?.length ?? 0) > 0}>
+              <MdxTable
+                columns={["Prop", "Type", "Default"]}
+                rows={(item.props ?? []).map((prop) => [
+                  <ApiReferenceCodeValue value={prop.name} />,
+                  <ApiReferenceCodeValue value={prop.type} />,
+                  <ApiReferenceDefaultValue prop={prop} />,
+                ])}
+              />
+            </Show>
+            <Show when={(item.examples?.length ?? 0) > 0}>
+              <div class="mt-5 grid gap-4">
+                <For each={item.examples ?? []}>
+                  {(example) => (
+                    <CodeBlock
+                      code={example.code}
+                      colorScheme="reference"
+                      language={example.language ?? "tsx"}
+                      lineNumbers={false}
+                    />
+                  )}
+                </For>
+              </div>
+            </Show>
           </article>
         )}
       </For>
@@ -529,6 +554,20 @@ function ApiReferenceDescription(props: Readonly<{ text: string }>) {
         }
       </For>
     </p>
+  );
+}
+
+function ApiReferenceCodeValue(props: Readonly<{ value: string }>) {
+  return <InlineCode>{props.value}</InlineCode>;
+}
+
+function ApiReferenceDefaultValue(props: Readonly<{ prop: ApiReferenceProp }>) {
+  return props.prop.default ? (
+    <InlineCode>{props.prop.default}</InlineCode>
+  ) : (
+    <span class="text-muted-foreground/64" aria-label="No default value">
+      -
+    </span>
   );
 }
 
@@ -749,7 +788,7 @@ function MissingDocPage(props: Readonly<{ slug: string }>) {
           <PageHeaderDescription>
             The registry does not include an item named <code>{props.slug}</code>.
           </PageHeaderDescription>
-          <ActionLink class={`${secondaryButtonClass} mt-6`} href="/docs">
+          <ActionLink class={`${secondaryButtonClass} mt-6`} href="/docs/introduction">
             <Puzzle size={16} />
             Back to docs
           </ActionLink>

--- a/apps/web/src/docs/registry-doc-blueprints.tsx
+++ b/apps/web/src/docs/registry-doc-blueprints.tsx
@@ -437,29 +437,155 @@ export const componentDocsOverrides = {
     examples: examples.breadcrumbExamples,
   },
   table: {
-    description: "Presentational native table anatomy for readable app data.",
+    description: "Presentational native table anatomy with compact and card-style variants.",
     maturity: "Experimental",
     previewAlign: "start",
     usageCode: examples.tableUsageCode,
     apiItems: [
       {
         name: "TableContainer",
-        description: "Optional overflow and border wrapper for clipping wide native tables.",
+        description:
+          "Overflow wrapper that carries default/card variant context through data attributes.",
+        props: [
+          { name: "class", type: "string" },
+          { name: "variant", type: '"default" | "card"', default: '"default"' },
+        ],
+        examples: [
+          {
+            code: `<TableContainer>
+  <Table>
+    <TableHeader>...</TableHeader>
+    <TableBody>...</TableBody>
+  </Table>
+</TableContainer>`,
+          },
+          {
+            code: `<TableContainer variant="card">
+  <Table>
+    <TableHeader>...</TableHeader>
+    <TableBody>...</TableBody>
+  </Table>
+</TableContainer>`,
+          },
+        ],
       },
       {
         name: "Table",
         description:
-          "Native table root with Keystone density, caption, and tabular-number styling.",
+          "Native table root with Keystone density, caption, tabular-number styling, and optional variant override.",
+        props: [
+          { name: "class", type: "string" },
+          { name: "variant", type: '"default" | "card"', default: '"default"' },
+        ],
+        examples: [
+          {
+            code: `<Table>
+  <TableCaption>Caption</TableCaption>
+  <TableHeader>...</TableHeader>
+  <TableBody>...</TableBody>
+</Table>`,
+          },
+        ],
       },
       {
-        name: "TableHeader / TableBody / TableFooter",
-        description: "Native table section wrappers with stable data hooks.",
+        name: "TableHeader",
+        description: "Native header section containing column headers.",
+        props: [{ name: "class", type: "string" }],
+        examples: [
+          {
+            code: `<TableHeader>
+  <TableRow>
+    <TableHead scope="col">Header</TableHead>
+  </TableRow>
+</TableHeader>`,
+          },
+        ],
       },
       {
-        name: "TableRow / TableHead / TableCell",
-        description: "Native row, header cell, and data cell parts for app-layer composition.",
+        name: "TableBody",
+        description: "Native body section containing table rows and data cells.",
+        props: [{ name: "class", type: "string" }],
+        examples: [
+          {
+            code: `<TableBody>
+  <TableRow>
+    <TableCell>Cell</TableCell>
+  </TableRow>
+</TableBody>`,
+          },
+        ],
       },
-      { name: "TableCaption", description: "Native caption part for readable table summaries." },
+      {
+        name: "TableFooter",
+        description: "Native footer section for totals, summaries, or aggregate rows.",
+        props: [{ name: "class", type: "string" }],
+        examples: [
+          {
+            code: `<TableFooter>
+  <TableRow>
+    <TableCell colSpan={3}>Total</TableCell>
+    <TableCell class="text-right">$39,550</TableCell>
+  </TableRow>
+</TableFooter>`,
+          },
+        ],
+      },
+      {
+        name: "TableRow",
+        description: "Native row part with hover and selected-state styling hooks.",
+        props: [
+          { name: "class", type: "string" },
+          { name: "data-state", type: '"selected" | string' },
+          { name: "data-selected", type: "string" },
+        ],
+        examples: [
+          {
+            code: `<TableRow data-state="selected">
+  <TableCell>Selected row</TableCell>
+</TableRow>`,
+          },
+        ],
+      },
+      {
+        name: "TableHead",
+        description: "Native header cell for column labels.",
+        props: [
+          { name: "class", type: "string" },
+          { name: "scope", type: '"col" | "row" | "colgroup" | "rowgroup"' },
+        ],
+        examples: [
+          {
+            code: `<TableHead class="text-right" scope="col">
+  Budget
+</TableHead>`,
+          },
+        ],
+      },
+      {
+        name: "TableCell",
+        description: "Native data cell for row values.",
+        props: [
+          { name: "class", type: "string" },
+          { name: "colSpan", type: "number" },
+        ],
+        examples: [
+          {
+            code: `<TableCell class="text-right font-medium tabular-nums">
+  $12,500
+</TableCell>`,
+          },
+        ],
+      },
+      {
+        name: "TableCaption",
+        description: "Native caption part for readable table summaries.",
+        props: [{ name: "class", type: "string" }],
+        examples: [
+          {
+            code: `<TableCaption>A list of current projects.</TableCaption>`,
+          },
+        ],
+      },
     ],
     examples: examples.tableExamples,
   },

--- a/apps/web/src/docs/registry-doc-examples.tsx
+++ b/apps/web/src/docs/registry-doc-examples.tsx
@@ -14,6 +14,10 @@ import {
   Card,
   CardDescription,
   CardFooter,
+  CardFrame,
+  CardFrameDescription,
+  CardFrameHeader,
+  CardFrameTitle,
   CardHeader,
   CardPanel,
   CardTitle,
@@ -77,6 +81,7 @@ import {
   TableCaption,
   TableCell,
   TableContainer,
+  TableFooter,
   TableHead,
   TableHeader,
   TableRow,
@@ -2257,7 +2262,7 @@ export function BreadcrumbExample() {
   return (
     <Breadcrumb
       items={[
-        { href: "/docs", label: "Docs" },
+        { href: "/docs/introduction", label: "Docs" },
         { href: "/docs/components", label: "Components" },
         { label: "Breadcrumb", current: true },
       ]}
@@ -2295,7 +2300,7 @@ export function Component() {
   return (
     <Breadcrumb
       items={[
-        { href: "/docs", label: "Docs" },
+        { href: "/docs/introduction", label: "Docs" },
         { href: "/docs/components", label: "Components" },
         { label: "Breadcrumb", current: true },
       ]}
@@ -2361,33 +2366,73 @@ export function Component() {
   );
 }`;
 
-const tableRows = [
-  { name: "Button", status: "Ready", owner: "Core UI" },
-  { name: "CommandMenu", status: "QA", owner: "App layer" },
-  { name: "Table", status: "Experimental", owner: "Data UI" },
+type TableStatus = "Failed" | "Paid" | "Pending" | "Unpaid";
+
+const tableProjectRows: {
+  budget: string;
+  project: string;
+  status: TableStatus;
+  team: string;
+}[] = [
+  { budget: "$12,500", project: "Website Redesign", status: "Paid", team: "Frontend Team" },
+  { budget: "$8,750", project: "Mobile App", status: "Unpaid", team: "Mobile Team" },
+  { budget: "$5,200", project: "API Integration", status: "Pending", team: "Backend Team" },
+  { budget: "$3,800", project: "Database Migration", status: "Paid", team: "DevOps Team" },
+  { budget: "$7,200", project: "User Dashboard", status: "Paid", team: "UX Team" },
+  { budget: "$2,100", project: "Security Audit", status: "Failed", team: "Security Team" },
 ];
+
+const tableStatusDotClass: Record<TableStatus, string> = {
+  Failed: "bg-destructive",
+  Paid: "bg-success",
+  Pending: "bg-warning",
+  Unpaid: "bg-muted-foreground/72",
+};
+
+function TableStatusBadge(props: { status: TableStatus }) {
+  return (
+    <span class="inline-flex h-6 items-center gap-1.5 rounded-md border border-border/72 bg-muted/20 px-2 font-medium text-foreground text-sm leading-none shadow-xs/5">
+      <span class={`size-2 rounded-full ${tableStatusDotClass[props.status]}`} />
+      {props.status}
+    </span>
+  );
+}
 
 export function TableExample() {
   return (
-    <TableContainer class="max-w-xl">
+    <TableContainer class="w-full max-w-5xl">
       <Table>
-        <TableCaption>Registry readiness by component.</TableCaption>
+        <TableCaption>A list of current projects.</TableCaption>
         <TableHeader>
           <TableRow>
-            <TableHead scope="col">Component</TableHead>
+            <TableHead scope="col">Project</TableHead>
             <TableHead scope="col">Status</TableHead>
-            <TableHead scope="col">Owner</TableHead>
+            <TableHead scope="col">Team</TableHead>
+            <TableHead class="text-right" scope="col">
+              Budget
+            </TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
-          {tableRows.map((row) => (
+          {tableProjectRows.map((row) => (
             <TableRow>
-              <TableCell class="font-medium text-foreground">{row.name}</TableCell>
-              <TableCell>{row.status}</TableCell>
-              <TableCell>{row.owner}</TableCell>
+              <TableCell class="font-medium text-foreground">{row.project}</TableCell>
+              <TableCell>
+                <TableStatusBadge status={row.status} />
+              </TableCell>
+              <TableCell>{row.team}</TableCell>
+              <TableCell class="text-right font-medium tabular-nums">{row.budget}</TableCell>
             </TableRow>
           ))}
         </TableBody>
+        <TableFooter>
+          <TableRow>
+            <TableCell class="font-semibold text-foreground" colSpan={3}>
+              Total Budget
+            </TableCell>
+            <TableCell class="text-right font-semibold tabular-nums">$39,550</TableCell>
+          </TableRow>
+        </TableFooter>
       </Table>
     </TableContainer>
   );
@@ -2399,38 +2444,72 @@ export const tableExampleCode = `import {
   TableCaption,
   TableCell,
   TableContainer,
+  TableFooter,
   TableHead,
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
 
 const rows = [
-  { name: "Button", status: "Ready", owner: "Core UI" },
-  { name: "CommandMenu", status: "QA", owner: "App layer" },
-  { name: "Table", status: "Experimental", owner: "Data UI" },
+  { budget: "$12,500", project: "Website Redesign", status: "Paid", team: "Frontend Team" },
+  { budget: "$8,750", project: "Mobile App", status: "Unpaid", team: "Mobile Team" },
+  { budget: "$5,200", project: "API Integration", status: "Pending", team: "Backend Team" },
+  { budget: "$3,800", project: "Database Migration", status: "Paid", team: "DevOps Team" },
+  { budget: "$7,200", project: "User Dashboard", status: "Paid", team: "UX Team" },
+  { budget: "$2,100", project: "Security Audit", status: "Failed", team: "Security Team" },
 ];
+
+const statusDotClass = {
+  Failed: "bg-destructive",
+  Paid: "bg-success",
+  Pending: "bg-warning",
+  Unpaid: "bg-muted-foreground/72",
+};
+
+function StatusBadge(props) {
+  return (
+    <span class="inline-flex h-6 items-center gap-1.5 rounded-md border border-border/72 bg-muted/20 px-2 font-medium text-foreground text-sm leading-none shadow-xs/5">
+      <span class={\`size-2 rounded-full \${statusDotClass[props.status]}\`} />
+      {props.status}
+    </span>
+  );
+}
 
 export function Component() {
   return (
     <TableContainer>
       <Table>
-        <TableCaption>Registry readiness by component.</TableCaption>
+        <TableCaption>A list of current projects.</TableCaption>
         <TableHeader>
           <TableRow>
-            <TableHead scope="col">Component</TableHead>
+            <TableHead scope="col">Project</TableHead>
             <TableHead scope="col">Status</TableHead>
-            <TableHead scope="col">Owner</TableHead>
+            <TableHead scope="col">Team</TableHead>
+            <TableHead class="text-right" scope="col">
+              Budget
+            </TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
           {rows.map((row) => (
             <TableRow>
-              <TableCell class="font-medium text-foreground">{row.name}</TableCell>
-              <TableCell>{row.status}</TableCell>
-              <TableCell>{row.owner}</TableCell>
+              <TableCell class="font-medium text-foreground">{row.project}</TableCell>
+              <TableCell>
+                <StatusBadge status={row.status} />
+              </TableCell>
+              <TableCell>{row.team}</TableCell>
+              <TableCell class="text-right font-medium tabular-nums">{row.budget}</TableCell>
             </TableRow>
           ))}
         </TableBody>
+        <TableFooter>
+          <TableRow>
+            <TableCell class="font-semibold text-foreground" colSpan={3}>
+              Total Budget
+            </TableCell>
+            <TableCell class="text-right font-semibold tabular-nums">$39,550</TableCell>
+          </TableRow>
+        </TableFooter>
       </Table>
     </TableContainer>
   );
@@ -2442,10 +2521,266 @@ export const tableExample = defineCodeExample({
   description: "Presentational native table anatomy for readable data.",
   id: "basic",
   title: "Basic Table",
-  variant: "centered",
+  variant: "full",
 });
 
-export const tableExamples = [tableExample] satisfies readonly CodeExample[];
+export function CardTableExample() {
+  return (
+    <TableContainer class="w-full max-w-5xl" variant="card">
+      <Table>
+        <TableCaption>A list of current projects.</TableCaption>
+        <TableHeader>
+          <TableRow>
+            <TableHead scope="col">Project</TableHead>
+            <TableHead scope="col">Status</TableHead>
+            <TableHead scope="col">Team</TableHead>
+            <TableHead class="text-right" scope="col">
+              Budget
+            </TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {tableProjectRows.map((row) => (
+            <TableRow data-state={row.status === "Paid" ? "selected" : undefined}>
+              <TableCell class="font-medium text-foreground">{row.project}</TableCell>
+              <TableCell>
+                <TableStatusBadge status={row.status} />
+              </TableCell>
+              <TableCell>{row.team}</TableCell>
+              <TableCell class="text-right font-medium tabular-nums">{row.budget}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+        <TableFooter>
+          <TableRow>
+            <TableCell class="font-semibold text-foreground" colSpan={3}>
+              Total Budget
+            </TableCell>
+            <TableCell class="text-right font-semibold tabular-nums">$39,550</TableCell>
+          </TableRow>
+        </TableFooter>
+      </Table>
+    </TableContainer>
+  );
+}
+
+export const cardTableExampleCode = `import {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableContainer,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+const rows = [
+  { budget: "$12,500", project: "Website Redesign", status: "Paid", team: "Frontend Team" },
+  { budget: "$8,750", project: "Mobile App", status: "Unpaid", team: "Mobile Team" },
+  { budget: "$5,200", project: "API Integration", status: "Pending", team: "Backend Team" },
+  { budget: "$3,800", project: "Database Migration", status: "Paid", team: "DevOps Team" },
+  { budget: "$7,200", project: "User Dashboard", status: "Paid", team: "UX Team" },
+  { budget: "$2,100", project: "Security Audit", status: "Failed", team: "Security Team" },
+];
+
+const statusDotClass = {
+  Failed: "bg-destructive",
+  Paid: "bg-success",
+  Pending: "bg-warning",
+  Unpaid: "bg-muted-foreground/72",
+};
+
+function StatusBadge(props) {
+  return (
+    <span class="inline-flex h-6 items-center gap-1.5 rounded-md border border-border/72 bg-muted/20 px-2 font-medium text-foreground text-sm leading-none shadow-xs/5">
+      <span class={\`size-2 rounded-full \${statusDotClass[props.status]}\`} />
+      {props.status}
+    </span>
+  );
+}
+
+export function Component() {
+  return (
+    <TableContainer variant="card">
+      <Table>
+        <TableCaption>A list of current projects.</TableCaption>
+        <TableHeader>
+          <TableRow>
+            <TableHead scope="col">Project</TableHead>
+            <TableHead scope="col">Status</TableHead>
+            <TableHead scope="col">Team</TableHead>
+            <TableHead class="text-right" scope="col">
+              Budget
+            </TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {rows.map((row) => (
+            <TableRow data-state={row.status === "Paid" ? "selected" : undefined}>
+              <TableCell class="font-medium text-foreground">{row.project}</TableCell>
+              <TableCell>
+                <StatusBadge status={row.status} />
+              </TableCell>
+              <TableCell>{row.team}</TableCell>
+              <TableCell class="text-right font-medium tabular-nums">{row.budget}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+        <TableFooter>
+          <TableRow>
+            <TableCell class="font-semibold text-foreground" colSpan={3}>
+              Total Budget
+            </TableCell>
+            <TableCell class="text-right font-semibold tabular-nums">$39,550</TableCell>
+          </TableRow>
+        </TableFooter>
+      </Table>
+    </TableContainer>
+  );
+}`;
+
+export const cardTableExample = defineCodeExample({
+  code: cardTableExampleCode,
+  component: CardTableExample,
+  description: "Card variant with separated rows, quiet borders, and selected-row styling.",
+  id: "card",
+  title: "Card Variant",
+  variant: "full",
+});
+
+export function CardFrameTableExample() {
+  return (
+    <CardFrame class="w-full max-w-5xl">
+      <CardFrameHeader>
+        <CardFrameTitle>Project Budget</CardFrameTitle>
+        <CardFrameDescription>
+          CardFrame keeps the table clipped inside a framed surface.
+        </CardFrameDescription>
+      </CardFrameHeader>
+      <TableContainer variant="card">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead scope="col">Project</TableHead>
+              <TableHead scope="col">Status</TableHead>
+              <TableHead scope="col">Team</TableHead>
+              <TableHead class="text-right" scope="col">
+                Budget
+              </TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {tableProjectRows.map((row) => (
+              <TableRow>
+                <TableCell class="font-medium text-foreground">{row.project}</TableCell>
+                <TableCell>
+                  <TableStatusBadge status={row.status} />
+                </TableCell>
+                <TableCell>{row.team}</TableCell>
+                <TableCell class="text-right font-medium tabular-nums">{row.budget}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </CardFrame>
+  );
+}
+
+export const cardFrameTableExampleCode = `import {
+  CardFrame,
+  CardFrameDescription,
+  CardFrameHeader,
+  CardFrameTitle,
+} from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+const rows = [
+  { budget: "$12,500", project: "Website Redesign", status: "Paid", team: "Frontend Team" },
+  { budget: "$8,750", project: "Mobile App", status: "Unpaid", team: "Mobile Team" },
+  { budget: "$5,200", project: "API Integration", status: "Pending", team: "Backend Team" },
+  { budget: "$3,800", project: "Database Migration", status: "Paid", team: "DevOps Team" },
+  { budget: "$7,200", project: "User Dashboard", status: "Paid", team: "UX Team" },
+  { budget: "$2,100", project: "Security Audit", status: "Failed", team: "Security Team" },
+];
+
+const statusDotClass = {
+  Failed: "bg-destructive",
+  Paid: "bg-success",
+  Pending: "bg-warning",
+  Unpaid: "bg-muted-foreground/72",
+};
+
+function StatusBadge(props) {
+  return (
+    <span class="inline-flex h-6 items-center gap-1.5 rounded-md border border-border/72 bg-muted/20 px-2 font-medium text-foreground text-sm leading-none shadow-xs/5">
+      <span class={\`size-2 rounded-full \${statusDotClass[props.status]}\`} />
+      {props.status}
+    </span>
+  );
+}
+
+export function Component() {
+  return (
+    <CardFrame>
+      <CardFrameHeader>
+        <CardFrameTitle>Project Budget</CardFrameTitle>
+        <CardFrameDescription>CardFrame keeps the table clipped inside a framed surface.</CardFrameDescription>
+      </CardFrameHeader>
+      <TableContainer variant="card">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead scope="col">Project</TableHead>
+              <TableHead scope="col">Status</TableHead>
+              <TableHead scope="col">Team</TableHead>
+              <TableHead class="text-right" scope="col">
+                Budget
+              </TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {rows.map((row) => (
+              <TableRow>
+                <TableCell class="font-medium text-foreground">{row.project}</TableCell>
+                <TableCell>
+                  <StatusBadge status={row.status} />
+                </TableCell>
+                <TableCell>{row.team}</TableCell>
+                <TableCell class="text-right font-medium tabular-nums">{row.budget}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </CardFrame>
+  );
+}`;
+
+export const cardFrameTableExample = defineCodeExample({
+  code: cardFrameTableExampleCode,
+  component: CardFrameTableExample,
+  description: "Card table inside CardFrame with the existing table-container clipping hook.",
+  id: "card-frame",
+  title: "CardFrame Table",
+  variant: "full",
+});
+
+export const tableExamples = [
+  tableExample,
+  cardTableExample,
+  cardFrameTableExample,
+] satisfies readonly CodeExample[];
 export const tableUsageCode = `import {
   Table,
   TableBody,

--- a/apps/web/src/docs/registry-doc-types.ts
+++ b/apps/web/src/docs/registry-doc-types.ts
@@ -15,7 +15,20 @@ export type CodeExample = {
 
 export type ApiReferenceItem = {
   description: string;
+  examples?: readonly ApiReferenceExample[];
   name: string;
+  props?: readonly ApiReferenceProp[];
+};
+
+export type ApiReferenceExample = {
+  code: string;
+  language?: string;
+};
+
+export type ApiReferenceProp = {
+  default?: string;
+  name: string;
+  type: string;
 };
 
 export type ComponentDocsBlueprint = {

--- a/apps/web/src/lib/docs-data.ts
+++ b/apps/web/src/lib/docs-data.ts
@@ -160,7 +160,7 @@ function componentBadge(name: string) {
 export const overviewPage: DocsPage = {
   description:
     "Solid primitives, source-owned UI components, shadcn-compatible registry metadata, and app-layer registry guidance.",
-  href: "/docs",
+  href: "/docs/introduction",
   label: "Introduction",
   title: "Introduction",
   toc: [
@@ -173,7 +173,7 @@ export const overviewPage: DocsPage = {
 export const navGroups: readonly NavGroup[] = [
   {
     title: "Overview",
-    items: [{ label: "Introduction", href: "/docs" }],
+    items: [{ label: "Introduction", href: "/docs/introduction" }],
   },
   {
     title: "Components",

--- a/apps/web/src/lib/registry-docs.gen.ts
+++ b/apps/web/src/lib/registry-docs.gen.ts
@@ -3380,7 +3380,7 @@ export const registryDocItems = [
       "head",
       "cell"
     ],
-    "api": "Table exports TableContainer, Table, TableHeader, TableBody, TableFooter, TableRow, TableHead, TableCell, and TableCaption. Every part forwards native HTML props, class, children, and data-scope/data-part/data-slot overrides for app-layer wrappers.",
+    "api": "Table exports TableContainer, Table, TableHeader, TableBody, TableFooter, TableRow, TableHead, TableCell, and TableCaption. TableContainer and Table accept variant?: \"default\" | \"card\" with default \"default\"; Table inherits the container variant unless overridden. Every part forwards native HTML props, class, children, and data-scope/data-part/data-slot overrides for app-layer wrappers.",
     "categories": [
       "base",
       "table",
@@ -3391,12 +3391,12 @@ export const registryDocItems = [
       "solid": ">=1.9.0 <2.0.0",
       "shadcn": "registry-item schema"
     },
-    "customization": "Customize the native anatomy through ui-table classes, shadcn-style data-slot values, and stable data-scope=\"ui-table\" data-part hooks.",
-    "dataAttributes": "Defaults use data-scope=\"ui-table\" and data-part values container, root, caption, header, body, footer, row, head, and cell. data-slot values are table-container, table, table-caption, table-header, table-body, table-footer, table-row, table-head, and table-cell. App-layer components may override those attributes while retaining native elements and classes.",
+    "customization": "Customize the native anatomy through ui-table classes, shadcn-style data-slot values, stable data-scope=\"ui-table\" data-part hooks, and the default/card variant context on TableContainer and Table.",
+    "dataAttributes": "Defaults use data-scope=\"ui-table\" and data-part values container, root, caption, header, body, footer, row, head, and cell. data-slot values are table-container, table, table-caption, table-header, table-body, table-footer, table-row, table-head, and table-cell. TableContainer and Table expose data-variant=\"default\" or data-variant=\"card\" for variant-scoped styling. App-layer components may override data-scope/data-part/data-slot while retaining native elements and classes.",
     "dependencies": [
       "cn"
     ],
-    "description": "Presentational native table anatomy for readable data grids and TanStack Table app-layer composition.",
+    "description": "Presentational native table anatomy with compact default and card-style variants for readable data grids and TanStack Table app-layer composition.",
     "files": [
       {
         "path": "packages/ui/src/components/table.tsx",
@@ -3413,12 +3413,13 @@ export const registryDocItems = [
       "tanstack-table",
       "data-table"
     ],
-    "limitations": "Table is presentational source, not a grid engine. It does not implement sorting, filtering, pagination, virtualization, roving focus, column sizing, column reordering, row selection, or async loading policy.",
+    "limitations": "Table is presentational source, not a grid engine and not a Core wrapper. Native table semantics are the primitive for this surface. It does not implement sorting, filtering, pagination, virtualization, roving focus, column sizing, column reordering, row selection, or async loading policy.",
     "maturity": "Experimental",
     "name": "table",
     "parity": {
+      "coss": "Adapts the coss card/default styling idea to Solid source and Keystone tokens: variant context, separated card rows, quiet borders, rounded row edges, footer treatment, caption spacing, and CardFrame-compatible table-container clipping.",
       "html": "Keeps native table semantics as the contract: Keystone does not replace table markup with ARIA grid roles unless a future app component requires that behavior explicitly.",
-      "shadcn": "Matches the copy-paste anatomy shape and data-slot ergonomics in Solid source form, with Keystone tokens, compact styling, and a TableContainer part compatible with CardFrame table-container clipping.",
+      "shadcn": "Matches the copy-paste anatomy shape and data-slot ergonomics in Solid source form, with Keystone tokens, compact default styling, optional card styling, and a TableContainer part compatible with CardFrame table-container clipping.",
       "tanstackTable": "The base parts are intentionally engine-agnostic and are consumed by the first-party DataTable kit, where TanStack Table owns row models, sorting, filtering, pagination, selection, and column visibility."
     },
     "registryDependencies": [

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as DocsRouteRouteImport } from './routes/docs/route'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as DocsIndexRouteImport } from './routes/docs/index'
+import { Route as DocsIntroductionRouteImport } from './routes/docs/introduction'
 import { Route as DocsComponentsIndexRouteImport } from './routes/docs/components/index'
 import { Route as DocsComponentsSlugRouteImport } from './routes/docs/components/$slug'
 
@@ -30,6 +31,11 @@ const DocsIndexRoute = DocsIndexRouteImport.update({
   path: '/',
   getParentRoute: () => DocsRouteRoute,
 } as any)
+const DocsIntroductionRoute = DocsIntroductionRouteImport.update({
+  id: '/introduction',
+  path: '/introduction',
+  getParentRoute: () => DocsRouteRoute,
+} as any)
 const DocsComponentsIndexRoute = DocsComponentsIndexRouteImport.update({
   id: '/components/',
   path: '/components/',
@@ -44,12 +50,14 @@ const DocsComponentsSlugRoute = DocsComponentsSlugRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/docs': typeof DocsRouteRouteWithChildren
+  '/docs/introduction': typeof DocsIntroductionRoute
   '/docs/': typeof DocsIndexRoute
   '/docs/components/$slug': typeof DocsComponentsSlugRoute
   '/docs/components/': typeof DocsComponentsIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/docs/introduction': typeof DocsIntroductionRoute
   '/docs': typeof DocsIndexRoute
   '/docs/components/$slug': typeof DocsComponentsSlugRoute
   '/docs/components': typeof DocsComponentsIndexRoute
@@ -58,6 +66,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/docs': typeof DocsRouteRouteWithChildren
+  '/docs/introduction': typeof DocsIntroductionRoute
   '/docs/': typeof DocsIndexRoute
   '/docs/components/$slug': typeof DocsComponentsSlugRoute
   '/docs/components/': typeof DocsComponentsIndexRoute
@@ -67,15 +76,22 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/docs'
+    | '/docs/introduction'
     | '/docs/'
     | '/docs/components/$slug'
     | '/docs/components/'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/docs' | '/docs/components/$slug' | '/docs/components'
+  to:
+    | '/'
+    | '/docs/introduction'
+    | '/docs'
+    | '/docs/components/$slug'
+    | '/docs/components'
   id:
     | '__root__'
     | '/'
     | '/docs'
+    | '/docs/introduction'
     | '/docs/'
     | '/docs/components/$slug'
     | '/docs/components/'
@@ -109,6 +125,13 @@ declare module '@tanstack/solid-router' {
       preLoaderRoute: typeof DocsIndexRouteImport
       parentRoute: typeof DocsRouteRoute
     }
+    '/docs/introduction': {
+      id: '/docs/introduction'
+      path: '/introduction'
+      fullPath: '/docs/introduction'
+      preLoaderRoute: typeof DocsIntroductionRouteImport
+      parentRoute: typeof DocsRouteRoute
+    }
     '/docs/components/': {
       id: '/docs/components/'
       path: '/components'
@@ -127,12 +150,14 @@ declare module '@tanstack/solid-router' {
 }
 
 interface DocsRouteRouteChildren {
+  DocsIntroductionRoute: typeof DocsIntroductionRoute
   DocsIndexRoute: typeof DocsIndexRoute
   DocsComponentsSlugRoute: typeof DocsComponentsSlugRoute
   DocsComponentsIndexRoute: typeof DocsComponentsIndexRoute
 }
 
 const DocsRouteRouteChildren: DocsRouteRouteChildren = {
+  DocsIntroductionRoute: DocsIntroductionRoute,
   DocsIndexRoute: DocsIndexRoute,
   DocsComponentsSlugRoute: DocsComponentsSlugRoute,
   DocsComponentsIndexRoute: DocsComponentsIndexRoute,

--- a/apps/web/src/routes/docs/components/index.tsx
+++ b/apps/web/src/routes/docs/components/index.tsx
@@ -3,6 +3,6 @@ import { createFileRoute, redirect } from "@tanstack/solid-router";
 export const Route = createFileRoute("/docs/components/")({
   ssr: true,
   beforeLoad: () => {
-    throw redirect({ to: "/docs" });
+    throw redirect({ to: "/docs/introduction" });
   },
 });

--- a/apps/web/src/routes/docs/index.tsx
+++ b/apps/web/src/routes/docs/index.tsx
@@ -1,18 +1,8 @@
-import { createFileRoute } from "@tanstack/solid-router";
-
-import { DocsOverview } from "@/components/docs-overview";
-import { seo } from "@/lib/utils";
-
-const overviewDescription =
-  "Solid primitives, source-owned UI components, shadcn-compatible registry metadata, and app-layer registry guidance.";
+import { createFileRoute, redirect } from "@tanstack/solid-router";
 
 export const Route = createFileRoute("/docs/")({
   ssr: true,
-  component: DocsOverview,
-  head: () => ({
-    meta: seo({
-      title: "Introduction · Keystone UI",
-      description: overviewDescription,
-    }),
-  }),
+  beforeLoad: () => {
+    throw redirect({ to: "/docs/introduction" });
+  },
 });

--- a/apps/web/src/routes/docs/introduction.tsx
+++ b/apps/web/src/routes/docs/introduction.tsx
@@ -1,0 +1,18 @@
+import { createFileRoute } from "@tanstack/solid-router";
+
+import { DocsOverview } from "@/components/docs-overview";
+import { seo } from "@/lib/utils";
+
+const overviewDescription =
+  "Solid primitives, source-owned UI components, shadcn-compatible registry metadata, and app-layer registry guidance.";
+
+export const Route = createFileRoute("/docs/introduction")({
+  ssr: true,
+  component: DocsOverview,
+  head: () => ({
+    meta: seo({
+      title: "Introduction · Keystone UI",
+      description: overviewDescription,
+    }),
+  }),
+});

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -3,6 +3,6 @@ import { createFileRoute, redirect } from "@tanstack/solid-router";
 export const Route = createFileRoute("/")({
   ssr: true,
   beforeLoad: () => {
-    throw redirect({ to: "/docs" });
+    throw redirect({ to: "/docs/introduction" });
   },
 });

--- a/packages/ui/src/components/data-table/data-table.test.tsx
+++ b/packages/ui/src/components/data-table/data-table.test.tsx
@@ -45,8 +45,10 @@ describe("DataTable TanStack proof", () => {
 
     expect(viewport?.getAttribute("data-scope")).toBe("ui-data-table");
     expect(viewport?.getAttribute("data-slot")).toBe("table-container");
+    expect(viewport?.getAttribute("data-variant")).toBe("default");
     expect(table?.getAttribute("data-scope")).toBe("ui-data-table");
     expect(table?.getAttribute("data-slot")).toBe("table");
+    expect(table?.getAttribute("data-variant")).toBe("default");
     expect(host.querySelector("caption")?.textContent).toBe("Service latency");
     expect(headers[0]?.getAttribute("aria-sort")).toBe("none");
     expect(cells[0]?.textContent).toBe("API");

--- a/packages/ui/src/components/table.test.tsx
+++ b/packages/ui/src/components/table.test.tsx
@@ -6,6 +6,7 @@ import {
   TableCaption,
   TableCell,
   TableContainer,
+  TableFooter,
   TableHead,
   TableHeader,
   TableRow,
@@ -31,6 +32,12 @@ describe("Table", () => {
                 <TableCell>$120k</TableCell>
               </TableRow>
             </TableBody>
+            <TableFooter>
+              <TableRow>
+                <TableCell>Total</TableCell>
+                <TableCell>$120k</TableCell>
+              </TableRow>
+            </TableFooter>
           </Table>
         </TableContainer>
       ),
@@ -42,14 +49,19 @@ describe("Table", () => {
     const caption = host.querySelector("caption");
     const head = host.querySelector("th");
     const selectedRow = host.querySelector("tbody tr");
+    const footer = host.querySelector("tfoot");
 
     expect(container?.getAttribute("data-scope")).toBe("ui-table");
     expect(container?.getAttribute("data-part")).toBe("container");
+    expect(container?.getAttribute("data-variant")).toBe("default");
     expect(table?.getAttribute("data-slot")).toBe("table");
+    expect(table?.getAttribute("data-variant")).toBe("default");
     expect(caption?.textContent).toBe("Quarterly revenue");
     expect(head?.getAttribute("scope")).toBe("col");
     expect(selectedRow?.getAttribute("data-state")).toBe("selected");
+    expect(footer?.getAttribute("data-part")).toBe("footer");
     expect(table?.className).toContain("caption-bottom");
+    expect(table?.className).toContain("border-collapse");
 
     dispose();
   });
@@ -74,6 +86,86 @@ describe("Table", () => {
     expect(container?.getAttribute("data-scope")).toBe("ui-data-table");
     expect(table?.getAttribute("data-scope")).toBe("ui-data-table");
     expect(body?.getAttribute("data-part")).toBe("body");
+    expect(table?.getAttribute("data-variant")).toBe("default");
+
+    dispose();
+  });
+
+  test("uses TableContainer card variant as styling context for table parts", () => {
+    const host = document.createElement("div");
+    const dispose = render(
+      () => (
+        <TableContainer variant="card">
+          <Table>
+            <TableCaption>Release channels</TableCaption>
+            <TableHeader>
+              <TableRow>
+                <TableHead scope="col">Channel</TableHead>
+                <TableHead scope="col">Status</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              <TableRow data-selected="">
+                <TableCell>Stable</TableCell>
+                <TableCell>Ready</TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell>Canary</TableCell>
+                <TableCell>Review</TableCell>
+              </TableRow>
+            </TableBody>
+            <TableFooter>
+              <TableRow>
+                <TableCell>Count</TableCell>
+                <TableCell>2</TableCell>
+              </TableRow>
+            </TableFooter>
+          </Table>
+        </TableContainer>
+      ),
+      host,
+    );
+
+    const container = host.querySelector("[data-slot='table-container']");
+    const table = host.querySelector("table");
+    const body = host.querySelector("tbody");
+    const footer = host.querySelector("tfoot");
+    const cell = host.querySelector("td");
+    const caption = host.querySelector("caption");
+
+    expect(container?.getAttribute("data-variant")).toBe("card");
+    expect(container?.className).toContain("data-[variant=card]:rounded-2xl");
+    expect(table?.getAttribute("data-variant")).toBe("card");
+    expect(table?.className).toContain("data-[variant=card]:border-separate");
+    expect(body?.className).toContain("in-data-[variant=card]:[&_tr>td]:bg-card");
+    expect(body?.className).toContain(
+      "in-data-[variant=card]:[&_tr[data-selected]>td]:bg-muted/48",
+    );
+    expect(footer?.className).toContain("in-data-[variant=card]:[&_td]:bg-transparent");
+    expect(cell?.className).toContain("in-data-[variant=card]:px-4");
+    expect(caption?.className).toContain("in-data-[variant=card]:pt-2");
+
+    dispose();
+  });
+
+  test("allows Table variant prop to override container context", () => {
+    const host = document.createElement("div");
+    const dispose = render(
+      () => (
+        <TableContainer variant="default">
+          <Table variant="card">
+            <TableBody />
+          </Table>
+        </TableContainer>
+      ),
+      host,
+    );
+
+    const container = host.querySelector("[data-slot='table-container']");
+    const table = host.querySelector("table");
+
+    expect(container?.getAttribute("data-variant")).toBe("default");
+    expect(table?.getAttribute("data-variant")).toBe("card");
 
     dispose();
   });

--- a/packages/ui/src/components/table.tsx
+++ b/packages/ui/src/components/table.tsx
@@ -1,17 +1,33 @@
-import { splitProps, type JSX, type ParentProps } from "solid-js";
+import {
+  createContext,
+  splitProps,
+  useContext,
+  type Accessor,
+  type JSX,
+  type ParentProps,
+} from "solid-js";
 import { cn } from "@/lib/cn";
+
+export type TableVariant = "default" | "card";
 
 type KeystoneTableDataAttributes = {
   "data-part"?: string;
   "data-scope"?: string;
   "data-slot"?: string;
+  "data-variant"?: string;
 };
 
 export type TableContainerProps = ParentProps<
-  JSX.HTMLAttributes<HTMLDivElement> & KeystoneTableDataAttributes
+  JSX.HTMLAttributes<HTMLDivElement> &
+    KeystoneTableDataAttributes & {
+      variant?: TableVariant;
+    }
 >;
 export type TableProps = ParentProps<
-  JSX.HTMLAttributes<HTMLTableElement> & KeystoneTableDataAttributes
+  JSX.HTMLAttributes<HTMLTableElement> &
+    KeystoneTableDataAttributes & {
+      variant?: TableVariant;
+    }
 >;
 export type TableHeaderProps = ParentProps<
   JSX.HTMLAttributes<HTMLTableSectionElement> & KeystoneTableDataAttributes
@@ -36,36 +52,63 @@ export type TableCaptionProps = ParentProps<
 >;
 
 const classes = (...tokens: string[]) => tokens.join(" ");
+const defaultTableVariant: Accessor<TableVariant> = () => "default";
+const TableVariantContext = createContext<Accessor<TableVariant>>(defaultTableVariant);
 
 export function TableContainer(props: TableContainerProps) {
-  const [local, rest] = splitProps(props, ["class", "data-part", "data-scope", "data-slot"]);
+  const [local, rest] = splitProps(props, [
+    "class",
+    "data-part",
+    "data-scope",
+    "data-slot",
+    "data-variant",
+    "variant",
+  ]);
+  const variant = () => local.variant ?? "default";
 
   return (
-    <div
-      {...rest}
-      data-scope={local["data-scope"] ?? "ui-table"}
-      data-part={local["data-part"] ?? "container"}
-      data-slot={local["data-slot"] ?? "table-container"}
-      class={cn(
-        classes(
-          "ui-table-container",
-          "relative",
-          "w-full",
-          "overflow-x-auto",
-          "rounded-lg",
-          "border",
-          "bg-background",
-          "not-dark:bg-clip-padding",
-          "shadow-xs/5",
-        ),
-        local.class,
-      )}
-    />
+    <TableVariantContext.Provider value={variant}>
+      <div
+        {...rest}
+        data-scope={local["data-scope"] ?? "ui-table"}
+        data-part={local["data-part"] ?? "container"}
+        data-slot={local["data-slot"] ?? "table-container"}
+        data-variant={local["data-variant"] ?? variant()}
+        class={cn(
+          classes(
+            "ui-table-container",
+            "relative",
+            "w-full",
+            "overflow-x-auto",
+            "rounded-lg",
+            "border",
+            "bg-background",
+            "not-dark:bg-clip-padding",
+            "shadow-xs/5",
+            "data-[variant=card]:rounded-2xl",
+            "data-[variant=card]:border-border/72",
+            "data-[variant=card]:bg-card",
+            "data-[variant=card]:text-card-foreground",
+            "data-[variant=card]:shadow-xs/5",
+          ),
+          local.class,
+        )}
+      />
+    </TableVariantContext.Provider>
   );
 }
 
 export function Table(props: TableProps) {
-  const [local, rest] = splitProps(props, ["class", "data-part", "data-scope", "data-slot"]);
+  const containerVariant = useContext(TableVariantContext);
+  const [local, rest] = splitProps(props, [
+    "class",
+    "data-part",
+    "data-scope",
+    "data-slot",
+    "data-variant",
+    "variant",
+  ]);
+  const variant = () => local.variant ?? containerVariant();
 
   return (
     <table
@@ -73,7 +116,20 @@ export function Table(props: TableProps) {
       data-scope={local["data-scope"] ?? "ui-table"}
       data-part={local["data-part"] ?? "root"}
       data-slot={local["data-slot"] ?? "table"}
-      class={cn("ui-table w-full caption-bottom border-collapse text-sm tabular-nums", local.class)}
+      data-variant={local["data-variant"] ?? variant()}
+      class={cn(
+        classes(
+          "ui-table",
+          "w-full",
+          "caption-bottom",
+          "border-collapse",
+          "text-sm",
+          "tabular-nums",
+          "data-[variant=card]:border-separate",
+          "data-[variant=card]:border-spacing-0",
+        ),
+        local.class,
+      )}
     />
   );
 }
@@ -87,7 +143,10 @@ export function TableHeader(props: TableHeaderProps) {
       data-scope={local["data-scope"] ?? "ui-table"}
       data-part={local["data-part"] ?? "header"}
       data-slot={local["data-slot"] ?? "table-header"}
-      class={cn("ui-table-header [&_tr]:border-b", local.class)}
+      class={cn(
+        "ui-table-header [&_tr]:border-b in-data-[variant=card]:[&_tr]:border-0",
+        local.class,
+      )}
     />
   );
 }
@@ -101,7 +160,30 @@ export function TableBody(props: TableBodyProps) {
       data-scope={local["data-scope"] ?? "ui-table"}
       data-part={local["data-part"] ?? "body"}
       data-slot={local["data-slot"] ?? "table-body"}
-      class={cn("ui-table-body [&_tr:last-child]:border-0", local.class)}
+      class={cn(
+        classes(
+          "ui-table-body",
+          "[&_tr:last-child]:border-0",
+          "in-data-[variant=card]:relative",
+          "in-data-[variant=card]:rounded-xl",
+          "in-data-[variant=card]:shadow-xs/5",
+          "in-data-[variant=card]:[&_tr]:border-0",
+          "in-data-[variant=card]:[&_tr>td]:border-b",
+          "in-data-[variant=card]:[&_tr>td]:border-border/72",
+          "in-data-[variant=card]:[&_tr>td]:bg-card",
+          "in-data-[variant=card]:[&_tr:first-child>td]:border-t",
+          "in-data-[variant=card]:[&_tr>td:first-child]:border-s",
+          "in-data-[variant=card]:[&_tr>td:last-child]:border-e",
+          "in-data-[variant=card]:[&_tr:first-child>td:first-child]:rounded-ss-xl",
+          "in-data-[variant=card]:[&_tr:first-child>td:last-child]:rounded-se-xl",
+          "in-data-[variant=card]:[&_tr:last-child>td:first-child]:rounded-es-xl",
+          "in-data-[variant=card]:[&_tr:last-child>td:last-child]:rounded-ee-xl",
+          "in-data-[variant=card]:[&_tr:hover>td]:bg-muted/28",
+          "in-data-[variant=card]:[&_tr[data-state=selected]>td]:bg-muted/48",
+          "in-data-[variant=card]:[&_tr[data-selected]>td]:bg-muted/48",
+        ),
+        local.class,
+      )}
     />
   );
 }
@@ -116,7 +198,19 @@ export function TableFooter(props: TableFooterProps) {
       data-part={local["data-part"] ?? "footer"}
       data-slot={local["data-slot"] ?? "table-footer"}
       class={cn(
-        "ui-table-footer border-t bg-muted/40 font-medium [&>tr]:last:border-b-0",
+        classes(
+          "ui-table-footer",
+          "border-t",
+          "bg-muted/40",
+          "font-medium",
+          "[&>tr]:last:border-b-0",
+          "in-data-[variant=card]:border-0",
+          "in-data-[variant=card]:bg-transparent",
+          "in-data-[variant=card]:[&_td]:border-0",
+          "in-data-[variant=card]:[&_td]:bg-transparent",
+          "in-data-[variant=card]:[&_td]:pt-4",
+          "in-data-[variant=card]:[&_td]:pb-3.5",
+        ),
         local.class,
       )}
     />
@@ -140,6 +234,10 @@ export function TableRow(props: TableRowProps) {
           "hover:bg-muted/40",
           "data-[state=selected]:bg-muted/64",
           "data-selected:bg-muted/64",
+          "in-data-[variant=card]:border-0",
+          "in-data-[variant=card]:hover:bg-transparent",
+          "in-data-[variant=card]:data-[state=selected]:bg-transparent",
+          "in-data-[variant=card]:data-selected:bg-transparent",
         ),
         local.class,
       )}
@@ -161,11 +259,19 @@ export function TableHead(props: TableHeadProps) {
           "ui-table-head",
           "h-9",
           "px-3",
+          "whitespace-nowrap",
           "text-left",
           "align-middle",
           "font-medium",
+          "leading-none",
           "text-muted-foreground",
           "[&:has([role=checkbox])]:pe-0",
+          "in-data-[variant=card]:h-10",
+          "in-data-[variant=card]:px-4",
+          "in-data-[variant=card]:text-muted-foreground/88",
+          "has-[[role=checkbox]]:w-px",
+          "first:has-[[role=checkbox]]:pe-0",
+          "last:has-[[role=checkbox]]:ps-0",
         ),
         local.class,
       )}
@@ -182,7 +288,24 @@ export function TableCell(props: TableCellProps) {
       data-scope={local["data-scope"] ?? "ui-table"}
       data-part={local["data-part"] ?? "cell"}
       data-slot={local["data-slot"] ?? "table-cell"}
-      class={cn("ui-table-cell p-3 align-middle [&:has([role=checkbox])]:pe-0", local.class)}
+      class={cn(
+        classes(
+          "ui-table-cell",
+          "bg-clip-padding",
+          "p-3",
+          "align-middle",
+          "[&:has([role=checkbox])]:pe-0",
+          "in-data-[variant=card]:px-4",
+          "in-data-[variant=card]:py-3.5",
+          "in-data-[variant=card]:leading-tight",
+          "in-data-[variant=card]:whitespace-nowrap",
+          "in-data-[slot=table-footer]:py-3.5",
+          "has-[[role=checkbox]]:w-px",
+          "first:has-[[role=checkbox]]:pe-0",
+          "last:has-[[role=checkbox]]:ps-0",
+        ),
+        local.class,
+      )}
     />
   );
 }
@@ -196,7 +319,10 @@ export function TableCaption(props: TableCaptionProps) {
       data-scope={local["data-scope"] ?? "ui-table"}
       data-part={local["data-part"] ?? "caption"}
       data-slot={local["data-slot"] ?? "table-caption"}
-      class={cn("ui-table-caption mt-3 text-muted-foreground text-sm", local.class)}
+      class={cn(
+        "ui-table-caption mt-0 border-border/64 border-t px-3 py-3 text-center text-muted-foreground text-sm leading-none in-data-[variant=card]:border-t-0 in-data-[variant=card]:pt-2 in-data-[variant=card]:pb-3.5",
+        local.class,
+      )}
     />
   );
 }

--- a/registry/default/items/table.json
+++ b/registry/default/items/table.json
@@ -3,7 +3,7 @@
   "name": "table",
   "type": "registry:ui",
   "title": "Table",
-  "description": "Presentational native table anatomy for readable data grids and TanStack Table app-layer composition.",
+  "description": "Presentational native table anatomy with compact default and card-style variants for readable data grids and TanStack Table app-layer composition.",
   "version": "0.1.0",
   "compatibility": {
     "registryTooling": ">=0.1.0 <0.2.0",
@@ -30,14 +30,14 @@
   "meta": {
     "install": "shadcn add https://keystone-ui.dev/r/table.json",
     "maturity": "Experimental",
-    "customization": "Customize the native anatomy through ui-table classes, shadcn-style data-slot values, and stable data-scope=\"ui-table\" data-part hooks.",
+    "customization": "Customize the native anatomy through ui-table classes, shadcn-style data-slot values, stable data-scope=\"ui-table\" data-part hooks, and the default/card variant context on TableContainer and Table.",
     "sourceFiles": [
       "packages/ui/src/components/table.tsx"
     ],
     "dependencies": [
       "cn"
     ],
-    "api": "Table exports TableContainer, Table, TableHeader, TableBody, TableFooter, TableRow, TableHead, TableCell, and TableCaption. Every part forwards native HTML props, class, children, and data-scope/data-part/data-slot overrides for app-layer wrappers.",
+    "api": "Table exports TableContainer, Table, TableHeader, TableBody, TableFooter, TableRow, TableHead, TableCell, and TableCaption. TableContainer and Table accept variant?: \"default\" | \"card\" with default \"default\"; Table inherits the container variant unless overridden. Every part forwards native HTML props, class, children, and data-scope/data-part/data-slot overrides for app-layer wrappers.",
     "accessibility": "The component preserves native table, caption, thead, tbody, tfoot, tr, th, and td semantics. Consumers own caption text, header scope, aria-sort, labelled regions, selected-row announcements, and any interactive controls placed inside cells.",
     "anatomy": [
       "container",
@@ -50,13 +50,14 @@
       "head",
       "cell"
     ],
-    "dataAttributes": "Defaults use data-scope=\"ui-table\" and data-part values container, root, caption, header, body, footer, row, head, and cell. data-slot values are table-container, table, table-caption, table-header, table-body, table-footer, table-row, table-head, and table-cell. App-layer components may override those attributes while retaining native elements and classes.",
+    "dataAttributes": "Defaults use data-scope=\"ui-table\" and data-part values container, root, caption, header, body, footer, row, head, and cell. data-slot values are table-container, table, table-caption, table-header, table-body, table-footer, table-row, table-head, and table-cell. TableContainer and Table expose data-variant=\"default\" or data-variant=\"card\" for variant-scoped styling. App-layer components may override data-scope/data-part/data-slot while retaining native elements and classes.",
     "state": "No controlled or uncontrolled state. Sorting, filtering, pagination, selection, column visibility, and row identity belong to app-layer engines such as TanStack Table or to host application state.",
     "ssr": "Renders deterministic native markup with no browser globals, effects, generated IDs, or hydration-sensitive state.",
-    "limitations": "Table is presentational source, not a grid engine. It does not implement sorting, filtering, pagination, virtualization, roving focus, column sizing, column reordering, row selection, or async loading policy.",
+    "limitations": "Table is presentational source, not a grid engine and not a Core wrapper. Native table semantics are the primitive for this surface. It does not implement sorting, filtering, pagination, virtualization, roving focus, column sizing, column reordering, row selection, or async loading policy.",
     "parity": {
+      "coss": "Adapts the coss card/default styling idea to Solid source and Keystone tokens: variant context, separated card rows, quiet borders, rounded row edges, footer treatment, caption spacing, and CardFrame-compatible table-container clipping.",
       "html": "Keeps native table semantics as the contract: Keystone does not replace table markup with ARIA grid roles unless a future app component requires that behavior explicitly.",
-      "shadcn": "Matches the copy-paste anatomy shape and data-slot ergonomics in Solid source form, with Keystone tokens, compact styling, and a TableContainer part compatible with CardFrame table-container clipping.",
+      "shadcn": "Matches the copy-paste anatomy shape and data-slot ergonomics in Solid source form, with Keystone tokens, compact default styling, optional card styling, and a TableContainer part compatible with CardFrame table-container clipping.",
       "tanstackTable": "The base parts are intentionally engine-agnostic and are consumed by the first-party DataTable kit, where TanStack Table owns row models, sorting, filtering, pagination, selection, and column visibility."
     }
   },


### PR DESCRIPTION
This PR adds unreleased badge behavior for stable component docs, makes `/docs/introduction` the canonical Introduction URL with `/` and `/docs` redirects, and updates docs links to point there directly.

It expands registry API rendering with prop/default tables and reference code snippets, then upgrades Table source/docs with compact/card variants, footer support, richer examples, generated metadata, and tests.

Validation: `bun run check-types`, `bun --cwd apps/web vite build`, and `bunx vitest run src/components/table.test.tsx src/components/data-table/data-table.test.tsx` from `packages/ui`.
