### PR TITLE
Fix command menu scroll and accordion copy

### DIFF
--- a/apps/web/src/docs/examples/controlled-accordion.tsx
+++ b/apps/web/src/docs/examples/controlled-accordion.tsx
@@ -18,12 +18,13 @@ export function Component() {
     },
     {
       content:
-        "Install components with the shadcn CLI, then own the generated source in your application.",
+        "Keystone is not released yet. The registry and install flow are still being shaped in this repo.",
       id: "item-2",
       title: "How do I get started?",
     },
     {
-      content: "Yes. Components are copy-paste source backed by Keystone Core.",
+      content:
+        "Not yet. Keystone is early and the component source is still changing before a public release.",
       id: "item-3",
       title: "Can I use it for my project?",
     },

--- a/apps/web/src/docs/examples/multiple-accordion.tsx
+++ b/apps/web/src/docs/examples/multiple-accordion.tsx
@@ -15,12 +15,13 @@ export function Component() {
     },
     {
       content:
-        "Install components with the shadcn CLI, then own the generated source in your application.",
+        "Keystone is not released yet. The registry and install flow are still being shaped in this repo.",
       id: "item-2",
       title: "How do I get started?",
     },
     {
-      content: "Yes. Components are copy-paste source backed by Keystone Core.",
+      content:
+        "Not yet. Keystone is early and the component source is still changing before a public release.",
       id: "item-3",
       title: "Can I use it for my project?",
     },

--- a/apps/web/src/docs/examples/single-accordion.tsx
+++ b/apps/web/src/docs/examples/single-accordion.tsx
@@ -15,12 +15,13 @@ export function Component() {
     },
     {
       content:
-        "Install components with the shadcn CLI, then own the generated source in your application.",
+        "Keystone is not released yet. The registry and install flow are still being shaped in this repo.",
       id: "item-2",
       title: "How do I get started?",
     },
     {
-      content: "Yes. Components are copy-paste source backed by Keystone Core.",
+      content:
+        "Not yet. Keystone is early and the component source is still changing before a public release.",
       id: "item-3",
       title: "Can I use it for my project?",
     },

--- a/packages/ui/src/components/command-menu.tsx
+++ b/packages/ui/src/components/command-menu.tsx
@@ -650,9 +650,10 @@ export function CommandMenuList(props: CommandMenuListProps) {
       class={cn(
         classes(
           "ui-command-menu-list",
-          "max-h-[min(var(--available-height),22rem)]",
+          "max-h-[min(var(--available-height,22rem),22rem)]",
           "min-h-0",
           "overflow-y-auto",
+          "overscroll-contain",
           "not-empty:p-2",
           "not-empty:scroll-py-2",
           "in-data-has-overflow-y:pe-3",


### PR DESCRIPTION
## Summary

Fixes two docs/UI polish issues in the current workspace diff: accordion examples no longer imply Keystone is publicly released, and command menu list scrolling behaves correctly when opened from the docs command palette.

## Core changes

- Updated controlled, single, and multiple accordion examples to describe Keystone as unreleased and still changing.
- Added a fallback max height to the command menu list when `--available-height` is not present.
- Added `overscroll-contain` to keep command menu wheel scrolling from chaining to the page.

## Validation

- `bun run check-types`
- `bun --filter @keystone-ui/ui test src/components/command-menu.test.tsx`
